### PR TITLE
[ROAD-659] Fix: sentry error parameter is incorrect

### DIFF
--- a/Snyk.Code.Library.Tests/SnykCode/CodeCacheServiceTest.cs
+++ b/Snyk.Code.Library.Tests/SnykCode/CodeCacheServiceTest.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Threading.Tasks;
     using Moq;
     using Snyk.Code.Library.Service;
     using Snyk.Common;
@@ -44,7 +45,7 @@
                 .Returns(this.projectPath);
 
             solutionServiceMock
-                .Setup(solutionService => solutionService.GetFiles())
+                .Setup(solutionService => solutionService.GetFilesAsync().Result)
                 .Returns(new List<string>());
 
             var fileProvider = new SnykCodeFileProvider(solutionServiceMock.Object);
@@ -89,7 +90,7 @@
                 .Returns(this.projectPath);
 
             solutionServiceMock
-                .Setup(solutionService => solutionService.GetFiles())
+                .Setup(solutionService => solutionService.GetFilesAsync().Result)
                 .Returns(new List<string>());
 
             var fileProvider = new SnykCodeFileProvider(solutionServiceMock.Object);
@@ -117,7 +118,7 @@
                 .Returns(this.projectPath);
 
             solutionServiceMock
-                .Setup(solutionService => solutionService.GetFiles())
+                .Setup(solutionService => solutionService.GetFilesAsync().Result)
                 .Returns(new List<string>());
 
             var fileProvider = new SnykCodeFileProvider(solutionServiceMock.Object);
@@ -152,7 +153,7 @@
                 .Returns(this.projectPath);
 
             solutionServiceMock
-                .Setup(solutionService => solutionService.GetFiles())
+                .Setup(solutionService => solutionService.GetFilesAsync().Result)
                 .Returns(new List<string>());
 
             var fileProvider = new SnykCodeFileProvider(solutionServiceMock.Object);

--- a/Snyk.Code.Library.Tests/SnykCode/SnykCodeServiceTest.cs
+++ b/Snyk.Code.Library.Tests/SnykCode/SnykCodeServiceTest.cs
@@ -255,6 +255,14 @@
                 MissingFiles = new string[] { filePath1, filePath2 },
             };
 
+            this.fileProviderMock
+                .Setup(fileProvider => fileProvider.GetFilesAsync().Result)
+                .Returns(filePaths);
+
+            this.filtersServiceMock
+                .Setup(filtersService => filtersService.FilterFilesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()).Result)
+                .Returns(filePaths);
+
             this.bundleServiceMock
                 .Setup(bundleService => bundleService.CreateBundleAsync(It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()).Result)
                 .Returns(bundle);
@@ -300,6 +308,14 @@
 
             this.analysisServiceMock
                 .Verify(analysisService => analysisService.GetAnalysisAsync(bundleId, It.IsAny<FireScanCodeProgressUpdate>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+        }
+
+        [Fact]
+        public async Task SnykCodeService_NoFilesForScanProvided_ReturnNullSuccessAsync()
+        {
+            var result = await this.snykCodeService.ScanAsync(this.fileProviderMock.Object);
+
+            Assert.Null(result);
         }
     }
 }

--- a/Snyk.Code.Library/Service/SnykCodeFileProvider.cs
+++ b/Snyk.Code.Library/Service/SnykCodeFileProvider.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using Snyk.Common;
 
     /// <summary>
@@ -30,7 +31,7 @@
         }
 
         /// <inheritdoc/>
-        public IEnumerable<string> GetFiles() => this.solutionService.GetFiles();
+        public async Task<IEnumerable<string>> GetFilesAsync() => await this.solutionService.GetFilesAsync();
 
         /// <inheritdoc/>
         public string GetSolutionPath()

