### PR TITLE
chore: fix warnings and resolve dependency conflicts [IDE-342]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 # Snyk Security Changelog
 
-## [1.1.48]
+## [1.1.50]
+
+### Fixed
+- Upgraded the version of the Analytics dependency.
+
+## [1.1.49]
 
 ### Fixed
 - Upgraded the version of Newtonsoft dependency.
 
-## [1.1.47]
+## [1.1.48]
 
 ### Fixed
 - shortened extension name to just Snyk Security
 
-## [1.1.46]
+## [1.1.47]
 - Only send Amplitude analytics events when connected to an MT US environment
 
 ## [1.1.45]

--- a/Snyk.Analytics/Snyk.Analytics.csproj
+++ b/Snyk.Analytics/Snyk.Analytics.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Analytics" Version="3.8.0" />
+    <PackageReference Include="Analytics" Version="3.8.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
   </ItemGroup>
 

--- a/Snyk.Analytics/Snyk.Analytics.csproj
+++ b/Snyk.Analytics/Snyk.Analytics.csproj
@@ -6,7 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Analytics" Version="3.8.1" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Snyk.Analytics/SnykAnalyticsService.cs
+++ b/Snyk.Analytics/SnykAnalyticsService.cs
@@ -46,7 +46,7 @@
                 }
 
                 this.analyticsEnabledOption = value;
-                Logger.Information(value ? "Analytics set to enabled" : "Analytics set to disabled");
+                Logger.Information("{V}", value ? "Analytics set to enabled" : "Analytics set to disabled");
             }
         }
 

--- a/Snyk.Code.Library.Tests/Snyk.Code.Library.Tests.csproj
+++ b/Snyk.Code.Library.Tests/Snyk.Code.Library.Tests.csproj
@@ -54,8 +54,8 @@
     </EmbeddedResource>    
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -64,14 +64,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.10.56">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Snyk.Code.Library.Tests/SnykCode/AnalysisServiceTest.cs
+++ b/Snyk.Code.Library.Tests/SnykCode/AnalysisServiceTest.cs
@@ -18,7 +18,7 @@
         private FireScanCodeProgressUpdate scanCodeProgressUpdate = (state, progress) => { };
 
         [Fact]
-        public void AnalysisService_FailedStatusProvided_GetAnalysisThrowException()
+        public async Task AnalysisService_FailedStatusProvided_GetAnalysisThrowException()
         {
             var codeClientMock = new Mock<ISnykCodeClient>();
 
@@ -37,7 +37,7 @@
                 .Setup(codeClient => codeClient.GetAnalysisAsync(dummyBundleId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dummyAnalysisResultDto);
 
-            _ = Assert.ThrowsAsync<AggregateException>(() => analysisService.GetAnalysisAsync(dummyBundleId, this.scanCodeProgressUpdate));
+            await Assert.ThrowsAsync<SnykCodeException>(() => analysisService.GetAnalysisAsync(dummyBundleId, this.scanCodeProgressUpdate));
 
             codeClientMock
                 .Verify(codeClient => codeClient.GetAnalysisAsync(dummyBundleId, It.IsAny<CancellationToken>()), Times.Exactly(1));
@@ -397,7 +397,7 @@
             var analysisResult = await analysisService.GetAnalysisAsync(dummyBundleId, this.scanCodeProgressUpdate);
 
             Assert.NotNull(analysisResult);
-            Assert.Equal(1, analysisResult.FileAnalyses.Count);
+            Assert.Single(analysisResult.FileAnalyses);
             Assert.Equal(3, analysisResult.FileAnalyses.First().Suggestions.Count);
 
             codeClientMock

--- a/Snyk.Code.Library.Tests/SnykCode/Api/SnykCodeClientTest.cs
+++ b/Snyk.Code.Library.Tests/SnykCode/Api/SnykCodeClientTest.cs
@@ -345,9 +345,9 @@
         }
 
         [Fact]
-        public void SnykCodeClient_WrongBundleProvided_CheckBundleFailed()
+        public async Task SnykCodeClient_WrongBundleProvided_CheckBundleFailed()
         {
-            _ = Assert.ThrowsAsync<AggregateException>(() => this.snykCodeClient.CheckBundleAsync("dummy"));
+            await Assert.ThrowsAsync<SnykCodeException>(async () => await this.snykCodeClient.CheckBundleAsync("dummy"));
         }
 
         [Fact]

--- a/Snyk.Code.Library.Tests/SnykCode/DcIgnoreServiceTest.cs
+++ b/Snyk.Code.Library.Tests/SnykCode/DcIgnoreServiceTest.cs
@@ -110,7 +110,7 @@
             var filteredFiles = dcIgnoreService.FilterFiles(folderPath, projectFiles).ToList();
 
             Assert.Equal(2, filteredFiles.Count);
-            Assert.Equal(expectedFiles, filteredFiles);
+            Assert.Equal(expectedFiles.OrderBy(x => x), filteredFiles.OrderBy(x => x));
             Assert.True(File.Exists(dcIGnorePath));
 
             File.Delete(dcIGnorePath);

--- a/Snyk.Code.Library.Tests/SnykCode/FiltersServiceTest.cs
+++ b/Snyk.Code.Library.Tests/SnykCode/FiltersServiceTest.cs
@@ -178,7 +178,7 @@
                 var filteredFiles = await filtersService.FilterFilesAsync(new[] { smallFile.FilePath, largeFile.FilePath });
 
                 // Assert
-                Assert.Equal(1, filteredFiles.Count);
+                Assert.Single(filteredFiles);
                 Assert.Contains(smallFile.FilePath, filteredFiles);
                 Assert.DoesNotContain(largeFile.FilePath, filteredFiles);
             }

