### PR TITLE
fix: integration tests workflow [HEAD-294]

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -18,8 +18,13 @@ jobs:
     - name: Check if secrets exist
       env: 
         Secret: ${{ secrets.SNYK_CODE_API_ENDPOINT_URL }}
-      if: ${{ env.Secret == '' }}
-      run: echo "MISSING SECRET"
+      run: |
+        if [ -z "$Secret" ]; then
+          echo "MISSING SECRET"
+          echo "::warning::Missing secret SNYK_CODE_API_ENDPOINT_URL"
+        else
+          echo "SECRET EXISTS"
+        fi
     - uses: microsoft/variable-substitution@v1 
       with:
         files: '.\Snyk.Common\appsettings.json'

--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -19,12 +19,13 @@ jobs:
       env: 
         Secret: ${{ secrets.SNYK_CODE_API_ENDPOINT_URL }}
       run: |
-        if [ -z "$Secret" ]; then
-          echo "MISSING SECRET"
-          echo "::warning::Missing secret SNYK_CODE_API_ENDPOINT_URL"
-        else
-          echo "SECRET EXISTS"
-        fi
+        if ([string]::IsNullOrEmpty($env:Secret)) {
+          Write-Host "MISSING SECRET"
+          Write-Host "::warning::Missing secret SNYK_CODE_API_ENDPOINT_URL"
+        }
+        else {
+          Write-Host "SECRET EXISTS"
+        }
     - uses: microsoft/variable-substitution@v1 
       with:
         files: '.\Snyk.Common\appsettings.json'

--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -6,21 +6,13 @@ on:
       solution-file-path:
         required: true
         type: string
-    secrets:
-      SEGMENT_ANALYTICS_WRITE_KEY:
-        required: true
-      SNYK_CODE_API_ENDPOINT_URL:
-        required: true
-      SENTRY_DSN:
-        required: true
-      SENTRY_ENVIRONMENT:
-        required: true
 jobs:
   build:
     runs-on: windows-2022
     defaults:
       run:
         working-directory: ${{ github.workspace }}
+    environment: snyk-msbuild-envs
     steps:
     - uses: actions/checkout@v2
     - uses: microsoft/variable-substitution@v1 

--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -15,6 +15,11 @@ jobs:
     environment: snyk-msbuild-envs
     steps:
     - uses: actions/checkout@v2
+    - name: Check if secrets exist
+      env: 
+        Secret: ${{ secrets.SNYK_CODE_API_ENDPOINT_URL }}
+      if: ${{ env.Secret == '' }}
+      run: echo "MISSING SECRET"
     - uses: microsoft/variable-substitution@v1 
       with:
         files: '.\Snyk.Common\appsettings.json'

--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -1,0 +1,61 @@
+name: Build Project
+
+on:
+  workflow_call:
+    inputs:
+      solution-file-path:
+        required: true
+        type: string
+    secrets:
+      SEGMENT_ANALYTICS_WRITE_KEY:
+        required: true
+      SNYK_CODE_API_ENDPOINT_URL:
+        required: true
+      SENTRY_DSN:
+        required: true
+      SENTRY_ENVIRONMENT:
+        required: true
+jobs:
+  build:
+    runs-on: windows-2022
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: microsoft/variable-substitution@v1 
+      with:
+        files: '.\Snyk.Common\appsettings.json'
+      env:
+        SegmentAnalyticsWriteKey: ${{ secrets.SEGMENT_ANALYTICS_WRITE_KEY }}
+        SnykCodeApiEndpointUrl: ${{ secrets.SNYK_CODE_API_ENDPOINT_URL }}
+        SentryDsn: ${{ secrets.SENTRY_DSN }}
+        Environment: ${{ secrets.SENTRY_ENVIRONMENT }}
+
+    - uses: actions/cache@v2
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.config') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1
+      with:
+        vs-version: '[17.0, )'
+
+    - name: Restore NuGet packages
+      run: nuget restore ${{ inputs.solution-file-path }}
+
+    - name: Build
+      run: |
+        msbuild ${{ inputs.solution-file-path }} /p:configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /v:m
+      shell: powershell
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-artifacts
+        path: |
+          **/bin
+          **/obj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           solution-file-path: ${{ env.SOLUTION_FILE_PATH }}
   test:
