### PR TITLE
feat: sast settings with organization as url query param [ROAD-734]

### DIFF
--- a/Snyk.VisualStudio.Extension.Tests/SnykApiServiceTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/SnykApiServiceTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace Snyk.VisualStudio.Extension.Shared.Tests
 {
     using System;
+    using System.Net.Http;
     using System.Threading.Tasks;
     using Moq;
     using Snyk.VisualStudio.Extension.Shared.Service;
@@ -33,6 +34,28 @@
             Assert.True(sastSettings.SastEnabled);
 
             Assert.NotNull(sastSettings.LocalCodeEngine);
+        }
+
+        [Fact]
+        public async Task SnykApiService_SendSastSettingsRequestAsync_OrgIsInQueryParamAsync()
+        {
+            var optionsMock = new Mock<ISnykOptions>();
+
+            optionsMock
+                .Setup(options => options.CustomEndpoint)
+                .Returns("https://dev.snyk.io/api");
+            optionsMock
+                .Setup(options => options.ApiToken)
+                .Returns(Environment.GetEnvironmentVariable("TEST_API_TOKEN"));
+            optionsMock
+                .Setup(options => options.Organization)
+                .Returns("my-super-org");
+
+            var apiService = new SnykApiService(optionsMock.Object);
+
+            HttpResponseMessage response = await apiService.SendSastSettingsRequestAsync();
+
+            Assert.Contains("?org=my-super-org", response.RequestMessage.RequestUri.Query);
         }
     }
 }


### PR DESCRIPTION
This PR adds a feature to check SAST API endpoint with organization from settings (if configured).
Organization will be added as URL query param:
```
<baseURL>/cli-config/settings/sast?org=<org-uuid-or-name>
```