--- a/Snyk.Code.Library/Service/FiltersService.cs
+++ b/Snyk.Code.Library/Service/FiltersService.cs
@@ -85,7 +85,7 @@
             {
                 return new FileInfo(path).Length > MaxFileSize;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return true;
             }

--- a/Snyk.Code.Library/Snyk.Code.Library.csproj
+++ b/Snyk.Code.Library/Snyk.Code.Library.csproj
@@ -33,7 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />

--- a/Snyk.Code.Library/Snyk.Code.Library.csproj
+++ b/Snyk.Code.Library/Snyk.Code.Library.csproj
@@ -43,7 +43,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -118,7 +117,7 @@
       <Version>3.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>5.0.0</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
       <Version>5.0.3</Version>
@@ -131,7 +130,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
-      <Version>15.8.122</Version>
+      <Version>16.10.56</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
@@ -143,16 +144,19 @@
       <Version>4.5.1</Version>
     </PackageReference>
     <PackageReference Include="System.Memory">
-      <Version>4.5.4</Version>
+      <Version>4.5.5</Version>
+    </PackageReference>
+    <PackageReference Include="System.Net.Http">
+      <Version>4.3.4</Version>
     </PackageReference>
     <PackageReference Include="System.Numerics.Vectors">
       <Version>4.5.0</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Encodings.Web">
-      <Version>5.0.1</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Threading.Tasks.Extensions">
       <Version>4.5.4</Version>

--- a/Snyk.Code.Library/Snyk.Code.Library.csproj
+++ b/Snyk.Code.Library/Snyk.Code.Library.csproj
@@ -146,9 +146,6 @@
     <PackageReference Include="System.Memory">
       <Version>4.5.5</Version>
     </PackageReference>
-    <PackageReference Include="System.Net.Http">
-      <Version>4.3.4</Version>
-    </PackageReference>
     <PackageReference Include="System.Numerics.Vectors">
       <Version>4.5.0</Version>
     </PackageReference>

--- a/Snyk.Common.Tests/Snyk.Common.Tests.csproj
+++ b/Snyk.Common.Tests/Snyk.Common.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+	<PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Snyk.Common/Authentication/OAuthToken.cs
+++ b/Snyk.Common/Authentication/OAuthToken.cs
@@ -26,7 +26,7 @@ public class OAuthToken
         {
             result = JsonSerializer.Deserialize<OAuthToken>(token);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             // nothing
         }

--- a/Snyk.Common/LogManager.cs
+++ b/Snyk.Common/LogManager.cs
@@ -58,7 +58,7 @@
                     config.AttachStacktrace = true;
 
                     // Disable default Sentry integrations for capture TaskUnobservedTaskException and AppDomainUnhandledException exceptions.
-                    config.DisableTaskUnobservedTaskExceptionCapture();
+                    config.DisableUnobservedTaskExceptionCapture();
                     config.DisableAppDomainUnhandledExceptionCapture();
 
                     // Register Snyk integrations for capture only Snyk related TaskUnobservedTaskException and AppDomainUnhandledException exceptions.

--- a/Snyk.Common/Service/SnykApiService.cs
+++ b/Snyk.Common/Service/SnykApiService.cs
@@ -61,7 +61,7 @@
                 this.options.SastSettings = sastSettings;
                 return sastSettings;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // In case of invalid json string return null.
                 return null;

--- a/Snyk.Common/Snyk.Common.csproj
+++ b/Snyk.Common/Snyk.Common.csproj
@@ -104,6 +104,9 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
     </PackageReference>
