### PR TITLE
[ROAD-351] fix: check cli file checksum

### DIFF
--- a/Snyk.Common/Sha256.cs
+++ b/Snyk.Common/Sha256.cs
@@ -1,5 +1,7 @@
 ﻿namespace Snyk.Common
 {
+    using System;
+    using System.IO;
     using System.Security.Cryptography;
     using System.Text;
 
@@ -30,6 +32,22 @@
                 }
 
                 return builder.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Get SHA 256 checksum for file.
+        /// </summary>
+        /// <param name="filePath">File path.</param>
+        /// <returns>Checksum string.</returns>
+        public static string Checksum(string filePath)
+        {
+            using (var sha256 = SHA256Managed.Create())
+            {
+                using (FileStream fileStream = File.OpenRead(filePath))
+                {
+                    return BitConverter.ToString(sha256.ComputeHash(fileStream)).Replace("-", string.Empty);
+                }
             }
         }
     }

--- a/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
+++ b/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="snyk_visual_studio_plugin_2022.1a8ce03c-713d-41f9-9d2d-6451639dfca5" Version="1.1.2" Language="en-US" Publisher="Snyk" />
+        <Identity Id="snyk_visual_studio_plugin_2022.1a8ce03c-713d-41f9-9d2d-6451639dfca5" Version="1.1.3" Language="en-US" Publisher="Snyk" />
         <DisplayName>Snyk Vulnerability Scanner</DisplayName>
         <Description xml:space="preserve">The Visual Studio extension (Snyk’s Vulnerability Scanner) helps you find and fix security vulnerabilities in your projects. Within a few seconds, the extension will provide a list of all the different types of security vulnerabilities identified together with actionable fix advice. The extension combines the power of two Snyk products: Snyk Open Source and Snyk Code.</Description>
         <MoreInfo>https://github.com/snyk/snyk-visual-studio-plugin/</MoreInfo>

--- a/Snyk.VisualStudio.Extension.Shared/CLI/Download/ChecksumVerificationException.cs
+++ b/Snyk.VisualStudio.Extension.Shared/CLI/Download/ChecksumVerificationException.cs
@@ -1,0 +1,19 @@
+﻿namespace Snyk.VisualStudio.Extension.Shared.CLI.Download
+{
+    using System;
+
+    /// <summary>
+    /// Exception for CLI download verification.
+    /// </summary>
+    public class ChecksumVerificationException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChecksumVerificationException"/> class.
+        /// </summary>
+        /// <param name="message">Exception message.</param>
+        public ChecksumVerificationException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Shared/CLI/Download/LatestReleaseInfo.cs
+++ b/Snyk.VisualStudio.Extension.Shared/CLI/Download/LatestReleaseInfo.cs
@@ -1,7 +1,5 @@
-﻿namespace Snyk.VisualStudio.Extension.Shared.CLI
+﻿namespace Snyk.VisualStudio.Extension.Shared.CLI.Download
 {
-    using Newtonsoft.Json;
-
     /// <summary>
     /// Represents latest CLI release information.
     /// </summary>
@@ -18,19 +16,13 @@
         public int Id { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether tag name.
-        /// </summary>
-        [JsonProperty("tag_name")]
-        public string TagName { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether name.
         /// </summary>
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets a value indicating whether version from TagName by removing 'v' char.
+        /// Gets or sets a value indicating whether version.
         /// </summary>
-        public string CliVersion => this.TagName?.Replace("v", string.Empty);
+        public string Version { get; set; }
     }
 }

--- a/Snyk.VisualStudio.Extension.Shared/CLI/Download/SnykCliDownloader.cs
+++ b/Snyk.VisualStudio.Extension.Shared/CLI/Download/SnykCliDownloader.cs
@@ -340,9 +340,14 @@
 
                 this.VerifyCliFile(tempCliFile);
 
-                File.Copy(tempCliFile, cliFileDestinationPath);
-
-                File.Delete(tempCliFile);
+                try
+                {
+                    File.Copy(tempCliFile, cliFileDestinationPath);
+                }
+                finally
+                {
+                    File.Delete(tempCliFile);
+                }
             }
         }
 

