### PR TITLE
fix: always use HEAD for image urls in readme sync

### DIFF
--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -20,7 +20,7 @@ jobs:
 
           cp ./docs/docs/ide-tools/visual-studio-extension.md ./snyk-visual-studio-plugin/README.md
           sed -i \
-              -e "s|../.gitbook/assets/|https://github.com/snyk/user-docs/raw/$(git -C ./docs rev-parse HEAD)/docs/.gitbook/assets/|g" \
+              -e "s|../.gitbook/assets/|https://github.com/snyk/user-docs/raw/HEAD/docs/.gitbook/assets/|g" \
               ./snyk-visual-studio-plugin/README.md
           sed -i \
               -E 's|(\{%.*%\})||g' \


### PR DESCRIPTION
### Description

Always use HEAD for image urls in readme sync to prevent bot detecting changes when it's only remote git head hash update.