### PR TITLE
fix: IOException in VS 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Changelog
 
+## [1.1.9]
+
+### Fixed
+- "Object reference not set to an instance of an object" when launching extension in Visual Studio 2022.
+
 ## [1.1.8]
 
 ### Fixed

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -70,7 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Community.VisualStudio.Toolkit.17">
-      <Version>17.0.430</Version>
+      <Version>17.0.394</Version>
     </PackageReference>
     <PackageReference Include="MarkdownSharp">
       <Version>2.0.5</Version>

--- a/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
+++ b/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="snyk_visual_studio_plugin_2022.1a8ce03c-713d-41f9-9d2d-6451639dfca5" Version="1.1.8" Language="en-US" Publisher="Snyk" />
+        <Identity Id="snyk_visual_studio_plugin_2022.1a8ce03c-713d-41f9-9d2d-6451639dfca5" Version="1.1.9" Language="en-US" Publisher="Snyk" />
         <DisplayName>Snyk Security - Code and Open Source Dependencies</DisplayName>
         <Description xml:space="preserve">The Visual Studio extension (Snyk Security - Code and Open Source Dependencies) helps you find and fix security vulnerabilities in your projects.</Description>
         <MoreInfo>https://github.com/snyk/snyk-visual-studio-plugin/</MoreInfo>

--- a/Snyk.VisualStudio.Extension/source.extension.vsixmanifest
+++ b/Snyk.VisualStudio.Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="snyk_visual_studio_plugin.154948da-e3ba-45ce-9bee-9688a7e30462" Version="1.1.8" Language="en-US" Publisher="Snyk" />
+        <Identity Id="snyk_visual_studio_plugin.154948da-e3ba-45ce-9bee-9688a7e30462" Version="1.1.9" Language="en-US" Publisher="Snyk" />
         <DisplayName>Snyk Security - Code and Open Source Dependencies</DisplayName>
         <Description xml:space="preserve">The Visual Studio extension (Snyk Security - Code and Open Source Dependencies) helps you find and fix security vulnerabilities in your projects.</Description>
         <MoreInfo>https://github.com/snyk/snyk-visual-studio-plugin/</MoreInfo>


### PR DESCRIPTION
### Description

Fixes the following exception when launching extension in Visual Studio 2022. Most likely this occurs due to [the last change](https://github.com/VsixCommunity/Community.VisualStudio.Toolkit/commit/972bef04aad23e1ba5cb30d0668bfba36d344500) in community toolkit.

> System.Windows.Markup.XamlParseException: Initialization of 'Snyk.VisualStudio.Extension.Shared.UI.Tree.SnykFilterableTree' threw an exception. ---> System.IO.IOException: Cannot locate resource 'themes/themeresources.xaml'.
   at MS.Internal.AppModel.ResourcePart.GetStreamCore(FileMode mode, FileAccess access)
   at System.IO.Packaging.PackagePart.GetStream(FileMode mode, FileAccess access)
   at System.IO.Packaging.PackWebResponse.CachedResponse.GetResponseStream()
   at System.IO.Packaging.PackWebResponse.get_ContentType()
   at MS.Internal.WpfWebRequestHelper.GetContentType(WebResponse response)
   at System.Windows.ResourceDictionary.set_Source(Uri value)
   at Community.VisualStudio.Toolkit.Themes.MergeStyles(FrameworkElement element)
   at Community.VisualStudio.Toolkit.Themes.OnElementInitialized(Object sender, EventArgs args)
   at System.EventHandler.Invoke(Object sender, EventArgs e)
   at System.Windows.FrameworkElement.RaiseInitialized(EventPrivateKey key, EventArgs e)
   at System.Windows.FrameworkElement.TryFireInitialized()
   at MS.Internal.Xaml.Runtime.ClrObjectRuntime.InitializationGuard(XamlType xamlType, Object obj, Boolean begin)


### Checklist

- [x] CHANGELOG.md updated

