### PR TITLE
[ROAD-1023] fix:  Marketplace title correction for 2022 VS

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
+++ b/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
         <Identity Id="snyk_visual_studio_plugin_2022.1a8ce03c-713d-41f9-9d2d-6451639dfca5" Version="0.0.0" Language="en-US" Publisher="Snyk" />
-        <DisplayName>Snyk Security - Code and Open Source Dependencies</DisplayName>
+        <DisplayName>(Preview) Snyk Security - Code and Open Source Dependencies</DisplayName>
         <Description xml:space="preserve">The Visual Studio extension (Snyk Security - Code and Open Source Dependencies) helps you find and fix security vulnerabilities in your projects.</Description>
         <MoreInfo>https://github.com/snyk/snyk-visual-studio-plugin/</MoreInfo>
         <License>LICENSE.txt</License>


### PR DESCRIPTION
### Description
Updated the description of the 2022 version of VS to contain a mention of “Preview”.
This will affect the description on the VS Marketplace for this version and this version only.
