### PR TITLE
fix: vsix manifest length exceeding schema limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
     defaults:
       run:
-        working-directory: ${{ github.workspace }} 
+        working-directory: ${{ github.workspace }}
     env:
       TEST_API_TOKEN: ${{ secrets.TEST_API_TOKEN }}
       VsixManifestPath: .\Snyk.VisualStudio.Extension\source.extension.vsixmanifest
@@ -34,7 +34,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget-
 
-    - uses: microsoft/variable-substitution@v1 
+    - uses: microsoft/variable-substitution@v1
       with:
         files: '.\Snyk.Common\appsettings.json'
       env:
@@ -119,14 +119,14 @@ jobs:
         asset_content_type: application/zip
 
     - name: Publish 2015-2019 extension to Marketplace
-      uses: cezarypiatek/VsixPublisherAction@0.1
+      uses: cezarypiatek/VsixPublisherAction@0.2
       with:
         extension-file: '.\Snyk.VisualStudio.Extension\bin\Release\Snyk.VisualStudio.Extension.vsix'
         publish-manifest-file: '.\Snyk.VisualStudio.Extension\vs-publish.json'
         personal-access-code: ${{ secrets.VS_PUBLISHER_ACCESS_TOKEN }}
 
     - name: Publish 2022 extension to Marketplace
-      uses: cezarypiatek/VsixPublisherAction@0.1
+      uses: cezarypiatek/VsixPublisherAction@0.2
       with:
         extension-file: '.\Snyk.VisualStudio.Extension.2022\bin\Release\Snyk.VisualStudio.Extension.vsix'
         publish-manifest-file: '.\Snyk.VisualStudio.Extension.2022\vs-publish.json'

--- a/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
+++ b/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
     <Metadata>
         <Identity Id="snyk_visual_studio_plugin_2022.1a8ce03c-713d-41f9-9d2d-6451639dfca5" Version="1.1.8" Language="en-US" Publisher="Snyk" />
         <DisplayName>Snyk Security - Code and Open Source Dependencies</DisplayName>
-        <Description xml:space="preserve">The Visual Studio extension (Snyk Security - Code and Open Source Dependencies) helps you find and fix security vulnerabilities in your projects. Within a few seconds, the extension will provide a list of all the different types of security vulnerabilities identified together with actionable fix advice. The extension combines the power of two Snyk products: Snyk Open Source and Snyk Code.</Description>
+        <Description xml:space="preserve">The Visual Studio extension (Snyk Security - Code and Open Source Dependencies) helps you find and fix security vulnerabilities in your projects.</Description>
         <MoreInfo>https://github.com/snyk/snyk-visual-studio-plugin/</MoreInfo>
         <License>LICENSE.txt</License>
         <ReleaseNotes>https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CHANGELOG.md</ReleaseNotes>


### PR DESCRIPTION
### Description
Fixes "VSSDK: error VsixPub0024 : The description for the extension must be set and it must be less than 280 characters in length." as reported in [the latest failed release](https://github.com/snyk/snyk-visual-studio-plugin/runs/5990477867?check_suite_focus=true).