+    <PackageReference Include="Sentry">
+      <Version>3.13.0</Version>
+    </PackageReference>
     <PackageReference Include="Sentry.Serilog">
       <Version>3.13.0</Version>
     </PackageReference>

--- a/Snyk.Common/Snyk.Common.csproj
+++ b/Snyk.Common/Snyk.Common.csproj
@@ -45,7 +45,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -101,32 +100,43 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
+      <Version>16.10.56</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>3.13.0</Version>
+      <Version>4.6.2</Version>
     </PackageReference>
     <PackageReference Include="Sentry.Serilog">
-      <Version>3.13.0</Version>
+      <Version>4.6.2</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Enrichers.Process">
-      <Version>2.0.1</Version>
+      <Version>2.0.2</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Enrichers.Thread">
       <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Exceptions">
-      <Version>7.0.0</Version>
+      <Version>8.4.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Extensions.Logging">
-      <Version>3.0.1</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.File">
       <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="SerilogAnalyzer">
       <Version>0.15.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Net.Http">
+      <Version>4.3.4</Version>
+    </PackageReference>
+    <PackageReference Include="System.Text.Json">
+      <Version>8.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Snyk.Common/SnykWebClient.cs
+++ b/Snyk.Common/SnykWebClient.cs
@@ -17,7 +17,11 @@
             this.Headers.Add("User-Agent", "Snyk.VisualStudio.Extension");
 
             ServicePointManager.Expect100Continue = true;
+            
+            // TODO: Get back to this and find an alternative
+#pragma warning disable RS0030 // Do not used banned APIs
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+#pragma warning restore RS0030 // Do not used banned APIs
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Properties/AssemblyInfo.cs
+++ b/Snyk.VisualStudio.Extension.2022/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using Microsoft.VisualStudio.Shell;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -91,7 +91,7 @@
       <Version>17.0.394</Version>
     </PackageReference>
     <PackageReference Include="MdXaml">
-      <Version>1.19.2</Version>
+      <Version>1.27.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -104,13 +104,13 @@
       <Version>3.8.1</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>3.13.0</Version>
+      <Version>4.6.2</Version>
     </PackageReference>
     <PackageReference Include="Sentry.Serilog">
-      <Version>3.13.0</Version>
+      <Version>4.6.2</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
-      <Version>2.10.0</Version>
+      <Version>3.1.1</Version>
     </PackageReference>
     <PackageReference Include="SerilogAnalyzer">
       <Version>0.15.0</Version>

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -101,7 +101,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Analytics">
-      <Version>3.8.0</Version>
+      <Version>3.8.1</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
       <Version>3.13.0</Version>

--- a/Snyk.VisualStudio.Extension.Shared/CLI/SnykCli.cs
+++ b/Snyk.VisualStudio.Extension.Shared/CLI/SnykCli.cs
@@ -1,17 +1,16 @@
-﻿namespace Snyk.VisualStudio.Extension.Shared.CLI
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Security.Authentication;
+using System.Threading.Tasks;
+using Serilog;
+using Snyk.Common;
+using Snyk.Common.Authentication;
+using Snyk.Common.Service;
+using Snyk.Common.Settings;
+namespace Snyk.VisualStudio.Extension.Shared.CLI
 {
-    using System.Collections.Generic;
-    using System.Collections.Specialized;
-    using System.IO;
-    using System.Linq;
-    using System.Security.Authentication;
-    using System.Threading.Tasks;
-    using Serilog;
-    using Common;
-    using Common.Authentication;
-    using Snyk.Common.Service;
-    using Snyk.Common.Settings;
-
     /// <summary>
     /// Incapsulate work logic with Snyk CLI.
     /// </summary>

--- a/Snyk.VisualStudio.Extension.Shared/Service/SentryService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SentryService.cs
@@ -29,7 +29,7 @@
 
             SentrySdk.ConfigureScope(scope =>
             {
-                scope.User = new User { Id = this.serviceProvider.AnalyticsService.UserIdAsHash, };
+                scope.User = new SentryUser { Id = this.serviceProvider.AnalyticsService.UserIdAsHash, };
 
                 scope.SetTag("vs.version", vsVersion.ToString());
                 scope.SetTag("vs.edition", this.serviceProvider.DTE.Edition);
@@ -51,17 +51,17 @@
             }
             else
             {
-                LogManager.SentryConfiguration.BeforeSend = sentryEvent =>
+                LogManager.SentryConfiguration.SetBeforeSend(sentryEvent =>
                 {
                     sentryEvent.SetTag("vs.project.type", solutionType.ToString());
                     return sentryEvent;
-                };
+                });
             }
         }
 
         private static void DiscardEventCallback()
         {
-            LogManager.SentryConfiguration.BeforeSend = _ => { return null; };
+            LogManager.SentryConfiguration.SetBeforeSend(_ => { return null; });
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykSolutionService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykSolutionService.cs
@@ -211,8 +211,11 @@
             Logger.Information("Enter InitializeSolutionEvents method");
 
             IVsSolution vsSolution = await this.ServiceProvider.GetServiceAsync(typeof(SVsSolution)) as IVsSolution;
-
+            
+            // TODO: Revisit this and find if it's necessary.
+#pragma warning disable CS0618 // Type or member is obsolete
             vsSolution.SetProperty((int)__VSPROPID4.VSPROPID_ActiveSolutionLoadManager, this);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             this.SolutionEvents = new SnykVsSolutionLoadEvents(this, this.ServiceProvider.OssService, this.ServiceProvider.SentryService);
 
@@ -258,7 +261,7 @@
 
                 return files;
             }
