### PR TITLE
Only send Amplitude analytics events when connected to an MT US environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Snyk Changelog
 
+## [1.1.46]
+- Only send Amplitude analytics events when connected to an MT US environment
+
 ## [1.1.45]
 
 ### Changed

--- a/Snyk.Common/Settings/ISnykOptions.cs
+++ b/Snyk.Common/Settings/ISnykOptions.cs
@@ -24,6 +24,8 @@
 
         bool IsFedramp();
 
+        bool IsAnalyticsPermitted();
+
         /// <summary>
         /// Gets or sets a value indicating whether CLI custom endpoint parameter.
         /// </summary>

--- a/Snyk.VisualStudio.Extension.Shared/CLI/SnykConsoleRunner.cs
+++ b/Snyk.VisualStudio.Extension.Shared/CLI/SnykConsoleRunner.cs
@@ -78,7 +78,7 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
                 }
             }
 
-            if (!this.options.UsageAnalyticsEnabled || this.options.IsFedramp())
+            if (!this.options.UsageAnalyticsEnabled || !this.options.IsAnalyticsPermitted())
             {
                 processStartInfo.EnvironmentVariables["SNYK_CFG_DISABLE_ANALYTICS"] = "1";
             }

--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykService.cs
@@ -319,7 +319,7 @@
 
             string anonymousId = this.Options.AnonymousId;
 
-            var enabled = this.Options.UsageAnalyticsEnabled && !this.Options.IsFedramp();
+            var enabled = this.Options.UsageAnalyticsEnabled && this.Options.IsAnalyticsPermitted();
             var endpoint = this.ApiEndpointResolver.UserMeEndpoint;
 
             Logger.Information("analytics enabled = {Enabled}, endpoint = {Endpoint}", enabled, endpoint);

--- a/Snyk.VisualStudio.Extension.Shared/Settings/SnykGeneralOptionsDialogPage.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Settings/SnykGeneralOptionsDialogPage.cs
@@ -401,11 +401,11 @@
             var endpoint = this.customEndpoint.IsNullOrEmpty() ? "https://app.snyk.io" : this.customEndpoint.RemoveTrailingSlashes();
             Uri uri = new Uri(endpoint);
 
-            if (!uri.Host.StartsWith("app") && uri.Host.EndsWith("snyk.io"))
+            if (!uri.Host.StartsWith("app") && (uri.Host.EndsWith("snyk.io") || uri.Host.EndsWith("snykgov.io")))
             {
                 return endpoint.Replace("https://", "https://app.").RemoveFromEnd("api");
             }
-            else if (uri.Host.StartsWith("app") && uri.Host.EndsWith("snyk.io"))
+            else if (uri.Host.StartsWith("app") && (uri.Host.EndsWith("snyk.io") || uri.Host.EndsWith("snykgov.io")))
             {
                 return endpoint.RemoveFromEnd("api");
             }

--- a/Snyk.VisualStudio.Extension.Shared/Settings/SnykGeneralOptionsDialogPage.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Settings/SnykGeneralOptionsDialogPage.cs
@@ -118,7 +118,7 @@
         /// <returns></returns>
         public bool IsAnalyticsPermitted()
         {
-            var endpointUri = new Uri(this.GetAppCustomEndpoint());
+            var endpointUri = new Uri(this.GetBaseAppURL());
 
             string[] permittedHosts = ["app.snyk.io", "app.us.snyk.io"];
             return permittedHosts.Contains(endpointUri.Host.ToLower());
@@ -154,7 +154,7 @@
         }
 
         /// <inheritdoc/>
