### PR TITLE
[ROAD-904] fix 🐛: scan running synchronously

### DIFF
--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykTasksService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykTasksService.cs
@@ -213,9 +213,10 @@
 
                 this.serviceProvider.AnalyticsService.LogAnalysisIsTriggeredEvent(this.GetSelectedFeatures(selectedFeatures));
 
-                await this.ScanOssAsync(selectedFeatures);
+                var ossScanTask = this.ScanOssAsync(selectedFeatures);
+                var snykCodeScanTask = this.ScanSnykCodeAsync(selectedFeatures);
 
-                this.ScanSnykCode(selectedFeatures);
+                await Task.WhenAll(ossScanTask, snykCodeScanTask);
             } catch (Exception ex)
             {
                 Logger.Error(ex, "Error on scan");
@@ -446,7 +447,7 @@
             }
         }
 
-        private void ScanSnykCode(FeaturesSettings featuresSettings)
+        private async Task ScanSnykCodeAsync(FeaturesSettings featuresSettings)
         {
             try
             {
@@ -479,57 +480,59 @@
 
                 Logger.Information("Start scan task");
 
-                _ = Task.Run(async () =>
-                {
-                    try
-                    {
-                        try
-                        {
-                            this.isSnykCodeScanning = true;
-
-                            this.FireSnykCodeScanningStartedEvent();
-
-                            var fileProvider = this.serviceProvider.SolutionService.FileProvider;
-
-                            var analysisResult = await this.serviceProvider.SnykCodeService.ScanAsync(fileProvider, progressWorker.TokenSource.Token);
-
-                            this.FireScanningUpdateEvent(analysisResult);
-
-                            this.FireSnykCodeScanningFinishedEvent();
-                        }
-                        catch (Exception e)
-                        {
-                            if (this.IsTaskCancelled(e))
-                            {
-                                this.FireScanningCancelledEvent();
-
-                                return;
-                            }
-
-                            string errorMessage = this.serviceProvider.SnykCodeService.GetSnykCodeErrorMessage(e);
-
-                            this.OnSnykCodeError(errorMessage);
-                        }
-                    }
-                    catch (Exception exception)
-                    {
-                        Logger.Error(exception, string.Empty);
-
-                        this.FireScanningCancelledEvent();
-                    }
-                    finally
-                    {
-                        this.DisposeCancellationTokenSource(this.snykCodeScanTokenSource);
-
-                        this.isSnykCodeScanning = false;
-
-                        this.FireTaskFinished();
-                    }
-                });
+                await Task.Run(() => this.RunSnykCodeScanAsync(progressWorker.TokenSource.Token));
             }
             catch (Exception ex)
             {
                 Logger.Error(ex, "Error on SnykCode scan");
+            }
+        }
+
+        private async Task RunSnykCodeScanAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                try
+                {
+                    this.isSnykCodeScanning = true;
+
+                    this.FireSnykCodeScanningStartedEvent();
+
+                    var fileProvider = this.serviceProvider.SolutionService.FileProvider;
+
+                    var analysisResult = await this.serviceProvider.SnykCodeService.ScanAsync(fileProvider, cancellationToken);
+
+                    this.FireScanningUpdateEvent(analysisResult);
+
+                    this.FireSnykCodeScanningFinishedEvent();
+                }
+                catch (Exception e)
+                {
+                    if (this.IsTaskCancelled(e))
+                    {
+                        this.FireScanningCancelledEvent();
+
+                        return;
+                    }
+
+                    string errorMessage = this.serviceProvider.SnykCodeService.GetSnykCodeErrorMessage(e);
+
+                    this.OnSnykCodeError(errorMessage);
+                }
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(exception, string.Empty);
+
+                this.FireScanningCancelledEvent();
+            }
+            finally
+            {
+                this.DisposeCancellationTokenSource(this.snykCodeScanTokenSource);
+
+                this.isSnykCodeScanning = false;
+
+                this.FireTaskFinished();
             }
         }
 


### PR DESCRIPTION
### Description

Before this changes extension first run OSS scan and only after this run Snyk Code scan. With this changes extension run a scan for OSS and for Snyk Code asynchronously.

### Checklist

- [x] CHANGELOG.md updated

### Screenshots / GIFs
<img width="478" alt="Screenshot 2022-05-04 at 13 13 24" src="https://user-images.githubusercontent.com/7049329/166663205-87c922aa-98bd-4e26-b225-b58e2b10a56a.png">
