### PR TITLE
[ROAD-890] fix: lost some Snyk Code results in case one file with same suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Fixed
 - The color of the text in the tree view does not match the color from VS theme.
-- Fixed the problem with partially lost Snyk Code results if file contains multiple identical suggestions.
-- Fixed a problem with partially lost Snyk Code results if a single file contains multiple identical suggestions.
+- A problem with partially lost Snyk Code results if a single file contains multiple identical suggestions.
 
 ## [1.1.15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@
 ### Fixed
 - The color of the text in the tree view does not match the color from VS theme.
 - Fixed the problem with partially lost Snyk Code results if file contains multiple identical suggestions.
-
-## [1.1.16]
-
-### Fixed
 - Fixed a problem with partially lost Snyk Code results if a single file contains multiple identical suggestions.
 
 ## [1.1.15]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 - The color of the text in the tree view does not match the color from VS theme.
+- Fixed the problem with partially lost Snyk Code results if file contains multiple identical suggestions.
+
+## [1.1.16]
+
+### Fixed
+- Fixed a problem with partially lost Snyk Code results if a single file contains multiple identical suggestions.
 
 ## [1.1.15]
 

--- a/Snyk.Code.Library/Service/AnalysisService.cs
+++ b/Snyk.Code.Library/Service/AnalysisService.cs
@@ -1,6 +1,7 @@
 ﻿namespace Snyk.Code.Library.Service
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
     using System.Threading;
@@ -136,9 +137,7 @@
                     var fileDtos = suggestionIdToFileKeyPair.Value;
 
                     var suggestionDto = analysisResultDto.Suggestions[suggestionId];
-                    var fileDto = fileDtos.First();
-                    var fileName = fileAnalysis.FileName;
-                    var suggestion = new Suggestion(fileName, suggestionDto, fileDto);
+                    var exampleFixes = new List<SuggestionFix>();
 
                     foreach (var exampleCommitFixes in suggestionDto.ExampleCommitFixes)
                     {
@@ -149,10 +148,20 @@
                                 .Select(line => new FixLine { Line = line.Line, LineChange = line.LineChange, LineNumber = line.LineNumber }).ToList(),
                         };
 
-                        suggestion.Fixes.Add(suggestionFix);
+                        exampleFixes.Add(suggestionFix);
                     }
 
-                    fileAnalysis.Suggestions.Add(suggestion);
+                    foreach (var fileDto in fileDtos)
+                    {
+                        var fileName = fileAnalysis.FileName;
+                        var suggestion = new Suggestion(fileName, suggestionDto, fileDto);
+                        foreach (var exampleFix in exampleFixes)
+                        {
+                            suggestion.Fixes.Add(exampleFix);
+                        }
+
+                        fileAnalysis.Suggestions.Add(suggestion);
+                    }
                 }
 
                 analysisResult.FileAnalyses.Add(fileAnalysis);


### PR DESCRIPTION
…n in different places

### Description

This PR fix issue with not complete Snyk Code results. If one file has multiple identical suggestions it will show all of them.

### Checklist

- [x] Tests added and all succeed
- [x] CHANGELOG.md updated

### Screenshots / GIFs

<img width="1166" alt="Screenshot 2022-05-17 at 16 35 27" src="https://user-images.githubusercontent.com/7049329/168823832-d753ceb4-757a-4499-b811-b7f58ac499af.png">