-            catch (Exception ignore)
+            catch (Exception)
             {
                 // SolutionItem.Children inside Children can throw parameter incorrect exception.
                 // In this case return empty list.

--- a/Snyk.VisualStudio.Extension.Shared/Settings/SnykSolutionOptionsUserControl.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Settings/SnykSolutionOptionsUserControl.cs
@@ -1,12 +1,12 @@
-﻿namespace Snyk.VisualStudio.Extension.Shared.Settings
-{
-    using System;
-    using System.Windows.Forms;
-    using Microsoft.VisualStudio.Shell;
-    using Serilog;
-    using Snyk.Common;
-    using Snyk.VisualStudio.Extension.Shared.Service;
+﻿using System;
+using System.Windows.Forms;
+using Microsoft.VisualStudio.Shell;
+using Serilog;
+using Snyk.Common;
+using Snyk.VisualStudio.Extension.Shared.Service;
 
+namespace Snyk.VisualStudio.Extension.Shared.Settings
+{
     /// <summary>
     /// Solution settings control.
     /// </summary>

--- a/Snyk.VisualStudio.Extension.Shared/SnykVSPackage.cs
+++ b/Snyk.VisualStudio.Extension.Shared/SnykVSPackage.cs
@@ -124,7 +124,7 @@ namespace Snyk.VisualStudio.Extension.Shared
         public async Task<object> CreateSnykServiceAsync(IAsyncServiceContainer container,
             CancellationToken cancellationToken, Type serviceType)
         {
-            var ideVersion = await GetVsMajorMinorVersion();
+            var ideVersion = await GetVsMajorMinorVersionAsync();
             var service = new SnykService(this, ideVersion);
 
             await service.InitializeAsync(cancellationToken);
@@ -149,7 +149,7 @@ namespace Snyk.VisualStudio.Extension.Shared
 
                 ToolWindow = FindToolWindow(typeof(SnykToolWindow), 0, true) as SnykToolWindow;
 
-                Logger.Information($"Check ToolWindow is not null {ToolWindow}.");
+                Logger.Information("Check ToolWindow is not null {ToolWindow}.", ToolWindow);
 
                 if (ToolWindow == null || ToolWindow.Frame == null)
                 {
@@ -195,7 +195,7 @@ namespace Snyk.VisualStudio.Extension.Shared
                 await InitializeGeneralOptionsAsync();
 
                 // Initialize analytics
-                var vsVersion = await GetReadableVsVersion();
+                var vsVersion = await GetReadableVsVersionAsync();
 
                 var tokenString = this.serviceProvider.NewCli().GetApiToken();
                 this.serviceProvider.Options.SetApiToken(tokenString);
@@ -259,8 +259,8 @@ namespace Snyk.VisualStudio.Extension.Shared
                 Logger.Information("Call generalOptionsDialogPage.Initialize()");
 
                 GeneralOptionsDialogPage.Initialize(this.serviceProvider);
-                var readableVsVersion = await this.GetReadableVsVersion();
-                var vsMajorMinorVersion = await this.GetVsMajorMinorVersion();
+                var readableVsVersion = await this.GetReadableVsVersionAsync();
+                var vsMajorMinorVersion = await this.GetVsMajorMinorVersionAsync();
                 GeneralOptionsDialogPage.Application = readableVsVersion;
                 GeneralOptionsDialogPage.ApplicationVersion = vsMajorMinorVersion;
                 GeneralOptionsDialogPage.IntegrationEnvironment = readableVsVersion;
@@ -268,7 +268,7 @@ namespace Snyk.VisualStudio.Extension.Shared
             }
         }
 
-        private async Task<string> GetVsVersion()
+        private async Task<string> GetVsVersionAsync()
         {
             try
             {
@@ -288,11 +288,11 @@ namespace Snyk.VisualStudio.Extension.Shared
             }
         }
 
-        private async Task<string> GetVsMajorMinorVersion()
+        private async Task<string> GetVsMajorMinorVersionAsync()
         {
             try
             {
-                var vsVersionString = (await GetVsVersion()).Split('.');
+                var vsVersionString = (await GetVsVersionAsync()).Split('.');
 
                 return $"{vsVersionString[0]}.{vsVersionString[1]}";
             }
@@ -302,11 +302,11 @@ namespace Snyk.VisualStudio.Extension.Shared
             }
         }
 
-        private async Task<string> GetReadableVsVersion()
+        private async Task<string> GetReadableVsVersionAsync()
         {
             try
             {
-                var vsVersionString = await GetVsVersion();
+                var vsVersionString = await GetVsVersionAsync();
                 var major = vsVersionString.Split('.').FirstOrDefault();
 
                 return major switch

--- a/Snyk.VisualStudio.Extension.Shared/Theme/SnykVsThemeService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Theme/SnykVsThemeService.cs
@@ -49,11 +49,11 @@
             }
             catch (COMException comException)
             {
-                Logger.Error(comException.Message);
+                Logger.Error("{Message}", comException.Message);
             }
             catch (InvalidComObjectException comObjectException)
             {
-                Logger.Error(comObjectException.Message);
+                Logger.Error("{Message}", comObjectException.Message);
             }
         }
 

--- a/Snyk.VisualStudio.Extension.Shared/UI/Notifications/VsInfoBarService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Notifications/VsInfoBarService.cs
@@ -61,12 +61,12 @@
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                if (actionItem.ActionContext == ContactSupport)
+                if (ContactSupport == actionItem.ActionContext.ToString())
                 {
                     Process.Start(SupportLink);
                 }
 
-                if (actionItem.ActionContext == KnownCaveats)
+                if (KnownCaveats == actionItem.ActionContext.ToString())
                 {
                     Process.Start(KnownCaveatsLink);
                 }

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/MessagePanel.xaml.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/MessagePanel.xaml.cs
@@ -1,21 +1,19 @@
-﻿namespace Snyk.VisualStudio.Extension.Shared.UI.Toolwindow
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.IO;
-    using System.Threading.Tasks;
-    using System.Windows;
-    using System.Windows.Controls;
-    using Community.VisualStudio.Toolkit;
-    using Microsoft.VisualStudio.Shell;
-    using Microsoft.VisualStudio.Shell.Interop;
-    using Microsoft.VisualStudio.Threading;
-    using Serilog;
-    using Serilog.Core;
-    using Snyk.Common;
-    using Snyk.VisualStudio.Extension.Shared.Service;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using Serilog;
+using Snyk.Common;
+using Snyk.VisualStudio.Extension.Shared.Service;
 
+namespace Snyk.VisualStudio.Extension.Shared.UI.Toolwindow
+{
     /// <summary>
     /// Interaction logic for MessagePanel.xaml.
     /// </summary>
@@ -102,7 +100,7 @@
             ThreadHelper.JoinableTaskFactory.Run(RunTestCodeNowAsync);
         }
 
-        private async Task RunTestCodeNowAsync()
+        private async System.Threading.Tasks.Task RunTestCodeNowAsync()
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             this.testCodeNowButton.IsEnabled = false; // Disable the button while authenticating

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/MessagePanel.xaml.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/MessagePanel.xaml.cs
@@ -97,7 +97,12 @@
             panel.Visibility = Visibility.Visible;
         }
 
-        private async void TestCodeNow_Click(object sender, RoutedEventArgs e)
+        private void TestCodeNow_Click(object sender, RoutedEventArgs e)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(RunTestCodeNowAsync);
+        }
+
+        private async Task RunTestCodeNowAsync()
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             this.testCodeNowButton.IsEnabled = false; // Disable the button while authenticating

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindow.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindow.cs
@@ -135,7 +135,7 @@
 
                         toolWindowControl.VulnerabilitiesTree.FilterBy(this.SearchQuery.SearchString);
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         this.ErrorCode = VSConstants.E_FAIL;
                     }

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindowControl.xaml.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykToolWindowControl.xaml.cs
@@ -570,8 +570,6 @@
 
                 this.messagePanel.Visibility = Visibility.Collapsed;
 
