### PR TITLE
fix: release publisher to be id instead of display name

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/vs-publish.json
+++ b/Snyk.VisualStudio.Extension.2022/vs-publish.json
@@ -7,6 +7,6 @@
   "assetFiles": [
   ],
   "overview": "../README.md",
-  "publisher": "Snyk",
+  "publisher": "snyk-security",
   "repo": "http://github.com/snyk/snyk-visual-studio-plugin/"
 }

--- a/Snyk.VisualStudio.Extension/vs-publish.json
+++ b/Snyk.VisualStudio.Extension/vs-publish.json
@@ -7,6 +7,6 @@
   "assetFiles": [
   ],
   "overview": "../README.md",
-  "publisher": "Snyk",
+  "publisher": "snyk-security",
   "repo": "http://github.com/snyk/snyk-visual-studio-plugin/"
 }


### PR DESCRIPTION
### Description

Release publisher to be id instead of display name.
