### PR TITLE
docs: redirect support to official channel

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Snyk Support
+    url: https://support.snyk.io
+    about: Contact Snyk Support
+  - name: Snyk User Docs
+    url: https://docs.snyk.io
+    about: Snyk User Documentation

--- a/.github/ISSUE_TEMPLATE/stop--don-t-use-github-issues.md
+++ b/.github/ISSUE_TEMPLATE/stop--don-t-use-github-issues.md
@@ -1,0 +1,11 @@
+---
+name: Please don't use GitHub Issues for support requests
+about: Email us at support@snyk.io
+title: Stop, this is not a support channel
+labels: ''
+assignees: ''
+---
+
+[Contact Snyk Support on the web](http://support.snyk.io) or email us at support@snyk.io
+
+**GitHub Issues are not monited by Snyk Support**


### PR DESCRIPTION
### Description

Updates Issue template to redirect users to support portal or email. An example can be seen here: https://github.com/snyk/vscode-extension/issues/new/choose

