### PR TITLE
[ROAD-992] fix: snyk code results partially lost for wpf projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - External example fixes tab control dark theme support.
+- Snyk Code results partially lost for WPF projecs.
 
 ## [1.1.21]
 

--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykSolutionService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykSolutionService.cs
@@ -247,14 +247,12 @@
                     {
                         files.Add(item.FullPath);
                     }
-                    else
-                    {
-                        var itemFiles = await this.GetSolutionItemFilesAsync(item);
 
-                        if (itemFiles != null && itemFiles.Count > 0)
-                        {
-                            files.AddRange(itemFiles);
-                        }
+                    var itemFiles = await this.GetSolutionItemFilesAsync(item);
+
+                    if (itemFiles != null && itemFiles.Count > 0)
+                    {
+                        files.AddRange(itemFiles);
                     }
                 }
 
@@ -272,14 +270,12 @@
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var item = await Toolkit.VS.Solutions.GetActiveItemAsync();
+            var solutionItem = await Toolkit.VS.Solutions.GetCurrentSolutionAsync();
 
-            if (item == null)
+            if (solutionItem == null)
             {
                 return await this.GetSolutionProjectsFilesFromDteAsync();
             }
-
-            var solutionItem = item.FindParent(Toolkit.SolutionItemType.Solution);
 
             return await this.GetSolutionItemFilesAsync(solutionItem);
         }


### PR DESCRIPTION
### Description

Fixed issue with Snyk Code results for WPF projects. This issue related to case when one physical file related to another (one parent and one child). For example

App.xaml
App.xaml.cs


### Checklist

- [x] CHANGELOG.md updated

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
