### PR TITLE
[ROAD-904] fix 🐛: run scan asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Changelog
 
+## [1.1.14]
+
+### Fixed
+- Run a scan for OSS and for Snyk Code asynchronously.
+
 ## [1.1.13]
 
 ### Fixed

--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykTasksService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykTasksService.cs
@@ -492,39 +492,32 @@
         {
             try
             {
-                try
-                {
-                    this.isSnykCodeScanning = true;
+                this.isSnykCodeScanning = true;
 
-                    this.FireSnykCodeScanningStartedEvent();
+                this.FireSnykCodeScanningStartedEvent();
 
-                    var fileProvider = this.serviceProvider.SolutionService.FileProvider;
+                var fileProvider = this.serviceProvider.SolutionService.FileProvider;
 
-                    var analysisResult = await this.serviceProvider.SnykCodeService.ScanAsync(fileProvider, cancellationToken);
+                var analysisResult = await this.serviceProvider.SnykCodeService.ScanAsync(fileProvider, cancellationToken);
 
-                    this.FireScanningUpdateEvent(analysisResult);
+                this.FireScanningUpdateEvent(analysisResult);
 
-                    this.FireSnykCodeScanningFinishedEvent();
-                }
-                catch (Exception e)
-                {
-                    if (this.IsTaskCancelled(e))
-                    {
-                        this.FireScanningCancelledEvent();
-
-                        return;
-                    }
-
-                    string errorMessage = this.serviceProvider.SnykCodeService.GetSnykCodeErrorMessage(e);
-
-                    this.OnSnykCodeError(errorMessage);
-                }
+                this.FireSnykCodeScanningFinishedEvent();
             }
-            catch (Exception exception)
+            catch (Exception e)
             {
-                Logger.Error(exception, string.Empty);
+                if (this.IsTaskCancelled(e))
+                {
+                    this.FireScanningCancelledEvent();
 
-                this.FireScanningCancelledEvent();
+                    return;
+                }
+
+                Logger.Error(e, "Error on Run Snyk Code scan");
+
+                string errorMessage = this.serviceProvider.SnykCodeService.GetSnykCodeErrorMessage(e);
+
+                this.OnSnykCodeError(errorMessage);
             }
             finally
             {


### PR DESCRIPTION
### Description

Before this changes extension first run OSS scan and only after this run Snyk Code scan. With this changes extension run a scan for OSS and for Snyk Code asynchronously.

### Checklist

- [x] CHANGELOG.md updated

### Screenshots / GIFs

<img width="478" alt="Screenshot 2022-05-04 at 13 13 24" src="https://user-images.githubusercontent.com/7049329/166663885-fea26f9e-cea0-4d04-8148-e463003bad49.png">