-                TreeNode treeNode = null;
-
                 if (this.resultsTree.SelectedItem is OssVulnerabilityTreeNode)
                 {
                     this.HandleOssTreeNodeSelected();

--- a/Snyk.VisualStudio.Extension.Shared/UI/Tree/SnykCodeQualityRootTreeNode.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Tree/SnykCodeQualityRootTreeNode.cs
@@ -19,7 +19,7 @@
         /// <summary>
         /// Gets a value indicating whether icon for open source node.
         /// </summary>
-        public string Icon => SnykIconProvider.SnykCodeIconPath;
+        public override string Icon => SnykIconProvider.SnykCodeIconPath;
 
         protected override string GetIssuesTypeName() => "issues";
 

--- a/Snyk.VisualStudio.Extension.Shared/UI/Tree/SnykCodeSecurityRootTreeNode.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Tree/SnykCodeSecurityRootTreeNode.cs
@@ -19,7 +19,7 @@
         /// <summary>
         /// Gets a value indicating whether icon for open source node.
         /// </summary>
-        public string Icon => SnykIconProvider.SnykCodeIconPath;
+        public override string Icon => SnykIconProvider.SnykCodeIconPath;
 
         protected override string GetIssuesTypeName() => "vulnerabilities";
 

--- a/Snyk.VisualStudio.Extension.Shared/analytics/SnykIdeAnalyticsService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/analytics/SnykIdeAnalyticsService.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using Microsoft.VisualStudio.Shell;
 using Serilog;
 using Snyk.Code.Library.Domain.Analysis;
 using Snyk.Common;
@@ -69,7 +69,6 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
             ossScanningStarted = DateTime.UtcNow;
         }
 