-        public string SnykCodeSettingsUrl => $"{this.GetAppCustomEndpoint()}/manage/snyk-code";
+        public string SnykCodeSettingsUrl => $"{this.GetBaseAppURL()}/manage/snyk-code";
 
         public SastSettings SastSettings
         {
@@ -396,22 +396,22 @@
 
         private void FireSettingsChangedEvent() => this.SettingsChanged?.Invoke(this, new SnykSettingsChangedEventArgs());
 
-        private string GetAppCustomEndpoint()
+        private string GetBaseAppURL()
         {
             var endpoint = this.customEndpoint.IsNullOrEmpty() ? "https://app.snyk.io" : this.customEndpoint.RemoveTrailingSlashes();
             Uri uri = new Uri(endpoint);
 
             if (!uri.Host.StartsWith("app") && (uri.Host.EndsWith("snyk.io") || uri.Host.EndsWith("snykgov.io")))
             {
-                return endpoint.Replace("https://", "https://app.").RemoveFromEnd("api");
+                return endpoint.Replace("https://", "https://app.").RemoveFromEnd("/api");
             }
             else if (uri.Host.StartsWith("app") && (uri.Host.EndsWith("snyk.io") || uri.Host.EndsWith("snykgov.io")))
             {
-                return endpoint.RemoveFromEnd("api");
+                return endpoint.RemoveFromEnd("/api");
             }
             else
             {
-                return "https://app.snyk.io/";
+                return "https://app.snyk.io";
             }
         }
 

--- a/Snyk.VisualStudio.Extension.Shared/Settings/SnykGeneralOptionsDialogPage.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Settings/SnykGeneralOptionsDialogPage.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Linq;
     using System.Runtime.InteropServices;
     using System.Security.Authentication;
     using System.Threading.Tasks;
@@ -109,6 +110,18 @@
 
             var endpointUri = new Uri(endpoint);
             return endpointUri.Host.ToLower().EndsWith("snykgov.io");
+        }
+
+        /// <summary>
+        /// Checks if the current endpoint permits sending external analytics events
+        /// </summary>
+        /// <returns></returns>
+        public bool IsAnalyticsPermitted()
+        {
+            var endpointUri = new Uri(this.GetAppCustomEndpoint());
+
+            string[] permittedHosts = ["app.snyk.io", "app.us.snyk.io"];
+            return permittedHosts.Contains(endpointUri.Host.ToLower());
         }
 
         /// <summary>

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindowControl.xaml.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindowControl.xaml.cs
@@ -676,7 +676,7 @@
         {
             var options = this.serviceProvider.Options;
             this.serviceProvider.AnalyticsService.AnalyticsEnabledOption = 
-                options.UsageAnalyticsEnabled && !options.IsFedramp();
+                options.UsageAnalyticsEnabled && options.IsAnalyticsPermitted();
 
             if (options.ApiToken.IsValid())
             {

--- a/Snyk.VisualStudio.Extension.Tests/GeneralOptionsDialogPage.cs
+++ b/Snyk.VisualStudio.Extension.Tests/GeneralOptionsDialogPage.cs
@@ -1,5 +1,7 @@
 ﻿namespace Snyk.VisualStudio.Extension.Tests
 {
+    using System.Collections.Generic;
+    using System.Net;
     using Moq;
     using Snyk.VisualStudio.Extension.Shared.CLI;
     using Snyk.VisualStudio.Extension.Shared.Service;
@@ -61,6 +63,24 @@
                 optionsDialogPage.CustomEndpoint = endpoint;
                 Assert.False(optionsDialogPage.IsAnalyticsPermitted());
             }
+        }
+
+        [Theory]
+        [InlineData(null, "https://app.snyk.io/manage/snyk-code")]
+        [InlineData("", "https://app.snyk.io/manage/snyk-code")]
+        [InlineData("https://snyk.io", "https://app.snyk.io/manage/snyk-code")]
+        [InlineData("https://snyk.io/api", "https://app.snyk.io/manage/snyk-code")]
+        [InlineData("https://snyk.io/api/", "https://app.snyk.io/manage/snyk-code")]
+        [InlineData("https://snykgov.io/api", "https://app.snykgov.io/manage/snyk-code")]
+        [InlineData("https://app.snyk.io/api", "https://app.snyk.io/manage/snyk-code")]
+        [InlineData("https://app.eu.snyk.io/api", "https://app.eu.snyk.io/manage/snyk-code")]
+        [InlineData("https://app.snykgov.io/api", "https://app.snykgov.io/manage/snyk-code")]
+        [InlineData("https://example.org", "https://app.snyk.io/manage/snyk-code")]
+        public void SnykCodeSettingsUrl(string endpoint, string expected)
+        {
+            var optionsDialogPage = new SnykGeneralOptionsDialogPage();
+            optionsDialogPage.CustomEndpoint = endpoint;
+            Assert.Equal(expected, optionsDialogPage.SnykCodeSettingsUrl);
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/GeneralOptionsDialogPage.cs
+++ b/Snyk.VisualStudio.Extension.Tests/GeneralOptionsDialogPage.cs
@@ -26,5 +26,41 @@
             // Assert
             cliMock.Verify(mock => mock.UnsetApiToken());
         }
+
+        [Fact]
+        public void IsAnalyticsPermitted_True()
+        {
+            var optionsDialogPage = new SnykGeneralOptionsDialogPage();
+
+            string[] endpoints = {
+                "https://app.snyk.io/api",
+                "https://snyk.io/api",
+                "https://app.us.snyk.io/api",
+            };
+
+            foreach (var endpoint in endpoints)
+            {
+                optionsDialogPage.CustomEndpoint = endpoint;
+                Assert.True(optionsDialogPage.IsAnalyticsPermitted());
+            }
+        }
+
+        [Fact]
+        public void IsAnalyticsPermitted_False()
+        {
+            var optionsDialogPage = new SnykGeneralOptionsDialogPage();
+
+            string[] endpoints = {
+                "https://app.eu.snyk.io/api",
+                "https://app.au.snyk.io/api",
+                "https://app.snykgov.io/api",
+            };
+
+            foreach (var endpoint in endpoints)
+            {
+                optionsDialogPage.CustomEndpoint = endpoint;
+                Assert.False(optionsDialogPage.IsAnalyticsPermitted());
+            }
+        }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/GeneralOptionsDialogPage.cs
+++ b/Snyk.VisualStudio.Extension.Tests/GeneralOptionsDialogPage.cs
@@ -29,40 +29,18 @@
             cliMock.Verify(mock => mock.UnsetApiToken());
         }
 
