### PR TITLE
fix: readme-sync pipeline [IDE-343]

### DIFF
--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -52,7 +52,7 @@ jobs:
             echo "No documentation changes detected, exiting."
           fi
         env:
-          SOURCE_PATH: ./docs/docs/integrations/ide-tools/visual-studio-extension/README.md
+          SOURCE_PATH: ./docs/docs/integrate-with-snyk/use-snyk-in-your-ide/visual-studio-extension/README.md
           FILE_TO_COMMIT: README.md
           DESTINATION_REPOSITORY: snyk-visual-studio-plugin
           DESTINATION_BRANCH: docs/automatic-gitbook-update


### PR DESCRIPTION
### Description
Fix failing readme-sync pipeline. 
It appears that the folder structure of snyk/user-docs has changed. 
This change update the SOURCE_PATH variable to use the correct README.md file.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
