### PR TITLE
fix: Visual Studio 2022 supports amd64 only

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
+++ b/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
@@ -14,9 +14,6 @@
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
-            <ProductArchitecture>x86</ProductArchitecture>
-        </InstallationTarget>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
     </Installation>


### PR DESCRIPTION
When publishing 2022, it fails with the following message:
```
Error: 
(Snyk Vulnerability Scanner) Target 'Microsoft.VisualStudio.Community' with version range '[17.0,18.0)' specifies 'x86' as the target product architecture, but Visual Studio 2022 and above only supports `amd64`. More info at http://aka.ms/VS2022ExtensionSupport 
```

This PR addresses the problem.