### PR TITLE
[ROAD-940] Fix error on get all project paths from dte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Snyk Changelog
 
+## [1.1.19]
+
+### Fixed
+- Errors when projects are nested inside solution folders
+
+## [1.1.18]
+
+### Changed
+- Removed manually included DLLs from VSIX package
+
 ## [1.1.17]
 
 ### Fixed
 - Selection of tree view items only working when clicking on the icon
 - Background color of unfocused selected items might blend with font color on some themes
-- Error on get all project paths from dte
 
 ## [1.1.16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Selection of tree view items only working when clicking on the icon
 - Background color of unfocused selected items might blend with font color on some themes
+- Error on get all project paths from dte
 
 ## [1.1.16]
 


### PR DESCRIPTION
### Description

If projects in solution organised via folders extension failed to get project path. Now this issue fixed. It check is dte project type is vsProjectKindSolutionFolder and in this case it will get project path using project sub projects items. 

Error on get all project paths from dte

### Checklist
- [x] CHANGELOG.md updated

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