+    needs: build-project
     name: Run Unit-Tests
     runs-on: windows-2022
     defaults:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Pull Request Workflow
 
 on:
   push:
@@ -12,6 +12,7 @@ env:
 jobs:
   build-project:
     uses: snyk/snyk-visual-studio-plugin/.github/workflows/build-project.yml@fix/release-flow
+
     with:
       solution-file-path: .
     secrets: inherit
@@ -33,5 +34,8 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: build-artifacts
+
+    - name: Setup VSTest
+      uses: darenm/Setup-VSTest@v1
     - name: Tests
       run: vstest.console.exe **\*.Tests.dll /TestCaseFilter:"FullyQualifiedName!=Xunit.Instances.VisualStudio&integration!=true" #exclude integration tests and the psuedo-tests that launch a VS instance

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,8 @@ jobs:
   build-project:
     uses: snyk/snyk-visual-studio-plugin/.github/workflows/build-project.yml@fix/release-flow
     with:
-      solution-file-path: ${{ env.SOLUTION_FILE_PATH }}
+      solution-file-path: .
+    secrets: inherit
   test:
     needs: build-project
     name: Run Unit-Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,9 @@ env:
 
 jobs:
   build-project:
-    runs-on: windows-2022
-    environment: snyk-msbuild-envs
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: ./.github/workflows/build-project.yml@fix/release-flow
-        with:
-          solution-file-path: ${{ env.SOLUTION_FILE_PATH }}
+    uses: snyk/snyk-visual-studio-plugin/.github/workflows/build-project.yml@fix/release-flow
+    with:
+      solution-file-path: ${{ env.SOLUTION_FILE_PATH }}
   test:
     needs: build-project
     name: Run Unit-Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,15 @@ env:
   DEFAULT_BRANCH: main
 
 jobs:
-  build:
+  build-project:
+    runs-on: windows-2022
+    environment: snyk-msbuild-envs
+    steps:
+      - uses: ./.github/workflows/build-project.yml@fix/release-flow
+        with:
+          solution-file-path: ${{ env.SOLUTION_FILE_PATH }}
+  test:
+    name: Run Unit-Tests
     runs-on: windows-2022
     defaults:
       run:
@@ -22,31 +30,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-
-    - uses: microsoft/variable-substitution@v1 
+    - name: Download build artifacts
+      uses: actions/download-artifact@v2
       with:
-        files: '.\Snyk.Common\appsettings.json'
-      env:
-        SegmentAnalyticsWriteKey: ${{ secrets.SEGMENT_ANALYTICS_WRITE_KEY }}
-        SnykCodeApiEndpointUrl: ${{ secrets.SNYK_CODE_API_ENDPOINT_URL }}
-        SentryDsn: ${{ secrets.SENTRY_DSN }}
-        Environment: ${{ secrets.SENTRY_ENVIRONMENT }}
-
-    - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1
-      with:
-        vs-version: '[17.0, ]'
-
-    - name: Setup VSTest
-      uses: darenm/Setup-VSTest@v1
-
-    - name: Restore NuGet packages
-      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
-
-    - name: Build
-      run: |
-        msbuild ${{env.SOLUTION_FILE_PATH}} /p:configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /v:m
-      shell: powershell
-
+        name: build-artifacts
     - name: Tests
       run: vstest.console.exe **\*.Tests.dll /TestCaseFilter:"FullyQualifiedName!=Xunit.Instances.VisualStudio&integration!=true" #exclude integration tests and the psuedo-tests that launch a VS instance

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: windows-2022
     environment: snyk-msbuild-envs
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: ./.github/workflows/build-project.yml@fix/release-flow
         with:
           solution-file-path: ${{ env.SOLUTION_FILE_PATH }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,84 @@
+name: test-changes
+
+on:
+  push:
+    branches:
+      - 'fix/release-flow'
+
+jobs:
+  build:
+    runs-on: windows-2022
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - uses: actions/cache@v2
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.config') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1
+      with:
+        vs-version: '[17.0, )'
+
+    - name: Restore NuGet packages
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      run: |
+        msbuild ${{env.SOLUTION_FILE_PATH}} /p:configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /v:m
+      shell: powershell
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-artifacts
+        path: |
+          **/*.dll
+          **/*.pdb
+  test-vs19:
+    needs: build
+    runs-on: windows-2019
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: build-artifacts
+
+    - name: Setup VSTest
+      uses: darenm/Setup-VSTest@v1
+
+    - name: Tests
+      run: vstest.console.exe **\*.Tests.dll
+
+  test-vs22:
+    needs: build
+    runs-on: windows-2022
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: build-artifacts
+
+    - name: Setup VSTest
+      uses: darenm/Setup-VSTest@v1
+
+    - name: Tests
+      run: vstest.console.exe **\*.Tests.dll

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,56 +2,12 @@ name: Integration Tests
 
 on:
   workflow_call:
-  workflow_dispatch:
+    secrets:
+      TEST_API_TOKEN:
+        required: true
 
 jobs:
-  build:
-    runs-on: windows-2022
-    defaults:
-      run:
-        working-directory: ${{ github.workspace }}
-    env:
-      TEST_API_TOKEN: ${{ secrets.TEST_API_TOKEN }}
-    steps:
-    - uses: actions/checkout@v2
-    - uses: microsoft/variable-substitution@v1 
-      with:
-        files: '.\Snyk.Common\appsettings.json'
-      env:
-        SegmentAnalyticsWriteKey: ${{ secrets.SEGMENT_ANALYTICS_WRITE_KEY }}
-        SnykCodeApiEndpointUrl: ${{ secrets.SNYK_CODE_API_ENDPOINT_URL }}
-        SentryDsn: ${{ secrets.SENTRY_DSN }}
-        Environment: ${{ secrets.SENTRY_ENVIRONMENT }}
-
-    - uses: actions/cache@v2
-      with:
-        path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.config') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-
-    - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1
-      with:
-        vs-version: '[17.0, )'
-
-    - name: Restore NuGet packages
-      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
-
-    - name: Build
-      run: |
-        msbuild ${{env.SOLUTION_FILE_PATH}} /p:configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /v:m
-      shell: powershell
-
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: build-artifacts
-        path: |
-          **/bin
-          **/obj
   test-vs19:
-    needs: build
     runs-on: windows-2019
     defaults:
       run:
@@ -72,7 +28,6 @@ jobs:
       run: vstest.console.exe **\bin\**\*Integration.Pre22.Tests.dll
 
   test-vs22:
-    needs: build
     runs-on: windows-2022
     defaults:
       run:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,4 @@
-name: test-changes
+name: Integration Tests
 
 on:
   push:
@@ -41,8 +41,8 @@ jobs:
       with:
         name: build-artifacts
         path: |
-          **/*.dll
-          **/*.pdb
+          **/bin
+          **/obj
   test-vs19:
     needs: build
     runs-on: windows-2019

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,10 +20,8 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: build-artifacts
-
     - name: Setup VSTest
       uses: darenm/Setup-VSTest@v1
-
     - name: Tests
       run: vstest.console.exe **\bin\**\*Integration.Pre22.Tests.dll
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,9 +1,8 @@
 name: Integration Tests
 
 on:
-  push:
-    branches:
-      - 'fix/release-flow'
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -15,9 +14,6 @@ jobs:
       TEST_API_TOKEN: ${{ secrets.TEST_API_TOKEN }}
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        
     - uses: microsoft/variable-substitution@v1 
       with:
         files: '.\Snyk.Common\appsettings.json'
@@ -64,7 +60,6 @@ jobs:
       TEST_API_TOKEN: ${{ secrets.TEST_API_TOKEN }}
     steps:
     - uses: actions/checkout@v2
-
     - name: Download build artifacts
       uses: actions/download-artifact@v2
       with:
@@ -86,14 +81,11 @@ jobs:
       TEST_API_TOKEN: ${{ secrets.TEST_API_TOKEN }}
     steps:
     - uses: actions/checkout@v2
-
     - name: Download build artifacts
       uses: actions/download-artifact@v2
       with:
         name: build-artifacts
-
     - name: Setup VSTest
       uses: darenm/Setup-VSTest@v1
-
     - name: Tests
       run: vstest.console.exe **\bin\**\*Integration.Tests.dll

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,6 +11,8 @@ jobs:
     defaults:
       run:
         working-directory: ${{ github.workspace }}
+    env:
+      TEST_API_TOKEN: ${{ secrets.TEST_API_TOKEN }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -58,6 +60,8 @@ jobs:
     defaults:
       run:
         working-directory: ${{ github.workspace }}
+    env:
+      TEST_API_TOKEN: ${{ secrets.TEST_API_TOKEN }}
     steps:
     - uses: actions/checkout@v2
 
@@ -70,7 +74,7 @@ jobs:
       uses: darenm/Setup-VSTest@v1
 
     - name: Tests
-      run: vstest.console.exe **\bin\**\*.Tests.dll
+      run: vstest.console.exe **\bin\**\*Integration.Tests.dll
 
   test-vs22:
     needs: build
@@ -78,6 +82,8 @@ jobs:
     defaults:
       run:
         working-directory: ${{ github.workspace }}
+    env:
+      TEST_API_TOKEN: ${{ secrets.TEST_API_TOKEN }}
     steps:
     - uses: actions/checkout@v2
 
@@ -90,4 +96,4 @@ jobs:
       uses: darenm/Setup-VSTest@v1
 
     - name: Tests
-      run: vstest.console.exe **\bin\**\*.Tests.dll
+      run: vstest.console.exe **\bin\**\*Integration.Tests.dll

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,6 +15,15 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        
+    - uses: microsoft/variable-substitution@v1 
+      with:
+        files: '.\Snyk.Common\appsettings.json'
+      env:
+        SegmentAnalyticsWriteKey: ${{ secrets.SEGMENT_ANALYTICS_WRITE_KEY }}
+        SnykCodeApiEndpointUrl: ${{ secrets.SNYK_CODE_API_ENDPOINT_URL }}
+        SentryDsn: ${{ secrets.SENTRY_DSN }}
+        Environment: ${{ secrets.SENTRY_ENVIRONMENT }}
 
     - uses: actions/cache@v2
       with:
@@ -61,7 +70,7 @@ jobs:
       uses: darenm/Setup-VSTest@v1
 
     - name: Tests
-      run: vstest.console.exe **\*.Tests.dll
+      run: vstest.console.exe **\bin\**\*.Tests.dll
 
   test-vs22:
     needs: build
@@ -81,4 +90,4 @@ jobs:
       uses: darenm/Setup-VSTest@v1
 
     - name: Tests
-      run: vstest.console.exe **\*.Tests.dll
+      run: vstest.console.exe **\bin\**\*.Tests.dll

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -74,7 +74,7 @@ jobs:
       uses: darenm/Setup-VSTest@v1
 
     - name: Tests
-      run: vstest.console.exe **\bin\**\*Integration.Tests.dll
+      run: vstest.console.exe **\bin\**\*Integration.Pre22.Tests.dll
 
   test-vs22:
     needs: build

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -1,8 +1,6 @@
 name: Pull Request Workflow
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
 
 env:
@@ -12,7 +10,6 @@ env:
 jobs:
   build-project:
     uses: snyk/snyk-visual-studio-plugin/.github/workflows/build-project.yml@fix/release-flow
-
     with:
       solution-file-path: .
     secrets: inherit

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build-project:
-    uses: snyk/snyk-visual-studio-plugin/.github/workflows/build-project.yml@fix/release-flow
+    uses: snyk/snyk-visual-studio-plugin/.github/workflows/build-project.yml@main
     with:
       solution-file-path: .
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,89 +11,26 @@ env:
   DEFAULT_BRANCH: main
 
 jobs:
-  build-and-test-vs19:
-    runs-on: windows-2019
-    defaults:
-      run:
-        working-directory: ${{ github.workspace }}
-    environment: snyk-msbuild-envs
-    env:
-      TEST_API_TOKEN: ${{ secrets.TEST_API_TOKEN }}
-      VsixManifestPath: .\Snyk.VisualStudio.Extension\source.extension.vsixmanifest
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - uses: actions/cache@v2
-      with:
-        path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.config') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-
-    - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1
-      with:
-        vs-version: '[16.0, 17.0)'
-
-    - name: Setup VSTest
-      uses: darenm/Setup-VSTest@v1
-
-    - name: Restore NuGet packages
-      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
-    
-    - name: Build
-      run: |
-        msbuild ${{env.SOLUTION_FILE_PATH}} /p:configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /v:m
-      shell: powershell
-
-    - name: Tests
-      run: vstest.console.exe **\*.Tests.dll
-
-  build-test-and-release-vs22:
-    needs: build-and-test-vs19
+  run-integration-tests:
+    uses: ./.github/workflows/integration-tests.yml
+  release:
+    needs: run-integration-tests
     runs-on: windows-2022
     defaults:
       run:
         working-directory: ${{ github.workspace }}
     environment: snyk-msbuild-envs
     env:
-      TEST_API_TOKEN: ${{ secrets.TEST_API_TOKEN }}
       VsixManifestPath: .\Snyk.VisualStudio.Extension\source.extension.vsixmanifest
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-
-    - uses: actions/cache@v2
+    - name: Download build artifacts
+      uses: actions/download-artifact@v2
       with:
-        path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.config') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-
-    - uses: microsoft/variable-substitution@v1
-      with:
-        files: '.\Snyk.Common\appsettings.json'
-      env:
-        SegmentAnalyticsWriteKey: ${{ secrets.SEGMENT_ANALYTICS_WRITE_KEY }}
-        SnykCodeApiEndpointUrl: ${{ secrets.SNYK_CODE_API_ENDPOINT_URL }}
-        SentryDsn: ${{ secrets.SENTRY_DSN }}
-        Environment: ${{ secrets.SENTRY_ENVIRONMENT }}
-
-    - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1
-      with:
-        vs-version: '[17.0, )'
-
-    - name: Setup VSTest
-      uses: darenm/Setup-VSTest@v1
-
-    - name: Restore NuGet packages
-      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+        name: build-artifacts
 
     - name: Calculate next semantic version Git tag (vsix version)
       id: vsix_version
@@ -110,14 +47,6 @@ jobs:
       with:
         version: ${{ steps.vsix_version.outputs.next-tag }}
         vsix-manifest-file: .\Snyk.VisualStudio.Extension.2022\source.extension.vsixmanifest
-
-    - name: Build
-      run: |
-        msbuild ${{env.SOLUTION_FILE_PATH}} /p:configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /v:m
-      shell: powershell
-
-    - name: Tests
-      run: vstest.console.exe **\*.Tests.dll
 
     - name: Set up Git actions user
       uses: fregante/setup-git-user@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,10 @@ env:
 
 jobs:
   build-project:
-    runs-on: windows-2022
-    environment: snyk-msbuild-envs
-    steps:
-      - uses: ./.github/workflows/build-project.yml@main
-        with:
-          solution-file-path: ${{ env.SOLUTION_FILE_PATH }}
+    uses: snyk/snyk-visual-studio-plugin/.github/workflows/build-project.yml@main
+    with:
+      solution-file-path: .
+    secrets: inherit
   run-integration-tests:
     needs: build-project
     uses: ./.github/workflows/integration-tests.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: release
 
 on:
-  push:
-    tags:
-    - 'v*'
   workflow_dispatch:
 
 env:
@@ -11,8 +8,17 @@ env:
   DEFAULT_BRANCH: main
 
 jobs:
+  build-project:
+    runs-on: windows-2022
+    environment: snyk-msbuild-envs
+    steps:
+      - uses: ./.github/workflows/build-project.yml@main
+        with:
+          solution-file-path: ${{ env.SOLUTION_FILE_PATH }}
   run-integration-tests:
-    uses: ./.github/workflows/integration-tests.yml
+    needs: build-project
+    uses: ./.github/workflows/integration-tests.yml@main
+    secrets: inherit
   release:
     needs: run-integration-tests
     runs-on: windows-2022

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -95,7 +95,7 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.4.2120">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.5.4074">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Tests/Integration.Pre22.Tests/Integration.Pre22.Tests.csproj
+++ b/Tests/Integration.Pre22.Tests/Integration.Pre22.Tests.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy">
-      <Version>0.1.169-beta</Version>
+      <Version>0.1.137-beta</Version>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable">
       <Version>1.1.36</Version>

--- a/Tests/Integration.Pre22.Tests/Integration.Pre22.Tests.csproj
+++ b/Tests/Integration.Pre22.Tests/Integration.Pre22.Tests.csproj
@@ -51,7 +51,12 @@
       <Version>1.1.36</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.utility">
-      <Version>2.4.1</Version>
+      <Version>2.4.2</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <Version>2.4.5</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Integration.Tests/Integration.Tests.csproj
+++ b/Tests/Integration.Tests/Integration.Tests.csproj
@@ -48,10 +48,15 @@
       <Version>0.1.137-beta</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0">
-      <Version>17.2.32505.113</Version>
+      <Version>17.5.33428.388</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.utility">
-      <Version>2.4.1</Version>
+      <Version>2.4.2</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <Version>2.4.5</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Integration.Tests/Integration.Tests.csproj
+++ b/Tests/Integration.Tests/Integration.Tests.csproj
@@ -48,7 +48,7 @@
       <Version>0.1.137-beta</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0">
-      <Version>17.5.33428.388</Version>
+      <Version>17.2.32505.113</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.utility">
       <Version>2.4.2</Version>

--- a/Tests/Integration.Tests/Integration.Tests.csproj
+++ b/Tests/Integration.Tests/Integration.Tests.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Extensibility.Testing.Xunit">
-      <Version>0.1.169-beta</Version>
+      <Version>0.1.137-beta</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0">
       <Version>17.2.32505.113</Version>

--- a/Tests/Integration.Tests/Integration.Tests.csproj
+++ b/Tests/Integration.Tests/Integration.Tests.csproj
@@ -45,10 +45,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Extensibility.Testing.Xunit">
-      <Version>0.1.137-beta</Version>
+      <Version>0.1.169-beta</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0">
-      <Version>17.2.32505.113</Version>
+    <PackageReference Include="Microsoft.VisualStudio.SDK">
+      <Version>17.0.32112.339</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.utility">
       <Version>2.4.2</Version>


### PR DESCRIPTION
### Description

Fix the release workflow. Build on VS22 and run on VS19.

This change:
- Renames "build.yml" to "pr-workflow.yml"
- Added a "build-project.yml" reusable workflow
- Added a check that verifies that the secrets are accessible in the build step
- Added an "integration-tests.yml" reusable workflow
- Modified both the pr-workflow and the release workflow to use the reusable workflows