### PR TITLE
[ROAD-682] fix: add check is sentry error related to extension

### DIFF
--- a/Snyk.Common/LogManager.cs
+++ b/Snyk.Common/LogManager.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using Sentry;
     using Sentry.Serilog;
     using Serilog;
     using Serilog.Core;
@@ -54,6 +55,9 @@
                     config.Dsn = appSettings.SentryDsn;
 
                     config.AttachStacktrace = true;
+
+                    config.DisableTaskUnobservedTaskExceptionCapture();
+                    config.DisableAppDomainUnhandledExceptionCapture();
 
                     SentryConfiguration = config;
                 })

--- a/Snyk.Common/LogManager.cs
+++ b/Snyk.Common/LogManager.cs
@@ -55,12 +55,6 @@
 
                     config.AttachStacktrace = true;
 
-
-                    config.Debug = true;
-                    config.TracesSampleRate = 1.0;
-
-
-
                     SentryConfiguration = config;
                 })
                 .WriteTo.File(

--- a/Snyk.Common/LogManager.cs
+++ b/Snyk.Common/LogManager.cs
@@ -2,12 +2,13 @@
 {
     using System;
     using System.IO;
-    using Sentry;
-    using Sentry.Serilog;
+    using global::Sentry;
+    using global::Sentry.Serilog;
     using Serilog;
     using Serilog.Core;
     using Serilog.Events;
     using Serilog.Exceptions;
+    using Snyk.Common.Sentry;
 
     /// <summary>
     /// Logger manager for create logger per class.
@@ -56,8 +57,13 @@
 
                     config.AttachStacktrace = true;
 
+                    // Disable default Sentry integrations for capture TaskUnobservedTaskException and AppDomainUnhandledException exceptions.
                     config.DisableTaskUnobservedTaskExceptionCapture();
                     config.DisableAppDomainUnhandledExceptionCapture();
+
+                    // Register Snyk integrations for capture only Snyk related TaskUnobservedTaskException and AppDomainUnhandledException exceptions.
+                    config.AddIntegration(new TaskUnobservedTaskExceptionIntegration());
+                    config.AddIntegration(new AppDomainUnhandledExceptionIntegration());
 
                     SentryConfiguration = config;
                 })

--- a/Snyk.Common/LogManager.cs
+++ b/Snyk.Common/LogManager.cs
@@ -55,6 +55,12 @@
 
                     config.AttachStacktrace = true;
 
+
+                    config.Debug = true;
+                    config.TracesSampleRate = 1.0;
+
+
+
                     SentryConfiguration = config;
                 })
                 .WriteTo.File(

--- a/Snyk.Common/Sentry/AbstractIntegration.cs
+++ b/Snyk.Common/Sentry/AbstractIntegration.cs
@@ -1,0 +1,46 @@
+﻿namespace Snyk.Common.Sentry
+{
+    using System;
+    using global::Sentry;
+    using global::Sentry.Integrations;
+
+    /// <summary>
+    /// Snyk integration abstract class for Sentry.
+    /// </summary>
+    public abstract class AbstractIntegration : ISdkIntegration
+    {
+        protected const string HandledKey = "Sentry:Handled";
+
+        protected const string MechanismKey = "Sentry:Mechanism";
+
+        protected const string SnykKey = "Snyk";
+
+        protected readonly IAppDomain appDomain;
+
+        protected IHub hub;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbstractIntegration"/> class.
+        /// Initialize appDoamin property with <see cref="AppDomainAdapter"/>.
+        /// </summary>
+        public AbstractIntegration() => this.appDomain = AppDomainAdapter.Instance;
+
+        /// <summary>
+        /// Registers this integration with the hub.
+        /// </summary>
+        /// <remarks>
+        /// This method is invoked when the Hub is created.
+        /// </remarks>
+        /// <param name="hub">The hub.</param>
+        /// <param name="options">The options.</param>
+        public abstract void Register(IHub hub, SentryOptions options);
+
+        /// <summary>
+        /// Check is provided exception stack trace contains mentions about extension.
+        /// </summary>
+        /// <param name="e">Source exception.</param>
+        /// <returns>True if contains mentions about Snyk extension.</returns>
+        protected static bool IsNeedToHandleException(Exception e)
+            => e != null && e.StackTrace != null && e.StackTrace.Contains(SnykKey);
+    }
+}

--- a/Snyk.Common/Sentry/AbstractIntegration.cs
+++ b/Snyk.Common/Sentry/AbstractIntegration.cs
@@ -1,6 +1,7 @@
 ﻿namespace Snyk.Common.Sentry
 {
     using System;
+    using System.Linq;
     using global::Sentry;
     using global::Sentry.Integrations;
 
@@ -47,17 +48,10 @@
                 return true;
             }
 
-            if (e is AggregateException)
+            if (e is AggregateException aggregateEx
+                && !aggregateEx.Flatten().InnerExceptions.Where(ex => IsExceptionRelatedToExtension(ex)).Any())
             {
-                var aggregateException = e as AggregateException;
-
-                foreach (var exception in aggregateException.Flatten().InnerExceptions)
-                {
-                    if (IsExceptionRelatedToExtension(exception))
-                    {
-                        return true;
-                    }
-                }
+                return true;
             }
 
             return false;

--- a/Snyk.Common/Sentry/AbstractIntegration.cs
+++ b/Snyk.Common/Sentry/AbstractIntegration.cs
@@ -41,6 +41,29 @@
         /// <param name="e">Source exception.</param>
         /// <returns>True if contains mentions about Snyk extension.</returns>
         protected static bool IsNeedToHandleException(Exception e)
+        {
+            if (IsExceptionRelatedToExtension(e))
+            {
+                return true;
+            }
+
+            if (e is AggregateException)
+            {
+                var aggregateException = e as AggregateException;
+
+                foreach (var exception in aggregateException.Flatten().InnerExceptions)
+                {
+                    if (IsExceptionRelatedToExtension(exception))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsExceptionRelatedToExtension(Exception e)
             => e != null && e.StackTrace != null && e.StackTrace.IndexOf(SnykKey, StringComparison.OrdinalIgnoreCase) >= 0;
     }
 }

--- a/Snyk.Common/Sentry/AbstractIntegration.cs
+++ b/Snyk.Common/Sentry/AbstractIntegration.cs
@@ -41,6 +41,6 @@
         /// <param name="e">Source exception.</param>
         /// <returns>True if contains mentions about Snyk extension.</returns>
         protected static bool IsNeedToHandleException(Exception e)
-            => e != null && e.StackTrace != null && e.StackTrace.Contains(SnykKey);
+            => e != null && e.StackTrace != null && e.StackTrace.IndexOf(SnykKey, StringComparison.OrdinalIgnoreCase) >= 0;
     }
 }

