### PR TITLE
[ROAD-660] fix: JsonReaderException unexpected character encountered while parsing

### DIFF
--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykApiService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykApiService.cs
@@ -39,7 +39,15 @@
             var response = await this.SendSastSettingsRequestAsync();
             var responseContent = await response.Content.ReadAsStringAsync();
 
-            return Json.Deserialize<SastSettings>(responseContent);
+            try
+            {
+                return Json.Deserialize<SastSettings>(responseContent);
+            }
+            catch (Exception e)
+            {
+                // In case of invalid json string return null.
+                return null;
+            }
         }
 
         /// <inheritdoc/>

--- a/Snyk.VisualStudio.Extension.Tests/SnykApiServiceTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/SnykApiServiceTest.cs
@@ -77,5 +77,25 @@
 
             Assert.Null(sastSettings);
         }
+
+        [Fact]
+        public async Task SnykApiService_InvalidUrlProvided_ReturnNullAsync()
+        {
+            var optionsMock = new Mock<ISnykOptions>();
+
+            optionsMock
+                .Setup(options => options.CustomEndpoint)
+                .Returns("https://snyk.io/");
+
+            optionsMock
+                .Setup(options => options.ApiToken)
+                .Returns(Environment.GetEnvironmentVariable("TEST_API_TOKEN"));
+
+            var apiService = new SnykApiService(optionsMock.Object);
+
+            var sastSettings = await apiService.GetSastSettingsAsync();
+
+            Assert.Null(sastSettings);
+        }
     }
 }


### PR DESCRIPTION
Wrap sast response with try/catch in case of invalid json response from server. If server returned invalid json (for example, html text) it just return null value.