### PR TITLE
[ROAD-1023] fix:  Marketplace title correction for 2015-2019 VS

### DIFF
--- a/Snyk.VisualStudio.Extension/source.extension.vsixmanifest
+++ b/Snyk.VisualStudio.Extension/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
         <Identity Id="snyk_visual_studio_plugin.154948da-e3ba-45ce-9bee-9688a7e30462" Version="0.0.0" Language="en-US" Publisher="Snyk" />
-        <DisplayName>Snyk Security - Code and Open Source Dependencies</DisplayName>
+        <DisplayName>Snyk Security - Code and Open Source Dependencies (VS 2015-2019)</DisplayName>
         <Description xml:space="preserve">The Visual Studio extension (Snyk Security - Code and Open Source Dependencies) helps you find and fix security vulnerabilities in your projects.</Description>
         <MoreInfo>https://github.com/snyk/snyk-visual-studio-plugin/</MoreInfo>
         <License>LICENSE.txt</License>


### PR DESCRIPTION
### Description
Updated the description of the LTS 2015-2019 version of VS to contain the date of the supported version.
This will affect the description on the VS Marketplace for this version and this version only.