--- a/Snyk.Common/Sentry/AppDomainAdapter.cs
+++ b/Snyk.Common/Sentry/AppDomainAdapter.cs
@@ -1,0 +1,37 @@
+﻿namespace Snyk.Common.Sentry
+{
+    using System;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Wrap <see cref="AppDomain"/> instance.
+    /// Based on code from: https://github.com/getsentry/sentry-dotnet/blob/main/src/Sentry/Internal/AppDomainAdapter.cs.
+    /// </summary>
+    public class AppDomainAdapter : IAppDomain
+    {
+        private AppDomainAdapter()
+        {
+            AppDomain.CurrentDomain.UnhandledException += this.OnUnhandledException;
+            AppDomain.CurrentDomain.ProcessExit += this.OnProcessExit;
+
+            TaskScheduler.UnobservedTaskException += this.OnUnobservedTaskException;
+        }
+
+        public event UnhandledExceptionEventHandler UnhandledException;
+
+        public event EventHandler ProcessExit;
+
+        public event EventHandler<UnobservedTaskExceptionEventArgs> UnobservedTaskException;
+
+        /// <summary>
+        /// Gets new instance of <see cref="AppDomainAdapter"/>.
+        /// </summary>
+        public static AppDomainAdapter Instance { get; } = new AppDomainAdapter();
+
+        private void OnProcessExit(object sender, EventArgs e) => this.ProcessExit?.Invoke(sender, e);
+
+        private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e) => this.UnhandledException?.Invoke(this, e);
+
+        private void OnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e) => this.UnobservedTaskException?.Invoke(this, e);
+    }
+}

--- a/Snyk.Common/Sentry/AppDomainUnhandledExceptionIntegration.cs
+++ b/Snyk.Common/Sentry/AppDomainUnhandledExceptionIntegration.cs
@@ -1,0 +1,43 @@
+﻿namespace Snyk.Common.Sentry
+{
+    using System;
+    using global::Sentry;
+
+    /// <summary>
+    /// Snyk integration for handle AppDomainUnhandledException.
+    /// Based on the code from: https://github.com/getsentry/sentry-dotnet/blob/main/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs.
+    /// </summary>
+    public class AppDomainUnhandledExceptionIntegration : AbstractIntegration
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppDomainUnhandledExceptionIntegration"/> class.
+        /// </summary>
+        public AppDomainUnhandledExceptionIntegration()
+            : base()
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void Register(IHub hub, SentryOptions options)
+        {
+            this.hub = hub;
+            this.appDomain.UnhandledException += this.Handle;
+        }
+
+        private void Handle(object sender, UnhandledExceptionEventArgs e)
+        {
+            if (e.ExceptionObject is Exception ex && IsNeedToHandleException(ex))
+            {
+                ex.Data[HandledKey] = false;
+                ex.Data[MechanismKey] = "AppDomain.UnhandledException";
+
+                _ = this.hub.CaptureException(ex);
+            }
+
+            if (e.IsTerminating)
+            {
+                (this.hub as IDisposable)?.Dispose();
+            }
+        }
+    }
+}