-        [SuppressMessage("Usage", "VSTHRD110:Observe result of async calls")]
         public void OnOssScanningUpdate(object sender, SnykCliScanEventArgs e)
         {
             try
@@ -87,7 +86,7 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
                 }
 
                 var payload = GetAnalyticsPayload("Snyk Open Source", durationMs, critical, high, medium, low);
-                cliProvider.Cli.ReportAnalyticsAsync(payload);
+                ThreadHelper.JoinableTaskFactory.Run(async () => await cliProvider.Cli.ReportAnalyticsAsync(payload));
             }
             catch (Exception exception)
             {
@@ -105,7 +104,6 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
             codeScanningStarted = DateTime.UtcNow;
         }
 
-        [SuppressMessage("Usage", "VSTHRD110:Observe result of async calls")]
         public void OnSnykCodeScanningUpdate(object sender, SnykCodeScanEventArgs e)
         {
             try
@@ -139,7 +137,7 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
                 }
 
                 var payload = GetAnalyticsPayload("Snyk Code", durationMs, critical, high, medium, low);
-                cliProvider.Cli.ReportAnalyticsAsync(payload);
+                ThreadHelper.JoinableTaskFactory.Run(async () => await cliProvider.Cli.ReportAnalyticsAsync(payload));
             }
             catch (Exception ex)
             {

--- a/Snyk.VisualStudio.Extension.Shared/analytics/SnykIdeAnalyticsService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/analytics/SnykIdeAnalyticsService.cs
@@ -86,7 +86,7 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
                 }
 
                 var payload = GetAnalyticsPayload("Snyk Open Source", durationMs, critical, high, medium, low);
-                ThreadHelper.JoinableTaskFactory.Run(async () => await cliProvider.Cli.ReportAnalyticsAsync(payload));
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () => await cliProvider.Cli.ReportAnalyticsAsync(payload)).FireAndForget();
             }
             catch (Exception exception)
             {
@@ -137,7 +137,7 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
                 }
 
                 var payload = GetAnalyticsPayload("Snyk Code", durationMs, critical, high, medium, low);
