### PR TITLE
fix: compatibility issues in VS2022 versions <17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Snyk Changelog
 
+## [1.1.29]
+
+### Fixed
+- Compatibility with VS2022 versions smaller than 17.3
+- Stop button raising an error message
+
 ## [1.1.28]
 
 ### Fixed
-- Snyk Code scans sometimes skips files unnecessarily, leading to missing results or "No supported code available" erros
+- Snyk Code scans sometimes skips files unnecessarily, leading to missing results or "No supported code available" errors.
 
 ## [1.1.27]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.1.29]
 
 ### Fixed
-- Compatibility with VS2022 versions smaller than 17.3
+- Extension failed to load with VS2022 versions smaller than 17.3
 - Stop button raising an error message
 
 ## [1.1.28]

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -75,10 +75,10 @@
     <PackageReference Include="MarkdownSharp">
       <Version>2.0.5</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.3.32804.24" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2094">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5240">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykTasksService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykTasksService.cs
@@ -38,7 +38,7 @@
 
         private ISnykServiceProvider serviceProvider;
 
-        private object cancelTasksLock;
+        private readonly object cancelTasksLock = new object();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SnykTasksService"/> class.


### PR DESCRIPTION
### Description

A fix for compatibility problems with VS2022 versions smaller than 17.3.
Also fixes the stop button not working.

### Checklist
- [x] CHANGELOG.md updated