### PR TITLE
[HEAD-331] fix: markdown rendering of code blocks in OSS description

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -90,8 +90,8 @@
     <PackageReference Include="Community.VisualStudio.Toolkit.17">
       <Version>17.0.394</Version>
     </PackageReference>
-    <PackageReference Include="MarkdownSharp">
-      <Version>2.0.5</Version>
+    <PackageReference Include="MdXaml">
+      <Version>1.19.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/DescriptionPanel.xaml.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/DescriptionPanel.xaml.cs
@@ -41,10 +41,5 @@
             this.descriptionHeaderPanel.Suggestion = value;
             await this.snykCodeDescriptionControl.SetSuggestionAsync(value);
         }
-
-        /// <summary>
-        /// Adapt components for VS theme change.
-        /// </summary>
-        public void AdaptComponentsForThemeChange() => this.ossDescriptionControl.AdaptComponentsForThemeChange();
     }
 }

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/OssDescriptionControl.xaml
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/OssDescriptionControl.xaml
@@ -6,6 +6,7 @@
              xmlns:html="clr-namespace:Snyk.VisualStudio.Extension.Shared.UI"
              xmlns:c="clr-namespace:Snyk.VisualStudio.Extension.Shared.UI.Controls"
              xmlns:toolkit="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
+             xmlns:mdXaml="clr-namespace:MdXaml;assembly=MdXaml"
              toolkit:Themes.UseVsTheme="True"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
@@ -49,11 +50,12 @@
         <c:TextField Grid.Row="7" Grid.Column="0" Text="Fixed in:" FontWeight="Bold" FontSize="12" Margin="5, 5, 5, 5"/>
         <c:TextField Grid.Row="7" Grid.Column="1" x:Name="fixedIn" Text="" FontSize="12" Margin="5, 5, 5, 5" TextWrapping="Wrap"/>
 
-        <html:HtmlRichTextBox Grid.Row="8" Grid.ColumnSpan="2" x:Name="overview" IsDocumentEnabled="True" 
-                                        IsReadOnly="True"
-                                        BorderThickness="0, 0, 0, 0"                                        
-                                        Background="{DynamicResource VsBrush.Window}" 
-                                        HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" Margin="0,25,0,0"/>
+        <mdXaml:MarkdownScrollViewer  x:Name="Overview" MarkdownStyle="{x:Static mdXaml:MarkdownStyle.Sasabune}"
+                                      Grid.Row="8" Grid.ColumnSpan="2" Grid.Column="0" 
+                                      HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Disabled"
+                                      ClickAction="OpenBrowser"
+                                      BorderThickness="1"
+                                      HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" Margin="0,25,0,0"/>
 
         <TextBlock Grid.Row="9" Grid.Column="0" FontSize="12" Margin="5, 20, 5, 5" TextWrapping="Wrap" MaxWidth="1000">
             <Hyperlink Name="moreAboutThisIssue" RequestNavigate="MoreAboutThisIssue_RequestNavigate">More about this issue</Hyperlink >

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/OssDescriptionControl.xaml.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/OssDescriptionControl.xaml.cs
@@ -2,8 +2,14 @@
 {
     using System;
     using System.Diagnostics;
+    using System.Linq;
     using System.Windows;
     using System.Windows.Controls;
+    using System.Windows.Documents;
+    using System.Windows.Input;
+    using MdXaml;
+    using Serilog;
+    using Snyk.Common;
     using Snyk.VisualStudio.Extension.Shared.CLI;
 
     /// <summary>
@@ -11,6 +17,7 @@
     /// </summary>
     public partial class OssDescriptionControl : UserControl
     {
+        private static readonly ILogger Logger = LogManager.ForContext<OssDescriptionControl>();
         /// <summary>
         /// Initializes a new instance of the <see cref="OssDescriptionControl"/> class.
         /// </summary>
@@ -45,18 +52,10 @@
                 this.fix.Text = vulnerability.FixedIn != null && vulnerability.FixedIn.Length != 0
                                          ? "Upgrade to " + string.Join(" > ", vulnerability.FixedIn) : string.Empty;
 
-                this.overview.Html = new MarkdownSharp.Markdown().Transform(vulnerability.Description);
+                this.Overview.Markdown = vulnerability.Description;
 
                 this.moreAboutThisIssue.NavigateUri = new Uri(vulnerability.Url);
             }
-        }
-
-        /// <summary>
-        /// Adapt components for VS theme change.
-        /// </summary>
-        public void AdaptComponentsForThemeChange()
-        {
-            this.overview.AdaptForeground();
         }
 
         private void MoreAboutThisIssue_RequestNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs args)

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindowControl.xaml.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindowControl.xaml.cs
@@ -109,8 +109,6 @@
 
             this.Loaded += (sender, args) => tasksService.Download();
 
-            serviceProvider.VsThemeService.ThemeChanged += this.OnVsThemeChanged;
-
             serviceProvider.Options.SettingsChanged += this.OnSettingsChanged;
 
             SnykScanCommand.Instance.UpdateControlsStateCallback = (isEnabled) => ThreadHelper.JoinableTaskFactory.Run(async () =>
@@ -346,13 +344,6 @@
                 "Failed to download Snyk CLI. You can specify a path to a Snyk CLI executable from the settings.";
             }
         }
-
-        /// <summary>
-        /// VsThemeChanged event handler. Call Adapt methods for <see cref="HtmlRichTextBox"/> controls.
-        /// </summary>
-        /// <param name="sender">Source object.</param>
-        /// <param name="eventArgs">Event args.</param>
-        public void OnVsThemeChanged(object sender, SnykVsThemeChangedEventArgs eventArgs) => this.descriptionPanel.AdaptComponentsForThemeChange();
 
         /// <summary>
         /// Show tool window.

--- a/Snyk.VisualStudio.Extension/Snyk.VisualStudio.Extension.csproj
+++ b/Snyk.VisualStudio.Extension/Snyk.VisualStudio.Extension.csproj
@@ -94,8 +94,8 @@
     <PackageReference Include="Community.VisualStudio.Toolkit.14">
       <Version>14.0.355</Version>
     </PackageReference>
-    <PackageReference Include="MarkdownSharp">
-      <Version>2.0.5</Version>
+    <PackageReference Include="MdXaml">
+      <Version>1.19.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.14.0">
       <Version>14.3.25407</Version>


### PR DESCRIPTION
### Description
Fixed markdown rendering of code blocks in the OSS description panel)

### Checklist
- [ ] CHANGELOG.md updated

### Screenshots / GIFs
![image](https://github.com/snyk/snyk-visual-studio-plugin/assets/35231408/c6821279-390d-4044-871b-997a4e021d77)