-                ThreadHelper.JoinableTaskFactory.Run(async () => await cliProvider.Cli.ReportAnalyticsAsync(payload));
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () => await cliProvider.Cli.ReportAnalyticsAsync(payload)).FireAndForget();
             }
             catch (Exception ex)
             {

--- a/Snyk.VisualStudio.Extension.Shared/analytics/SnykIdeAnalyticsService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/analytics/SnykIdeAnalyticsService.cs
@@ -86,7 +86,7 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
                 }
 
                 var payload = GetAnalyticsPayload("Snyk Open Source", durationMs, critical, high, medium, low);
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () => await cliProvider.Cli.ReportAnalyticsAsync(payload)).FireAndForget();
+                ThreadHelper.JoinableTaskFactory.Run(async () => await cliProvider.Cli.ReportAnalyticsAsync(payload));
             }
             catch (Exception exception)
             {
@@ -137,7 +137,7 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
                 }
 
                 var payload = GetAnalyticsPayload("Snyk Code", durationMs, critical, high, medium, low);
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () => await cliProvider.Cli.ReportAnalyticsAsync(payload)).FireAndForget();
+                ThreadHelper.JoinableTaskFactory.Run(async () => await cliProvider.Cli.ReportAnalyticsAsync(payload));
             }
             catch (Exception ex)
             {

--- a/Snyk.VisualStudio.Extension.Shared/analytics/SnykIdeAnalyticsService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/analytics/SnykIdeAnalyticsService.cs
@@ -34,9 +34,9 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
         {
             scanTopicProvider.OssScanningFinished += OnOssScanningFinished;
             scanTopicProvider.CliScanningStarted += OnCliScanningStarted;
-            scanTopicProvider.OssScanningUpdate += OnOssScanningUpdate;
+            scanTopicProvider.OssScanningUpdate += (sender, args) => ThreadHelper.JoinableTaskFactory.RunAsync(async () => await OnOssScanningUpdateAsync(sender, args)).FireAndForget();
+            scanTopicProvider.SnykCodeScanningUpdate += (sender, args) => ThreadHelper.JoinableTaskFactory.RunAsync(async () => await OnSnykCodeScanningUpdateAsync(sender, args)).FireAndForget();
             scanTopicProvider.SnykCodeScanningStarted += OnSnykCodeScanningStarted;
-            scanTopicProvider.SnykCodeScanningUpdate += OnSnykCodeScanningUpdate;
             scanTopicProvider.SnykCodeScanningFinished += OnSnykCodeScanningFinished;
         }
 
@@ -69,7 +69,7 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
             ossScanningStarted = DateTime.UtcNow;
         }
 
-        public void OnOssScanningUpdate(object sender, SnykCliScanEventArgs e)
+        public async System.Threading.Tasks.Task OnOssScanningUpdateAsync(object sender, SnykCliScanEventArgs e)
         {
             try
             {
@@ -86,7 +86,7 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
                 }
 
                 var payload = GetAnalyticsPayload("Snyk Open Source", durationMs, critical, high, medium, low);
-                ThreadHelper.JoinableTaskFactory.Run(async () => await cliProvider.Cli.ReportAnalyticsAsync(payload));
+                await cliProvider.Cli.ReportAnalyticsAsync(payload);
             }
             catch (Exception exception)
             {
@@ -104,7 +104,7 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
             codeScanningStarted = DateTime.UtcNow;
         }
 