--- a/Snyk.VisualStudio.Extension.Shared/CLI/Download/SnykCliDownloader.cs
+++ b/Snyk.VisualStudio.Extension.Shared/CLI/Download/SnykCliDownloader.cs
@@ -178,11 +178,6 @@
 
             if (this.IsCliDownloadNeeded(lastCheckDate, filePath))
             {
-                if (this.IsCliFileExists(fileDestinationPath))
-                {
-                    File.Delete(fileDestinationPath);
-                }
-
                 await this.DownloadAsync(
                     fileDestinationPath: fileDestinationPath,
                     progressWorker: progressWorker,

--- a/Snyk.VisualStudio.Extension.Shared/CLI/Download/SnykCliDownloader.cs
+++ b/Snyk.VisualStudio.Extension.Shared/CLI/Download/SnykCliDownloader.cs
@@ -25,6 +25,8 @@
 
         private string currentCliVersion;
 
+        private string extectedSha;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SnykCliDownloader"/> class.
         /// </summary>
@@ -140,17 +142,6 @@
                 return true;
             }
 
-            try
-            {
-                this.VerifyCliFile(cliFileDestinationPath);
-            }
-            catch (ChecksumVerificationException e)
-            {
-                Logger.Error(e, "Cli file checksum verification failed");
-
-                return true;
-            }
-
             return false;
         }
 
@@ -262,14 +253,18 @@
                 throw new ChecksumVerificationException("Cli file not exists, can't verify checksum");
             }
 
-            string extectedSha = this.GetLatestCliSha();
             string currentSha = Sha256.Checksum(cliPath);
 
-            if (extectedSha.ToLower() != currentSha.ToLower())
+            if (this.extectedSha.ToLower() != currentSha.ToLower())
             {
-                throw new ChecksumVerificationException($"Expected {extectedSha}, but downloaded file has {currentSha}");
+                throw new ChecksumVerificationException($"Expected {this.extectedSha}, but downloaded file has {currentSha}");
             }
         }
