### PR TITLE
fix: vsix manifest publisher id

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
+++ b/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="snyk_visual_studio_plugin_2022.1a8ce03c-713d-41f9-9d2d-6451639dfca5" Version="1.1.8" Language="en-US" Publisher="Snyk" />
+        <Identity Id="snyk_visual_studio_plugin_2022.1a8ce03c-713d-41f9-9d2d-6451639dfca5" Version="1.1.8" Language="en-US" Publisher="snyk-security" />
         <DisplayName>Snyk Security - Code and Open Source Dependencies</DisplayName>
         <Description xml:space="preserve">The Visual Studio extension (Snyk Security - Code and Open Source Dependencies) helps you find and fix security vulnerabilities in your projects.</Description>
         <MoreInfo>https://github.com/snyk/snyk-visual-studio-plugin/</MoreInfo>

--- a/Snyk.VisualStudio.Extension/source.extension.vsixmanifest
+++ b/Snyk.VisualStudio.Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="snyk_visual_studio_plugin.154948da-e3ba-45ce-9bee-9688a7e30462" Version="1.1.8" Language="en-US" Publisher="Snyk" />
+        <Identity Id="snyk_visual_studio_plugin.154948da-e3ba-45ce-9bee-9688a7e30462" Version="1.1.8" Language="en-US" Publisher="snyk-security" />
         <DisplayName>Snyk Security - Code and Open Source Dependencies</DisplayName>
         <Description xml:space="preserve">The Visual Studio extension (Snyk Security - Code and Open Source Dependencies) helps you find and fix security vulnerabilities in your projects.</Description>
         <MoreInfo>https://github.com/snyk/snyk-visual-studio-plugin/</MoreInfo>


### PR DESCRIPTION
### Description

Attempt to fix `VSSDK: error VsixPub0029 : An error occurred while communicating with the marketplace: vsixId: The VSIX ID in the provided file is already in use. Every extension needs to have an unique ID. Provide a file with an unique ID.` in release.