### PR TITLE
fix: upgrading package version on Newtonsoft IDE-218

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Security Changelog
 
+## [1.1.48]
+
+### Fixed
+- Upgraded the version of Newtonsoft dependency.
+
 ## [1.1.47]
 
 ### Fixed

--- a/Snyk.Code.Library/Snyk.Code.Library.csproj
+++ b/Snyk.Code.Library/Snyk.Code.Library.csproj
@@ -135,7 +135,7 @@
       <Version>15.8.122</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>6.0.1</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="SerilogAnalyzer">
       <Version>0.15.0</Version>

--- a/Snyk.Common/Snyk.Common.csproj
+++ b/Snyk.Common/Snyk.Common.csproj
@@ -102,7 +102,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>6.0.1</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="Sentry.Serilog">
       <Version>3.13.0</Version>


### PR DESCRIPTION
### Description

This patch Upgrade the version of the Newtonsoft dependency.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated


