### PR TITLE
[ROAD-821] fix: restore all tree items after clear search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Changelog
 
+## [1.1.15]
+
+### Fixed
+ - Restore all tree items after clear search or filter.
+
 ## [1.1.14]
 
 ### Fixed

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindow.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindow.cs
@@ -89,7 +89,7 @@
         /// </summary>
         public override void ClearSearch()
         {
-            SnykToolWindowControl toolWindowControl = (SnykToolWindowControl) this.Content;
+            var toolWindowControl = (SnykToolWindowControl) this.Content;
 
             toolWindowControl.VulnerabilitiesTree.DisplayAllVulnerabilities();
         }
@@ -125,18 +125,21 @@
             {
                 this.ErrorCode = VSConstants.S_OK;
 
-                try
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
-                    ThreadHelper.ThrowIfNotOnUIThread();
-                    SnykToolWindowControl toolWindowControl = (SnykToolWindowControl)toolWindow.Content;
-                    toolWindowControl.VulnerabilitiesTree.FilterBy(this.SearchQuery.SearchString);
-                }
-                catch (Exception exception)
-                {
-                    Console.WriteLine(exception.Message);
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                    this.ErrorCode = VSConstants.E_FAIL;
-                }
+                    try
+                    {
+                        var toolWindowControl = (SnykToolWindowControl)this.toolWindow.Content;
+
+                        toolWindowControl.VulnerabilitiesTree.FilterBy(this.SearchQuery.SearchString);
+                    }
+                    catch (Exception e)
+                    {
+                        this.ErrorCode = VSConstants.E_FAIL;
+                    }
+                });
 
                 base.OnStartSearch();
             }

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindow.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindow.cs
@@ -125,7 +125,7 @@
             {
                 this.ErrorCode = VSConstants.S_OK;
 
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
                     await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/Snyk.VisualStudio.Extension.Shared/UI/Tree/SnykFilterableTree.xaml.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Tree/SnykFilterableTree.xaml.cs
@@ -226,7 +226,7 @@
 
                     if (searchString != null && searchString != string.Empty)
                     {
-                        isVulnIncluded = isVulnIncluded && vulnerability.GetPackageNameTitle().Contains(searchString);
+                        isVulnIncluded = isVulnIncluded && vulnerability.GetPackageNameTitle().ToLowerInvariant().Contains(searchString.ToLowerInvariant());
                     }
 
                     return isVulnIncluded;
@@ -247,7 +247,7 @@
 
                     if (searchString != null && searchString != string.Empty)
                     {
-                        isVulnIncluded = isVulnIncluded && suggestion.GetDisplayTitleWithLineNumber().Contains(searchString);
+                        isVulnIncluded = isVulnIncluded && suggestion.GetDisplayTitleWithLineNumber().ToLowerInvariant().Contains(searchString.ToLowerInvariant());
                     }
 
                     return isVulnIncluded;

--- a/Snyk.VisualStudio.Extension.Shared/UI/Tree/SnykFilterableTree.xaml.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Tree/SnykFilterableTree.xaml.cs
@@ -1,7 +1,6 @@
 ﻿namespace Snyk.VisualStudio.Extension.Shared.UI.Tree
 {
     using System;
-    using System.ComponentModel;
     using System.Linq;
     using System.Windows;
     using System.Windows.Controls;
@@ -176,12 +175,12 @@
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            foreach (TreeNode treeNode in this.codeSecurityRootNode.Items)
-            {
-                ICollectionView collectionView = CollectionViewSource.GetDefaultView(treeNode.Items);
+            var restoreOssItemsTask = this.DisplayAllVulnerabilitiesAsync(this.ossRootNode);
+            var restoreCodeSecurityItemsTask = this.DisplayAllVulnerabilitiesAsync(this.codeSecurityRootNode);
+            var restoreCodeQualityItemsTask = this.DisplayAllVulnerabilitiesAsync(this.codeQualityRootNode);
 
-                collectionView.Filter = null;
-            }
+            await System.Threading.Tasks.Task
+                .WhenAll(restoreOssItemsTask, restoreCodeSecurityItemsTask, restoreCodeQualityItemsTask);
         });
 
         /// <summary>
@@ -201,6 +200,18 @@
             this.FilterSnykCodeItems(this.codeQualityRootNode, severityFilter, searchString);
             this.FilterSnykCodeItems(this.codeSecurityRootNode, severityFilter, searchString);
         });
+
+        private async System.Threading.Tasks.Task DisplayAllVulnerabilitiesAsync(RootTreeNode rootTreeNode)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            foreach (var treeNode in rootTreeNode.Items)
+            {
+                var collectionView = CollectionViewSource.GetDefaultView(treeNode.Items);
+
+                collectionView.Filter = null;
+            }
+        }
 
         private void FilterOssItems(RootTreeNode rootTreeNode, SeverityFilter severityFilter, string searchString)
         {


### PR DESCRIPTION
### Description

Fix issue with search/filter functionality. Now if user search or filter OSS/SnykCode results and after this clear search keyword it will restore all results in results tree.

### Checklist

- [x] CHANGELOG.md updated

### Screenshots / GIFs

<img width="1288" alt="Screenshot 2022-05-13 at 18 24 41" src="https://user-images.githubusercontent.com/7049329/168323136-efd1453f-198c-4f38-bc94-1e231c9520bc.png">