--- a/Snyk.Code.Library/Service/SnykCodeService.cs
+++ b/Snyk.Code.Library/Service/SnykCodeService.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Serilog;
@@ -115,7 +116,14 @@
         {
             this.FireScanProgressEvent(SnykCodeScanState.Preparing, 0);
 
-            var files = await this.GetFilteredFilesAsync(fileProvider.GetSolutionPath(), fileProvider.GetFiles());
+            var solutionFiles = await fileProvider.GetFilesAsync();
+
+            var files = await this.GetFilteredFilesAsync(fileProvider.GetSolutionPath(), solutionFiles);
+
+            if (files == null || files.Count() == 0)
+            {
+                return null;
+            }
 
             this.codeCacheService.Initialize(files);
 

--- a/Snyk.Common/IFileProvider.cs
+++ b/Snyk.Common/IFileProvider.cs
@@ -1,6 +1,7 @@
 ﻿namespace Snyk.Common
 {
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Provide file path and content for solutions and projects.
@@ -11,7 +12,7 @@
         /// Get solution files.
         /// </summary>
         /// <returns>List of file paths.</returns>
-        IEnumerable<string> GetFiles();
+        Task<IEnumerable<string>> GetFilesAsync();
 
         /// <summary>
         /// Get solution path.

--- a/Snyk.Common/ISolutionService.cs
+++ b/Snyk.Common/ISolutionService.cs
@@ -1,6 +1,7 @@
 ﻿namespace Snyk.Common
 {
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Service for solution related functionality.
@@ -22,11 +23,17 @@
         /// Get all solution files.
         /// </summary>
         /// <returns>List of solution files.</returns>
-        IEnumerable<string> GetFiles();
+        Task<IEnumerable<string>> GetFilesAsync();
 
         /// <summary>
         /// Clean solution related variables.
         /// </summary>
         void Clean();
+
+        /// <summary>
+        /// Check is folder opened as solution.
+        /// </summary>
+        /// <returns>True is user open folder as solution.</returns>
+        bool IsSolutionOpenedAsFolder();
     }
 }

--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykTasksService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykTasksService.cs
@@ -8,6 +8,7 @@
     using Microsoft.VisualStudio.Shell;
     using Serilog;
     using Snyk.Code.Library.Domain.Analysis;
+    using Snyk.Code.Library.Service;
     using Snyk.Common;
     using Snyk.VisualStudio.Extension.Shared.CLI;
     using Snyk.VisualStudio.Extension.Shared.CLI.Download;

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindowControl.xaml.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindowControl.xaml.cs
@@ -59,7 +59,7 @@
         /// </summary>
         /// <returns>True if result tree not empty.</returns>
         public bool IsTreeContentNotEmpty() => this.resultsTree.CliRootNode.HasContent
-            || this.resultsTree.CodeSequrityRootNode.HasContent
+            || this.resultsTree.CodeSecurityRootNode.HasContent
             || this.resultsTree.CodeQualityRootNode.HasContent;
 
         /// <summary>
@@ -176,7 +176,7 @@
 
             this.messagePanel.ShowScanningMessage();
 
-            this.resultsTree.CodeSequrityRootNode.State = RootTreeNodeState.Scanning;
+            this.resultsTree.CodeSecurityRootNode.State = RootTreeNodeState.Scanning;
             this.resultsTree.CodeQualityRootNode.State = RootTreeNodeState.Scanning;
 
             this.UpdateActionsState();
@@ -230,7 +230,7 @@
             this.serviceProvider.AnalyticsService.LogAnalysisReadyEvent(AnalysisType.SnykCodeSecurity, AnalyticsAnalysisResult.Error);
 
             this.resultsTree.CodeQualityRootNode.State = RootTreeNodeState.Error;
-            this.resultsTree.CodeSequrityRootNode.State = RootTreeNodeState.Error;
+            this.resultsTree.CodeSecurityRootNode.State = RootTreeNodeState.Error;
 
             NotificationService.Instance.ShowErrorInfoBar(eventArgs.Error);
 
@@ -255,7 +255,7 @@
                 ? RootTreeNodeState.LocalCodeEngineIsEnabled : RootTreeNodeState.DisabledForOrganization;
 
             this.resultsTree.CodeQualityRootNode.State = disabledNodeState;
-            this.resultsTree.CodeSequrityRootNode.State = disabledNodeState;
+            this.resultsTree.CodeSecurityRootNode.State = disabledNodeState;
         });
 
         /// <summary>
@@ -414,14 +414,14 @@
                 var sastSettings = await this.serviceProvider.ApiService.GetSastSettingsAsync();
 
                 this.resultsTree.CodeQualityRootNode.State = this.GetSnykCodeRootNodeState(sastSettings, options.SnykCodeQualityEnabled);
-                this.resultsTree.CodeSequrityRootNode.State = this.GetSnykCodeRootNodeState(sastSettings, options.SnykCodeSecurityEnabled);
+                this.resultsTree.CodeSecurityRootNode.State = this.GetSnykCodeRootNodeState(sastSettings, options.SnykCodeSecurityEnabled);
             }
             catch (Exception e)
             {
                 Logger.Error(e, "Error on get sast settings and display tree node state");
 
                 this.resultsTree.CodeQualityRootNode.State = RootTreeNodeState.Error;
-                this.resultsTree.CodeSequrityRootNode.State = RootTreeNodeState.Error;
+                this.resultsTree.CodeSecurityRootNode.State = RootTreeNodeState.Error;
 
                 NotificationService.Instance.ShowErrorInfoBar(e.Message);
             }
@@ -504,7 +504,15 @@
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                this.resultsTree.AnalysisResults = analysisResult;
+                if (analysisResult != null)
+                {
+                    this.resultsTree.AnalysisResults = analysisResult;
+                }
+                else
+                {
+                    this.resultsTree.CodeQualityRootNode.State = RootTreeNodeState.NoFilesForSnykCodeScan;
+                    this.resultsTree.CodeSecurityRootNode.State = RootTreeNodeState.NoFilesForSnykCodeScan;
+                }
             });
         }
 

--- a/Snyk.VisualStudio.Extension.Shared/UI/Tree/RootTreeNode.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Tree/RootTreeNode.cs
@@ -51,6 +51,9 @@
                     case RootTreeNodeState.LocalCodeEngineIsEnabled:
                         title = this.GetTitlePrefix() + " (disabled due to local code engine)";
                         break;