--- a/Snyk.Common/Sentry/IAppDomain.cs
+++ b/Snyk.Common/Sentry/IAppDomain.cs
@@ -1,0 +1,18 @@
+﻿namespace Snyk.Common.Sentry
+{
+    using System;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Interface for <see cref="AppDomainAdapter"/>.
+    /// Based on code from: https://github.com/getsentry/sentry-dotnet/blob/main/src/Sentry/Internal/AppDomainAdapter.cs.
+    /// </summary>
+    public interface IAppDomain
+    {
+        event UnhandledExceptionEventHandler UnhandledException;
+
+        event EventHandler ProcessExit;
+
+        event EventHandler<UnobservedTaskExceptionEventArgs> UnobservedTaskException;
+    }
+}

--- a/Snyk.Common/Sentry/TaskUnobservedTaskExceptionIntegration.cs
+++ b/Snyk.Common/Sentry/TaskUnobservedTaskExceptionIntegration.cs
@@ -1,0 +1,37 @@
+﻿namespace Snyk.Common.Sentry
+{
+    using System.Threading.Tasks;
+    using global::Sentry;
+
+    /// <summary>
+    /// Snyk integration for handle TaskUnobservedTaskException.
+    /// Based on code from: https://github.com/getsentry/sentry-dotnet/blob/main/src/Sentry/Integrations/TaskUnobservedTaskExceptionIntegration.cs.
+    /// </summary>
+    public class TaskUnobservedTaskExceptionIntegration : AbstractIntegration
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskUnobservedTaskExceptionIntegration"/> class.
+        /// </summary>
+        public TaskUnobservedTaskExceptionIntegration()
+            : base()
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void Register(IHub hub, SentryOptions options)
+        {
+            this.hub = hub;
+            this.appDomain.UnobservedTaskException += this.Handle;
+        }
+
+        private void Handle(object sender, UnobservedTaskExceptionEventArgs e)
+        {
+            if (IsNeedToHandleException(e.Exception))
+            {
+                e.Exception.Data[MechanismKey] = "UnobservedTaskException";
+
+                _ = this.hub.CaptureException(e.Exception);
+            }
+        }
+    }
+}

--- a/Snyk.Common/Snyk.Common.csproj
+++ b/Snyk.Common/Snyk.Common.csproj
@@ -138,6 +138,11 @@
     <Compile Include="Json.cs" />
     <Compile Include="LogManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Sentry\AbstractIntegration.cs" />
+    <Compile Include="Sentry\AppDomainAdapter.cs" />
+    <Compile Include="Sentry\AppDomainUnhandledExceptionIntegration.cs" />
+    <Compile Include="Sentry\IAppDomain.cs" />
+    <Compile Include="Sentry\TaskUnobservedTaskExceptionIntegration.cs" />
     <Compile Include="Sha256.cs" />
     <Compile Include="SnykAppSettings.cs" />
     <Compile Include="SnykDirectory.cs" />
@@ -166,6 +171,7 @@
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.10.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.10.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
   <Target Name="WriteAppSettingsFile" BeforeTargets="PreBuildEvent">

--- a/Snyk.VisualStudio.Extension.Shared/Service/SentryService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SentryService.cs
@@ -3,7 +3,6 @@
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
     using Microsoft.VisualStudio.Threading;
-    using Sentry;
     using Snyk.Common;
     using Task = System.Threading.Tasks.Task;
 
@@ -44,28 +43,10 @@
         {
             LogManager.SentryConfiguration.BeforeSend = sentryEvent =>
             {
-                // Filter error's not related to Snyk Extension.
-                if (this.CheckEventNotRelatedToExtension(sentryEvent))
-                {
-                    return null;
-                }
-
                 sentryEvent.SetTag("vs.project.type", solutionType.ToString());
 
                 return sentryEvent;
             };
-        }
-
-        private bool CheckEventNotRelatedToExtension(SentryEvent sentryEvent)
-        {
-            if (sentryEvent.Logger == null)
-            {
-                return true;
-            }
-
-            return sentryEvent.Exception != null
-                && sentryEvent.Exception.StackTrace != null
-                && !sentryEvent.Exception.StackTrace.Contains(SnykKeyword);
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.Shared/Service/SentryService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SentryService.cs
@@ -3,6 +3,7 @@
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
     using Microsoft.VisualStudio.Threading;
+    using Sentry;
     using Snyk.Common;
     using Task = System.Threading.Tasks.Task;
 

--- a/Snyk.VisualStudio.Extension.Shared/Service/SentryService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SentryService.cs
@@ -12,8 +12,6 @@
     /// </summary>
     public class SentryService : ISentryService
     {
-        private const string SnykKeyword = "Snyk";
-
         private ISnykServiceProvider serviceProvider;
 
         /// <summary>


### PR DESCRIPTION
To fix issue with not related to extension exceptions now it filter Sentry errors before send. It check Logger property and StackTrace content. 

Errors from extension must have SentryEvent.Logger = "Snyk.VisualStudio.CLI.SomeClass" property set. And also error must have Snyk mention in StackTrace 