-        public void OnSnykCodeScanningUpdate(object sender, SnykCodeScanEventArgs e)
+        public async System.Threading.Tasks.Task OnSnykCodeScanningUpdateAsync(object sender, SnykCodeScanEventArgs e)
         {
             try
             {
@@ -137,7 +137,7 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
                 }
 
                 var payload = GetAnalyticsPayload("Snyk Code", durationMs, critical, high, medium, low);
-                ThreadHelper.JoinableTaskFactory.Run(async () => await cliProvider.Cli.ReportAnalyticsAsync(payload));
+                await cliProvider.Cli.ReportAnalyticsAsync(payload);
             }
             catch (Exception ex)
             {

--- a/Snyk.VisualStudio.Extension.Tests/OssServiceTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/OssServiceTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace Snyk.VisualStudio.Extension.Tests
 {
     using System.Threading;
+    using System.Threading.Tasks;
     using Moq;
     using Snyk.Common.Settings;
     using Snyk.VisualStudio.Extension.Shared.CLI;
@@ -80,7 +81,7 @@
         }
 
         [Fact]
-        public void OssServiceTest_ClearCache_ReturnNewValue()
+        public async Task OssServiceTest_ClearCache_ReturnNewValueAsync()
         {
             var serviceProviderMock = new Mock<ISnykServiceProvider>();
             var cliMock = new Mock<ICli>();
@@ -104,7 +105,7 @@
 
             var tokenSource = new CancellationTokenSource();
 
-            ossService.ScanAsync(string.Empty, tokenSource.Token);
+            await ossService.ScanAsync(string.Empty, tokenSource.Token);
 
             ossService.ClearCache();
 

--- a/Snyk.VisualStudio.Extension.Tests/Snyk.VisualStudio.Extension.Tests.csproj
+++ b/Snyk.VisualStudio.Extension.Tests/Snyk.VisualStudio.Extension.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
@@ -32,16 +32,16 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>    
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />    
-    <PackageReference Include="Moq" Version="4.16.1" />
+  <ItemGroup>
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+	<PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Snyk.VisualStudio.Extension.Tests/analytics/SnykIDEAnalyticsServiceTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/analytics/SnykIDEAnalyticsServiceTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Moq;
 using Snyk.Code.Library.Api.Dto.Analysis;
 using Snyk.Code.Library.Domain.Analysis;
@@ -58,7 +59,7 @@ namespace Snyk.VisualStudio.Extension.Tests.analytics
         }
 
         [Fact]
-        public void SnykIdeAnalyticsServiceTest_shouldReportAnalyticsOnSnykCodeScanningUpdate()
+        public async Task SnykIdeAnalyticsServiceTest_shouldReportAnalyticsOnSnykCodeScanningUpdateAsync()
         {
             var optionsProviderMock = new Mock<ISnykOptionsProvider>();
             var optionsMock = new Mock<ISnykOptions>();
@@ -71,7 +72,7 @@ namespace Snyk.VisualStudio.Extension.Tests.analytics
             var analysisResult = SetupAnalysisResult();
             var e = new SnykCodeScanEventArgs(analysisResult);
 
-            service.OnSnykCodeScanningUpdate(this, e);
+            await service.OnSnykCodeScanningUpdateAsync(this, e);
 
             // assert payload is generated (anonymousID called) and cli reportAnalytics is called
             optionsMock.VerifyGet(options => options.AnonymousId, Times.Once);
@@ -80,7 +81,7 @@ namespace Snyk.VisualStudio.Extension.Tests.analytics
         }
 
         [Fact]
-        public void SnykIdeAnalyticsServiceTest_shouldReportAnalyticsOnOssScanningUpdate()
+        public async Task SnykIdeAnalyticsServiceTest_shouldReportAnalyticsOnOssScanningUpdateAsync()
         {
             var optionsProviderMock = new Mock<ISnykOptionsProvider>();
             var optionsMock = new Mock<ISnykOptions>();
@@ -93,7 +94,7 @@ namespace Snyk.VisualStudio.Extension.Tests.analytics
             var cliResult = SetupCliResult();
 
             var e = new SnykCliScanEventArgs(cliResult);
-            service.OnOssScanningUpdate(this, e);
+            await service.OnOssScanningUpdateAsync(this, e);
 
             // assert payload is generated (anonymousID called) and cli reportAnalytics is called
             optionsMock.VerifyGet(options => options.AnonymousId, Times.Once);

--- a/Snyk.VisualStudio.Extension/Snyk.VisualStudio.Extension.csproj
+++ b/Snyk.VisualStudio.Extension/Snyk.VisualStudio.Extension.csproj
@@ -89,7 +89,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Analytics">
-      <Version>3.8.0</Version>
+      <Version>3.8.1</Version>
     </PackageReference>
     <PackageReference Include="Community.VisualStudio.Toolkit.14">
       <Version>14.0.355</Version>

--- a/Snyk.VisualStudio.Extension/Snyk.VisualStudio.Extension.csproj
+++ b/Snyk.VisualStudio.Extension/Snyk.VisualStudio.Extension.csproj
@@ -95,19 +95,19 @@
       <Version>14.0.355</Version>
     </PackageReference>
     <PackageReference Include="MdXaml">
-      <Version>1.19.2</Version>
+      <Version>1.27.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.14.0">
       <Version>14.3.25407</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>3.13.0</Version>
+      <Version>4.6.2</Version>
     </PackageReference>
     <PackageReference Include="Sentry.Serilog">
-      <Version>3.13.0</Version>
+      <Version>4.6.2</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
-      <Version>2.10.0</Version>
+      <Version>3.1.1</Version>
     </PackageReference>
     <PackageReference Include="SerilogAnalyzer">
       <Version>0.15.0</Version>

--- a/Tests/Integration.Pre22.Tests/Integration.Pre22.Tests.csproj
+++ b/Tests/Integration.Pre22.Tests/Integration.Pre22.Tests.csproj
@@ -48,7 +48,7 @@
       <Version>0.1.137-beta</Version>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable">
-      <Version>1.1.36</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.utility">
       <Version>2.4.2</Version>

--- a/Tests/Integration.Tests/Integration.Tests.csproj
+++ b/Tests/Integration.Tests/Integration.Tests.csproj
@@ -51,10 +51,10 @@
       <Version>17.0.32112.339</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.utility">
-      <Version>2.4.2</Version>
+      <Version>2.8.0</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.4.5</Version>
+      <Version>2.8.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
### Description

1. Update Dependancies.
2. Cleanup IDE warnings.
3. Fix dependancy versions mismatch.

### Note: 
Warnings that won't be fixed with this PR:

* Dependency version conflict for System.Net.Http seems to be an issue with the Framework itself. The issue happens when a .Net Framework project references a .Netstandard project.
Which is the case with CodeLibrary referencing Analytics.
* Using Newtonsoft.Json > 6.0.8.
* Warnings regarding .xaml.cs files not finding it's parent is caused by a bug in VS when using Shared Project type. (https://developercommunity.visualstudio.com/t/overactive-warning-the-parent-file-cannot-be-found/911196)


### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