-        [Fact]
-        public void IsAnalyticsPermitted_True()
+        [Theory]
+        [InlineData("https://app.snyk.io/api", true)]
+        [InlineData("https://snyk.io/api", true)]
+        [InlineData("https://app.us.snyk.io/api", true)]
+        [InlineData("https://app.eu.snyk.io/api", false)]
+        [InlineData("https://app.au.snyk.io/api", false)]
+        [InlineData("https://app.snykgov.io/api", false)]
+        public void IsAnalyticsPermitted(string endpoint, bool expected)
         {
             var optionsDialogPage = new SnykGeneralOptionsDialogPage();
-
-            string[] endpoints = {
-                "https://app.snyk.io/api",
-                "https://snyk.io/api",
-                "https://app.us.snyk.io/api",
-            };
-
-            foreach (var endpoint in endpoints)
-            {
-                optionsDialogPage.CustomEndpoint = endpoint;
-                Assert.True(optionsDialogPage.IsAnalyticsPermitted());
-            }
-        }
-
-        [Fact]
-        public void IsAnalyticsPermitted_False()
-        {
-            var optionsDialogPage = new SnykGeneralOptionsDialogPage();
-
-            string[] endpoints = {
-                "https://app.eu.snyk.io/api",
-                "https://app.au.snyk.io/api",
-                "https://app.snykgov.io/api",
-            };
-
-            foreach (var endpoint in endpoints)
-            {
-                optionsDialogPage.CustomEndpoint = endpoint;
-                Assert.False(optionsDialogPage.IsAnalyticsPermitted());
-            }
+            optionsDialogPage.CustomEndpoint = endpoint;
+            Assert.Equal(expected, optionsDialogPage.IsAnalyticsPermitted());
         }
 
         [Theory]

--- a/Snyk.VisualStudio.Extension.Tests/SnykCliTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/SnykCliTest.cs
@@ -28,6 +28,10 @@
                 .Returns(false);
 
             this.optionsMock
+                .Setup(options => options.IsAnalyticsPermitted())
+                .Returns(true);
+
+            this.optionsMock
                 .Setup(options => options.ApiToken)
                 .Returns(AuthenticationToken.EmptyToken);
         }

