### PR TITLE
fix: [IDE-219] send settings when firing scan events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Security Changelog
 
+## [1.1.51]
+
+### Fixed
+- Fixed a UI issue when toggling Code and Quality Scans in Settings page.
+
 ## [1.1.50]
 
 ### Fixed

--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykCodeScanEventArgs.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykCodeScanEventArgs.cs
@@ -33,6 +33,16 @@
         public bool OssScanRunning { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether Code scan is enabled.
+        /// </summary>
+        public bool CodeScanEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether Quality scan is enabled.
+        /// </summary>
+        public bool QualityScanEnabled { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether local code engine enabled.
         /// </summary>
         public bool LocalCodeEngineEnabled { get; set; }

--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykTasksService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykTasksService.cs
@@ -56,6 +56,11 @@
         public event EventHandler<SnykCliScanEventArgs> CliScanningStarted;
 
         /// <summary>
+        /// OSS Scanning Disabled event handler.
+        /// </summary>
+        public event EventHandler<SnykCliScanEventArgs> OssScanningDisabled;
+        
+        /// <summary>
         /// SnykCode scanning started event handler.
         /// </summary>
         public event EventHandler<SnykCodeScanEventArgs> SnykCodeScanningStarted;
@@ -489,6 +494,7 @@
             {
                 if (!featuresSettings.OssEnabled)
                 {
+                    FireOssScanningDisabledEvent();
                     return;
                 }
 
@@ -611,7 +617,7 @@
 
                 Logger.Information("Start scan task");
 
-                await Task.Run(() => this.RunSnykCodeScanAsync(progressWorker.TokenSource.Token));
+                await Task.Run(() => this.RunSnykCodeScanAsync(progressWorker.TokenSource.Token, featuresSettings));
             }
             catch (Exception ex)
             {
@@ -619,13 +625,13 @@
             }
         }
 
-        private async Task RunSnykCodeScanAsync(CancellationToken cancellationToken)
+        private async Task RunSnykCodeScanAsync(CancellationToken cancellationToken, FeaturesSettings featuresSettings)
         {
             try
             {
                 this.isSnykCodeScanning = true;
 
-                this.FireSnykCodeScanningStartedEvent();
+                this.FireSnykCodeScanningStartedEvent(featuresSettings);
 
                 var fileProvider = this.serviceProvider.SolutionService.FileProvider;
 
@@ -694,11 +700,20 @@
         /// </summary>
         private void FireOssScanningStartedEvent() => this.CliScanningStarted?.Invoke(this, new SnykCliScanEventArgs());
 
+
+        /// <summary>
+        /// Fire OSS scanning disabled event.
+        /// </summary>
+        private void FireOssScanningDisabledEvent() => this.OssScanningDisabled?.Invoke(this, new SnykCliScanEventArgs());
+
+
         /// <summary>
         /// Fire SnykCode scanning started event.
         /// </summary>
-        private void FireSnykCodeScanningStartedEvent() =>
-            this.SnykCodeScanningStarted?.Invoke(this, new SnykCodeScanEventArgs());
+        private void FireSnykCodeScanningStartedEvent(FeaturesSettings featuresSettings) =>
+            this.SnykCodeScanningStarted?.Invoke(this, 
+                new SnykCodeScanEventArgs { QualityScanEnabled = featuresSettings.CodeQualityEnabled, 
+                                            CodeScanEnabled = featuresSettings.CodeSecurityEnabled});
 
         /// <summary>
         /// Fire scanning update with <see cref="SnykCliScanEventArgs"/> object.


### PR DESCRIPTION
### Description

- Send User settings when Code or Quality Scanning Events are triggered to ensure correctly setting the TreeNode state.
- If a scan type is disabled, clear the TreeNode. 

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
