### PR TITLE
fix: publisher in release

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/vs-publish.json
+++ b/Snyk.VisualStudio.Extension.2022/vs-publish.json
@@ -7,6 +7,6 @@
   "assetFiles": [
   ],
   "overview": "../README.md",
-  "publisher": "Snyk Ltd.",
+  "publisher": "Snyk",
   "repo": "http://github.com/snyk/snyk-visual-studio-plugin/"
 }

--- a/Snyk.VisualStudio.Extension/vs-publish.json
+++ b/Snyk.VisualStudio.Extension/vs-publish.json
@@ -7,6 +7,6 @@
   "assetFiles": [
   ],
   "overview": "../README.md",
-  "publisher": "Snyk Ltd.",
+  "publisher": "Snyk",
   "repo": "http://github.com/snyk/snyk-visual-studio-plugin/"
 }


### PR DESCRIPTION
### Description
Fixes `VSSDK: error VsixPub0029 : An error occurred while communicating with the marketplace: The publisher name 'Snyk Ltd.' is invalid. Publisher names may only contain 'A' through 'Z', 'a' through 'z', '0' through '9' and '-'. The publisher name must start with an alphabetic or numeric character.`