### PR TITLE
fix: special http header with org name

### DIFF
--- a/Snyk.Code.Library.Tests/SnykCode/Api/SnykCodeClientTest.cs
+++ b/Snyk.Code.Library.Tests/SnykCode/Api/SnykCodeClientTest.cs
@@ -30,12 +30,6 @@
                 ContextOrgName);
         }
 
-        public async Task SnykCodeClient_HttpClient() {
-            Assert.Equal(4, this.snykCodeClient.httpClient.DefaultRequestHeaders.Count);
-            
-            // Check special header for organization name.
-            Assert.Equal(this.snykCodeClient.contextOrgName, this.snykCodeClient.httpClient.DefaultRequestHeaders.Get("snyk-org-name"));
-        }
         [Fact]
         public async Task SnykCodeClient_TwoFilesWithIssuesProvided_GetAnalysisSuccessAsync()
         {

--- a/Snyk.Code.Library.Tests/SnykCode/Api/SnykCodeClientTest.cs
+++ b/Snyk.Code.Library.Tests/SnykCode/Api/SnykCodeClientTest.cs
@@ -30,6 +30,12 @@
                 ContextOrgName);
         }
 
+        public async Task SnykCodeClient_HttpClient() {
+            Assert.Equal(4, this.snykCodeClient.httpClient.DefaultRequestHeaders.Count);
+            
+            // Check special header for organization name.
+            Assert.Equal(this.snykCodeClient.contextOrgName, this.snykCodeClient.httpClient.DefaultRequestHeaders.Get("snyk-org-name"));
+        }
         [Fact]
         public async Task SnykCodeClient_TwoFilesWithIssuesProvided_GetAnalysisSuccessAsync()
         {

--- a/Snyk.Code.Library/Api/SnykCodeClient.cs
+++ b/Snyk.Code.Library/Api/SnykCodeClient.cs
@@ -42,7 +42,7 @@
         /// <param name="orgName">User organization name.</param>
         public SnykCodeClient(string baseUrl, string token, string flowName, string orgName)
         {
-            this.httpClient = HttpClientFactory.NewHttpClient(token, baseUrl);
+            this.httpClient = HttpClientFactory.NewHttpClient(token, baseUrl, orgName);
 
             Logger.Information("Create http client with with url {BaseUrl}.", baseUrl);
 

--- a/Snyk.Common/HttpClientFactory.cs
+++ b/Snyk.Common/HttpClientFactory.cs
@@ -15,8 +15,9 @@
         /// </summary>
         /// <param name="token">User API token.</param>
         /// <param name="baseUrl">Base URL.</param>
+        /// <param name="orgName">User organization name.</param>
         /// <returns>New HttpClient instance.</returns>
-        public static HttpClient NewHttpClient(string token, string baseUrl = null)
+        public static HttpClient NewHttpClient(string token, string baseUrl = null, string orgName = null)
         {
             var httpClient = new HttpClient(new HttpClientHandler
             {
@@ -31,6 +32,13 @@
             {
                 httpClient.BaseAddress = new Uri(baseUrl);
             }
+
+            if (!string.IsNullOrEmpty(orgName))
+            {
+                httpClient.DefaultRequestHeaders.Add("snyk-org-name", orgName);
+            }
+
+            // TODO: Add snyk-request-id header logic
 
             httpClient.DefaultRequestHeaders.Add("Session-Token", token);
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));


### PR DESCRIPTION
### Description

If user have is attached to several organizations with different settings, it may cause unpredictable behaviour. This PR set a special HTTP header, that is used in identification on server side.

https://snyksec.atlassian.net/browse/ZEN-357

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
