### PR TITLE
fix: release categories

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/vs-publish.json
+++ b/Snyk.VisualStudio.Extension.2022/vs-publish.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "http://json.schemastore.org/vsix-publish",
-  "categories": [ "Tools", "Coding" ],
+  "categories": [ "Security", "Coding" ],
   "identity": {
     "internalName": "SnykVulnerabilityScannerV2022"
   },

--- a/Snyk.VisualStudio.Extension/vs-publish.json
+++ b/Snyk.VisualStudio.Extension/vs-publish.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "http://json.schemastore.org/vsix-publish",
-  "categories": [ "Tools", "Coding" ],
+  "categories": [ "Security", "Coding" ],
   "identity": {
     "internalName": "SnykVulnerabilityScanner"
   },


### PR DESCRIPTION
### Description

Fixes https://github.com/snyk/snyk-visual-studio-plugin/runs/5968095874?check_suite_focus=true
>VSSDK: error VsixPub0006 : The publish manifest from 'D:\a\snyk-visual-studio-plugin\snyk-visual-studio-plugin\.\Snyk.VisualStudio.Extension\vs-publish.json' contains some invalid entries: Encountered an unsupported category: Tools..

As per https://stackoverflow.com/questions/57147010/is-it-possible-to-publish-a-visual-studio-template-extension-through-the-command question, default type for extension is "Tools" anyway, so no need to specify otherwise.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [x] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