--- a/Snyk.VisualStudio.Extension.Tests/SnykConsoleRunnerTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/SnykConsoleRunnerTest.cs
@@ -12,7 +12,7 @@ namespace Snyk.VisualStudio.Extension.Shared.Tests
     {
 
         [Fact]
-        public void SnykConsoleRunnerTest_CreateProcess_Respects_Analytics_Off_IsFedramp()
+        public void SnykConsoleRunnerTest_CreateProcess_Respects_Analytics_Off_IsAnalyticsNotPermitted()
         {
             var optionsMock = new Mock<ISnykOptions>();
             optionsMock
@@ -20,26 +20,7 @@ namespace Snyk.VisualStudio.Extension.Shared.Tests
                 .Returns(false);
 
             optionsMock
-                .Setup(options => options.IsFedramp())
-                .Returns(true);
-
-            var cut = new SnykConsoleRunner(optionsMock.Object);
-
-            var process = cut.CreateProcess("snyk", "test");
-
-            Assert.Equal("1", process.StartInfo.EnvironmentVariables["SNYK_CFG_DISABLE_ANALYTICS"]);
-        }
-        
-        [Fact]
-        public void SnykConsoleRunnerTest_CreateProcess_Respects_Analytics_Off_IsNotFedramp()
-        {
-            var optionsMock = new Mock<ISnykOptions>();
-            optionsMock
-                .Setup(options => options.UsageAnalyticsEnabled)
-                .Returns(false);
-
-            optionsMock
-                .Setup(options => options.IsFedramp())
+                .Setup(options => options.IsAnalyticsPermitted())
                 .Returns(false);
 
             var cut = new SnykConsoleRunner(optionsMock.Object);
@@ -50,15 +31,15 @@ namespace Snyk.VisualStudio.Extension.Shared.Tests
         }
         
         [Fact]
-        public void SnykConsoleRunnerTest_CreateProcess_Respects_Analytics_On_IsFedramp()
+        public void SnykConsoleRunnerTest_CreateProcess_Respects_Analytics_Off_IsAnalyticsPermitted()
         {
             var optionsMock = new Mock<ISnykOptions>();
             optionsMock
                 .Setup(options => options.UsageAnalyticsEnabled)
-                .Returns(true);
+                .Returns(false);
 
             optionsMock
-                .Setup(options => options.IsFedramp())
+                .Setup(options => options.IsAnalyticsPermitted())
                 .Returns(true);
 
             var cut = new SnykConsoleRunner(optionsMock.Object);
@@ -67,9 +48,9 @@ namespace Snyk.VisualStudio.Extension.Shared.Tests
 
             Assert.Equal("1", process.StartInfo.EnvironmentVariables["SNYK_CFG_DISABLE_ANALYTICS"]);
         }
-        
+
         [Fact]
-        public void SnykConsoleRunnerTest_CreateProcess_Respects_Analytics_On_IsNotFedramp()
+        public void SnykConsoleRunnerTest_CreateProcess_Respects_Analytics_On_IsAnalyticsPermitted()
         {
             var optionsMock = new Mock<ISnykOptions>();
             optionsMock
@@ -77,14 +58,33 @@ namespace Snyk.VisualStudio.Extension.Shared.Tests
                 .Returns(true);
 
             optionsMock
-                .Setup(options => options.IsFedramp())
-                .Returns(false);
+                .Setup(options => options.IsAnalyticsPermitted())
+                .Returns(true);
 
             var cut = new SnykConsoleRunner(optionsMock.Object);
 
             var process = cut.CreateProcess("snyk", "test");
 
             Assert.Null(process.StartInfo.EnvironmentVariables["SNYK_CFG_DISABLE_ANALYTICS"]);
+        }
+
+        [Fact]
+        public void SnykConsoleRunnerTest_CreateProcess_Respects_Analytics_On_IsAnalyticsNotPermitted()
+        {
+            var optionsMock = new Mock<ISnykOptions>();
+            optionsMock
+                .Setup(options => options.UsageAnalyticsEnabled)
+                .Returns(true);
+
+            optionsMock
+                .Setup(options => options.IsAnalyticsPermitted())
+                .Returns(false);
+
+            var cut = new SnykConsoleRunner(optionsMock.Object);
+
+            var process = cut.CreateProcess("snyk", "test");
+
+            Assert.Equal("1", process.StartInfo.EnvironmentVariables["SNYK_CFG_DISABLE_ANALYTICS"]);
         }
     }
 }


### PR DESCRIPTION
### Description

Disables sending analytics events to Amplitude when connected to a non-US MT or FedRAMP environment.

Co-authored-by: Knut <knut.funkel@snyk.io>

https://snyksec.atlassian.net/browse/IDE-24

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] ~~README.md updated, if user-facing~~