### PR TITLE
[ROAD-295] Fix: json deserialisation error

### DIFF
--- a/Snyk.Code.Library.Tests/SnykCode/SnykCodeClientTest.cs
+++ b/Snyk.Code.Library.Tests/SnykCode/SnykCodeClientTest.cs
@@ -416,6 +416,14 @@
             Assert.True(status.IsSucccess);
         }
 
+        [Fact]
+        public void SnykCodeClient_WaitingAnalysisResultJsonProvided_DeserialisationAnalysisJsonSuccess()
+        {
+            var analysisResultDto = Json.Deserialize<AnalysisResultDto>("{\"status\":\"ANALYZING\",\"progress\":0.5,\"complete\":false}");
+
+            Assert.NotNull(analysisResultDto);
+        }
+
         private string GetResourceContent(string resourceName) 
             => File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "Resources", resourceName));
     }

--- a/Snyk.Code.Library/Api/Dto/Analysis/AnalysisResultDto.cs
+++ b/Snyk.Code.Library/Api/Dto/Analysis/AnalysisResultDto.cs
@@ -13,7 +13,7 @@
         /// <summary>
         /// Gets or sets a value indicating anaylysis progress (from 0 to 1).
         /// </summary>
-        public long Progress { get; set; }
+        public float Progress { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating anaylysis url.

--- a/Snyk.Code.Library/Domain/Analysis/AnalysisResult.cs
+++ b/Snyk.Code.Library/Domain/Analysis/AnalysisResult.cs
@@ -20,7 +20,7 @@
         /// <summary>
         /// Gets or sets a value indicating anaylysis progress (from 0 to 1).
         /// </summary>
-        public long Progress { get; set; }
+        public float Progress { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating anaylysis url.


### PR DESCRIPTION
Fix deserialisation with json like

`"{\"status\":\"ANALYZING\",\"progress\":0.5,\"complete\":false}"`.

The issue was with progress type. It was long, but progress value could be 0.5.