### PR TITLE
[ROAD-305] fix: external example fixes dark theme support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [1.1.21]
 
+### Fixed
+- External example fixes tab control dark theme support.
+
+
 ### Changed
 - Replace the word "Remediation" with "Fix" in OSS report
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Snyk Changelog
 
-## [1.1.21]
+## [1.1.22]
 
 ### Fixed
 - External example fixes tab control dark theme support.
 
+## [1.1.21]
 
 ### Changed
-- Replace the word "Remediation" with "Fix" in OSS report
+- Replace the word "Remediation" with "Fix" in OSS report.
 
 ## [1.1.20]
 

--- a/Snyk.VisualStudio.Extension.Shared/Snyk.VisualStudio.Extension.Shared.projitems
+++ b/Snyk.VisualStudio.Extension.Shared/Snyk.VisualStudio.Extension.Shared.projitems
@@ -182,6 +182,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Theme\VsBroadcastMessageEvents.cs">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)UI\Toolwindow\SnykCode\ExampleFixTab.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\Toolwindow\SnykCode\ExternalExampleFixRichTextBox.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\Controls\TextField.xaml.cs">
       <DependentUpon>TextField.xaml</DependentUpon>
     </Compile>

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykCode/ExampleFixTab.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykCode/ExampleFixTab.cs
@@ -1,0 +1,21 @@
+﻿namespace Snyk.VisualStudio.Extension.Shared.UI.Toolwindow.SnykCode
+{
+    using System.Collections.ObjectModel;
+    using Snyk.Code.Library.Domain.Analysis;
+
+    /// <summary>
+    /// Domain object for Example fix tab.
+    /// </summary>
+    public class ExampleFixTab
+    {
+        /// <summary>
+        /// Gets or sets a value for tab title.
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets a lines list.
+        /// </summary>
+        public ObservableCollection<FixLine> Lines { get; set; }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykCode/ExternalExampleFixRichTextBox.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykCode/ExternalExampleFixRichTextBox.cs
@@ -1,0 +1,98 @@
+﻿namespace Snyk.VisualStudio.Extension.Shared.UI.Toolwindow.SnykCode
+{
+    using System.Collections.ObjectModel;
+    using System.Windows;
+    using System.Windows.Controls;
+    using System.Windows.Documents;
+    using System.Windows.Media;
+    using Snyk.Code.Library.Domain.Analysis;
+
+    /// <summary>
+    /// Extended <see cref="RichTextBox"/> for display code example with red/green highlite rows.
+    /// </summary>
+    public class ExternalExampleFixRichTextBox : RichTextBox
+    {
+        public static readonly DependencyProperty LinesProperty =
+            DependencyProperty.Register("Lines", typeof(ObservableCollection<FixLine>), typeof(ExternalExampleFixRichTextBox), new PropertyMetadata(OnLinesChanged));
+
+        /// <summary>
+        /// Gets or sets lines of code in editor.
+        /// </summary>
+        public ObservableCollection<FixLine> Lines
+        {
+            get => this.GetValue(LinesProperty) as ObservableCollection<FixLine>;
+            set => this.SetValue(LinesProperty, value);
+        }
+
+        /// <summary>
+        /// Create new flow document with code lines using <see cref="Paragraph"/> with proper background brush.
+        /// </summary>
+        /// <param name="dependencyObject">Must be ExternalExampleFixRichTextBox instance.</param>
+        /// <param name="evenArgs">Event args with new value as ObservableCollection<FixLine>.</param>
+        private static void OnLinesChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs evenArgs)
+        {
+            if (dependencyObject is ExternalExampleFixRichTextBox richTextBox)
+            {
+                richTextBox.Document.Blocks.Clear();
+
+                var lines = evenArgs.NewValue as ObservableCollection<FixLine>;
+
+                if (lines == null)
+                {
+                    return;
+                }
+
+                FlowDocument flowDocument = new FlowDocument();
+
+                foreach (var line in lines)
+                {
+                    var lineDecorations = GetLineDecorations(line.LineChange);
+
+                    var paragraph = new Paragraph();
+                    paragraph.Margin = new Thickness(0);
+                    paragraph.Padding = new Thickness(2);
+
+                    if (lineDecorations.Item2 != null)
+                    {
+                        paragraph.Background = lineDecorations.Item2;
+                    }
+
+                    paragraph.Inlines.Add($"   {line.LineNumber} {lineDecorations.Item1}    {line.Line}");
+
+                    flowDocument.Blocks.Add(paragraph);
+                }
+
+                richTextBox.Document = flowDocument;
+            }
+        }
+
+        /// <summary>
+        /// This method transform this line to "+" or "-" and return brush for each case.
+        /// </summary>
+        /// <param name="lineChange">Could be "added" or "removed". </param>
+        /// <returns>Return tuple with "+" or "-" and brush for each case.</returns>
+        private static (string, SolidColorBrush) GetLineDecorations(string lineChange)
+        {
+            string lineChangeSymbol = string.Empty;
+            SolidColorBrush backgroundBrush = null;
+
+            switch (lineChange)
+            {
+                case "added":
+                    lineChangeSymbol = "+";
+                    backgroundBrush = Brushes.DarkSeaGreen;
+
+                    break;
+                case "removed":
+                    lineChangeSymbol = "-";
+                    backgroundBrush = Brushes.PaleVioletRed;
+
+                    break;
+                default:
+                    break;
+            }
+
+            return (lineChangeSymbol, backgroundBrush);
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykCode/ExternalExampleFixesControl.xaml
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykCode/ExternalExampleFixesControl.xaml
@@ -2,9 +2,9 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:Snyk.VisualStudio.Extension.Shared.UI.Toolwindow.SnykCode"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"              
              xmlns:c="clr-namespace:Snyk.VisualStudio.Extension.Shared.UI.Controls"
+             xmlns:snykCode="clr-namespace:Snyk.VisualStudio.Extension.Shared.UI.Toolwindow.SnykCode"
              xmlns:toolkit="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
              toolkit:Themes.UseVsTheme="True"
              mc:Ignorable="d" 
@@ -19,12 +19,52 @@
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
-        
+
         <c:TextField Grid.Row="0" Grid.Column="0" Text="External example fixes" FontWeight="Bold" Margin="0, 0, 0, 8"/>
 
         <c:TextField Grid.Row="1" Grid.Column="0" x:Name="shortDescription" Margin="0, 0, 0, 8"/>
 
         <TabControl Grid.Row="3" Grid.Column="0" x:Name="externalExampleFixesTab" Padding="4, 4, 4, 4" 
-                    Background="Transparent" Foreground="{DynamicResource VsBrush.WindowText}"/>
+                    BorderThickness="0, 0, 0, 0"
+                    Background="{DynamicResource VsBrush.Window}" Foreground="{DynamicResource VsBrush.WindowText}">
+            <TabControl.Resources>
+                <Style TargetType="TabItem">
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type TabItem}">
+                                <Border x:Name="PART_Border" Background="{TemplateBinding Background}" BorderThickness="1,1,1,0">
+                                    <ContentPresenter ContentSource="Header" Margin="1"/>
+                                </Border>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="IsSelected" Value="True">
+                                        <Setter Property="Background" Value="{DynamicResource VsBrush.ActiveBorder}"/>
+                                        <Setter Property="Foreground" Value="{DynamicResource VsBrush.WindowText}"/>
+                                    </Trigger>
+
+                                    <Trigger Property="IsSelected" Value="false">
+                                        <Setter Property="Background" Value="{DynamicResource VsBrush.InactiveBorderKey}"/>
+                                        <Setter Property="Foreground" Value="{DynamicResource VsBrush.WindowText}"/>
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </TabControl.Resources>
+            <TabControl.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Title}" Background="{DynamicResource VsBrush.Window}" Foreground="{DynamicResource VsBrush.WindowText}" Padding="5, 1, 5, 1"/>
+                </DataTemplate>
+            </TabControl.ItemTemplate>
+            <TabControl.ContentTemplate>
+                <DataTemplate>
+                    <snykCode:ExternalExampleFixRichTextBox Lines="{Binding Lines}" 
+                                           IsDocumentEnabled="True" 
+                                           IsReadOnly="True"
+                                           Background="{DynamicResource VsBrush.Window}" Foreground="{DynamicResource VsBrush.WindowText}"
+                                           HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"/>
+                </DataTemplate>
+            </TabControl.ContentTemplate>
+        </TabControl>
     </Grid>
 </UserControl>

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykCode/ExternalExampleFixesControl.xaml.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykCode/ExternalExampleFixesControl.xaml.cs
@@ -1,11 +1,10 @@
 ﻿namespace Snyk.VisualStudio.Extension.Shared.UI.Toolwindow.SnykCode
 {
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Linq;
     using System.Windows;
     using System.Windows.Controls;
-    using System.Windows.Documents;
-    using System.Windows.Media;
     using Snyk.Code.Library.Domain.Analysis;
 
     /// <summary>
@@ -14,6 +13,8 @@
     public partial class ExternalExampleFixesControl : UserControl
     {
         private const int ShowExamplesCount = 3;
+
+        private ObservableCollection<ExampleFixTab> tabs = new ObservableCollection<ExampleFixTab>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExternalExampleFixesControl"/> class.
@@ -30,7 +31,7 @@
         /// <param name="fixes">Suggestion fixes.</param>
         internal void Display(int repoDatasetSize, IList<SuggestionFix> fixes)
         {
-            this.externalExampleFixesTab.Items.Clear();
+            this.tabs.Clear();
 
             this.Visibility = fixes != null && fixes.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
 
@@ -49,57 +50,16 @@
             {
                 var fix = fixes.ElementAt(i);
 
-                var exampleLinesTextBox = new HtmlRichTextBox();
-                exampleLinesTextBox.IsReadOnly = true;
-                exampleLinesTextBox.Document.Blocks.Clear();
-                exampleLinesTextBox.FontFamily = new FontFamily("Consolas");
-
-
-                foreach (var fixLine in fix.Lines)
+                this.tabs.Add(new ExampleFixTab
                 {
-                    string lineChangeSymbol = string.Empty;
-                    SolidColorBrush backgroundBrush = null;
-
-                    switch (fixLine.LineChange)
-                    {
-                        case "added":
-                            lineChangeSymbol = "+";
-                            backgroundBrush = Brushes.LightGreen;
-
-                            break;
-                        case "removed":
-                            lineChangeSymbol = "-";
-                            backgroundBrush = Brushes.LightCoral;
-
-                            break;
-                        default:
-                            break;
-                    }
-
-                    var lineText = $"   {fixLine.LineNumber} {lineChangeSymbol}    {fixLine.Line}";
-
-                    var document = exampleLinesTextBox.Document;
-
-                    Paragraph paragraph = new Paragraph();
-                    paragraph.Inlines.Clear();
-                    paragraph.Margin = new Thickness(0);
-                    paragraph.Padding = new Thickness(2);
-
-                    if (backgroundBrush != null)
-                    {
-                        paragraph.Background = backgroundBrush;
-                    }
-
-                    paragraph.Inlines.Add(lineText);
-
-                    document.Blocks.Add(paragraph);
-                }
-
-                this.externalExampleFixesTab.Items.Add(new TabItem
-                {
-                    Header = new TextBlock { Text = this.GetGithubRepositoryName(fix.CommitURL), },
-                    Content = exampleLinesTextBox,
+                    Title = this.GetGithubRepositoryName(fix.CommitURL),
+                    Lines = new ObservableCollection<FixLine>(fix.Lines),
                 });
+            }
+
+            if (this.externalExampleFixesTab.ItemsSource == null)
+            {
+                this.externalExampleFixesTab.ItemsSource = this.tabs;
             }
         }
 


### PR DESCRIPTION
### Description

Right now external example fixes displayed in white theme even if user use dark VS theme. This PR fix this issue.

### Checklist

- [ ] CHANGELOG.md updated

### Screenshots / GIFs

<img width="1556" alt="Screenshot 2022-06-16 at 13 47 45" src="https://user-images.githubusercontent.com/7049329/174057431-1d093610-34da-475f-a7e6-6c1c58fdb7f0.png">

<img width="1558" alt="Screenshot 2022-06-16 at 13 48 31" src="https://user-images.githubusercontent.com/7049329/174057457-693783be-5c72-4529-86b4-f290276c43d3.png">