+                    case RootTreeNodeState.NoFilesForSnykCodeScan:
+                        title = this.GetTitlePrefix() + " (no supported code available)";
+                        break;
                     case RootTreeNodeState.Disabled:
                     default:
                         title = this.GetTitlePrefix() + " (disabled)";
@@ -83,7 +86,9 @@
             get => this.state;
             set
             {
-                if (this.State == RootTreeNodeState.ResultDetails && value == RootTreeNodeState.Enabled)
+                if ((this.State == RootTreeNodeState.ResultDetails
+                    || this.State == RootTreeNodeState.NoFilesForSnykCodeScan)
+                    && value == RootTreeNodeState.Enabled)
                 {
                     return;
                 }

--- a/Snyk.VisualStudio.Extension.Shared/UI/Tree/RootTreeNodeState.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Tree/RootTreeNodeState.cs
@@ -40,5 +40,10 @@
         /// Local code engine is enabled state.
         /// </summary>
         LocalCodeEngineIsEnabled,
+
+        /// <summary>
+        /// No files for SnykCode scan (No supported code available).
+        /// </summary>
+        NoFilesForSnykCodeScan,
     }
 }

--- a/Snyk.VisualStudio.Extension.Shared/UI/Tree/SnykFilterableTree.xaml.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Tree/SnykFilterableTree.xaml.cs
@@ -20,7 +20,7 @@
 
         private readonly RootTreeNode ossRootNode;
 
-        private readonly SnykCodeSecurityRootTreeNode codeSequrityRootNode;
+        private readonly SnykCodeSecurityRootTreeNode codeSecurityRootNode;
 
         private readonly SnykCodeQualityRootTreeNode codeQualityRootNode;
 
@@ -34,11 +34,11 @@
             instance = this;
 
             this.ossRootNode = new OssRootTreeNode(this);
-            this.codeSequrityRootNode = new SnykCodeSecurityRootTreeNode(this);
+            this.codeSecurityRootNode = new SnykCodeSecurityRootTreeNode(this);
             this.codeQualityRootNode = new SnykCodeQualityRootTreeNode(this);
 
             this.vulnerabilitiesTree.Items.Add(this.ossRootNode);
-            this.vulnerabilitiesTree.Items.Add(this.codeSequrityRootNode);
+            this.vulnerabilitiesTree.Items.Add(this.codeSecurityRootNode);
             this.vulnerabilitiesTree.Items.Add(this.codeQualityRootNode);
         }
 
@@ -55,7 +55,7 @@
         /// <summary>
         /// Gets code sequrity root node.
         /// </summary>
-        public SnykCodeSecurityRootTreeNode CodeSequrityRootNode => this.codeSequrityRootNode;
+        public SnykCodeSecurityRootTreeNode CodeSecurityRootNode => this.codeSecurityRootNode;
 
         /// <summary>
         /// Gets code quality root node.
@@ -130,9 +130,9 @@
         {
             set
             {
-                if (this.codeSequrityRootNode.Enabled)
+                if (this.codeSecurityRootNode.Enabled)
                 {
-                    this.AppendSnykCodeIssues(this.codeSequrityRootNode, value, suggestion => suggestion.Categories.Contains("Security"));
+                    this.AppendSnykCodeIssues(this.codeSecurityRootNode, value, suggestion => suggestion.Categories.Contains("Security"));
 
                     SnykAnalyticsService.Instance
                         .LogAnalysisReadyEvent(AnalysisType.SnykCodeSecurity, AnalyticsAnalysisResult.Success);
@@ -164,7 +164,7 @@
         public void Clear()
         {
             this.ossRootNode.Clean();
-            this.codeSequrityRootNode.Clean();
+            this.codeSecurityRootNode.Clean();
             this.codeQualityRootNode.Clean();
         }
 
@@ -175,7 +175,7 @@
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            foreach (TreeNode treeNode in this.codeSequrityRootNode.Items)
+            foreach (TreeNode treeNode in this.codeSecurityRootNode.Items)
             {
                 ICollectionView collectionView = CollectionViewSource.GetDefaultView(treeNode.Items);
 
@@ -198,7 +198,7 @@
             this.FilterOssItems(this.ossRootNode, severityFilter, searchString);
 
             this.FilterSnykCodeItems(this.codeQualityRootNode, severityFilter, searchString);
-            this.FilterSnykCodeItems(this.codeSequrityRootNode, severityFilter, searchString);
+            this.FilterSnykCodeItems(this.codeSecurityRootNode, severityFilter, searchString);
         });
 
         private void FilterOssItems(RootTreeNode rootTreeNode, SeverityFilter severityFilter, string searchString)


### PR DESCRIPTION
In this PR reworked logic for get files in Solution. Now extension get solution files using VS toolkit api. 

First extension will check project/solution type. If project opened as folder it will get folder files using .net classes. If project is .net solution it will use VS toolkit api.

If project not contains files to scan it will show message in corresponding tree node item. For example

<img width="1503" alt="Screenshot 2022-03-28 at 08 44 38" src="https://user-images.githubusercontent.com/7049329/160333956-a71efd8d-7d80-41f4-b261-fc900e56781e.png">