+
+        /// <summary>
+        /// Initialize extectedSha property with latest value from server.
+        /// </summary>
+        public void SaveLatestCliSha() => this.extectedSha = this.GetLatestCliSha();
 
         private void PrepareSnykCliDirectory()
         {
@@ -291,6 +286,8 @@
 
             try
             {
+                this.SaveLatestCliSha();
+
                 await this.DownloadFileAsync(progressWorker, cliDownloadUrl, cliFileDestinationPath);
             }
             catch (ChecksumVerificationException e)

--- a/Snyk.VisualStudio.Extension.Shared/CLI/Download/SnykCliDownloader.cs
+++ b/Snyk.VisualStudio.Extension.Shared/CLI/Download/SnykCliDownloader.cs
@@ -215,11 +215,8 @@
 
             LatestReleaseInfo latestReleaseInfo = this.GetLatestReleaseInfo();
 
-                    string cliVersion = latestReleaseInfo.TagName;
+            string cliDownloadUrl = string.Format(LatestReleaseDownloadUrl, latestReleaseInfo.Version, SnykCli.CliFileName);
 
-                    Logger.Information("Latest relase information CLI version: {CliVersion}", cliVersion);
-
-                    string cliDownloadUrl = string.Format(LatestReleaseDownloadUrl, cliVersion, SnykCli.CliFileName);
             Logger.Information("Latest relase information: version {Version} and url {Url}", latestReleaseInfo.Version, latestReleaseInfo.Url);
 
             progressWorker.CancelIfCancellationRequested();

--- a/Snyk.VisualStudio.Extension.Shared/Service/ISnykProgressWorker.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/ISnykProgressWorker.cs
@@ -6,11 +6,6 @@
     public interface ISnykProgressWorker
     {
         /// <summary>
-        /// Gets or sets a value indicating whether is update download.
-        /// </summary>
-        bool IsUpdateDownload { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether is work finished.
         /// </summary>
         bool IsWorkFinished { get; set; }

--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykProgressWorker.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykProgressWorker.cs
@@ -52,17 +52,7 @@
         /// <summary>
         /// Notify download started.
         /// </summary>
-        public void DownloadStarted()
-        {
-            if (this.IsUpdateDownload)
-            {
-                this.TasksService.OnUpdateDownloadStarted();
-            }
-            else
-            {
-                this.TasksService.OnDownloadStarted();
-            }
-        }
+        public void DownloadStarted() => this.TasksService.OnDownloadStarted();
 
         /// <summary>
         /// Notify donwload cancelled.

--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykTasksService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykTasksService.cs
@@ -629,8 +629,6 @@
 
             downloadFinishedCallbacks.Add(new CliDownloadFinishedCallback(() =>
             {
-                cliDownloader.VerifyCliFile();
-
                 userStorageService.SaveCurrentCliVersion(cliDownloader.GetLatestReleaseInfo().Name);
                 userStorageService.SaveCliReleaseLastCheckDate(DateTime.UtcNow);
 

--- a/Snyk.VisualStudio.Extension.Shared/Settings/SnykGeneralSettingsUserControl.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Settings/SnykGeneralSettingsUserControl.cs
@@ -10,7 +10,6 @@
     using Snyk.VisualStudio.Extension.Shared.Service;
     using Snyk.VisualStudio.Extension.Shared.UI;
     using Snyk.VisualStudio.Extension.Shared.UI.Notifications;
-    using static Snyk.VisualStudio.Extension.Shared.CLI.SnykCliDownloader;
     using static Snyk.VisualStudio.Extension.Shared.CLI.Download.SnykCliDownloader;
 
     /// <summary>

--- a/Snyk.VisualStudio.Extension.Shared/Settings/SnykGeneralSettingsUserControl.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Settings/SnykGeneralSettingsUserControl.cs
@@ -11,6 +11,7 @@
     using Snyk.VisualStudio.Extension.Shared.UI;
     using Snyk.VisualStudio.Extension.Shared.UI.Notifications;
     using static Snyk.VisualStudio.Extension.Shared.CLI.SnykCliDownloader;
+    using static Snyk.VisualStudio.Extension.Shared.CLI.Download.SnykCliDownloader;
 
     /// <summary>
     /// Control for Snyk General Settings.

--- a/Snyk.VisualStudio.Extension.Shared/Snyk.VisualStudio.Extension.Shared.projitems
+++ b/Snyk.VisualStudio.Extension.Shared/Snyk.VisualStudio.Extension.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Snyk.VisualStudio.Extension.Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)CLI\Download\ChecksumVerificationException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cache\AbstractCacheHierarchyEvents.cs">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Compile>

--- a/Snyk.VisualStudio.Extension.Tests/SnykCliDownloaderTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/SnykCliDownloaderTest.cs
@@ -23,6 +23,8 @@
         {
             var cliDownloader = new SnykCliDownloader(null);
 
+            cliDownloader.SaveLatestCliSha();
+
             string tempCliPath = Path.Combine(Path.GetTempPath(), SnykCli.CliFileName);
 
             File.Delete(tempCliPath);

--- a/Snyk.VisualStudio.Extension/source.extension.vsixmanifest
+++ b/Snyk.VisualStudio.Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="snyk_visual_studio_plugin.154948da-e3ba-45ce-9bee-9688a7e30462" Version="1.1.2" Language="en-US" Publisher="Snyk" />
+        <Identity Id="snyk_visual_studio_plugin.154948da-e3ba-45ce-9bee-9688a7e30462" Version="1.1.3" Language="en-US" Publisher="Snyk" />
         <DisplayName>Snyk Vulnerability Scanner</DisplayName>
         <Description xml:space="preserve">The Visual Studio extension (Snyk’s Vulnerability Scanner) helps you find and fix security vulnerabilities in your projects. Within a few seconds, the extension will provide a list of all the different types of security vulnerabilities identified together with actionable fix advice. The extension combines the power of two Snyk products: Snyk Open Source and Snyk Code.</Description>
         <MoreInfo>https://github.com/snyk/snyk-visual-studio-plugin/</MoreInfo>


### PR DESCRIPTION
Fixed if cli file broken. After cli download finished it will verify file checksum and if it's wrong extension will try to download cli again.