### PR TITLE
fix: use VS Brushes for background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Security Changelog
 
+## [1.1.53]
+
+### Fixed
+- Use dynamic colors for the suggestion fix textbox.
+
 ## [1.1.52]
 
 ### Fixed

--- a/Snyk.VisualStudio.Extension.Shared/Snyk.VisualStudio.Extension.Shared.projitems
+++ b/Snyk.VisualStudio.Extension.Shared/Snyk.VisualStudio.Extension.Shared.projitems
@@ -159,6 +159,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)SnykVSPackage.cs">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Theme\ColorExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Theme\SnykVsThemeService.cs">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Compile>

--- a/Snyk.VisualStudio.Extension.Shared/Theme/ColorExtension.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Theme/ColorExtension.cs
@@ -1,0 +1,10 @@
+﻿namespace Snyk.VisualStudio.Extension.Shared.Theme
+{
+    public static class ColorExtension
+    {
+        public static System.Windows.Media.SolidColorBrush ToBrush(this System.Drawing.Color color)
+        {
+            return new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromArgb(color.A, color.R, color.G, color.B));
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykCode/ExternalExampleFixRichTextBox.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykCode/ExternalExampleFixRichTextBox.cs
@@ -5,7 +5,9 @@
     using System.Windows.Controls;
     using System.Windows.Documents;
     using System.Windows.Media;
+    using Microsoft.VisualStudio.PlatformUI;
     using Snyk.Code.Library.Domain.Analysis;
+    using Snyk.VisualStudio.Extension.Shared.Theme;
 
     /// <summary>
     /// Extended <see cref="RichTextBox"/> for display code example with red/green highlite rows.
@@ -14,6 +16,8 @@
     {
         public static readonly DependencyProperty LinesProperty =
             DependencyProperty.Register("Lines", typeof(ObservableCollection<FixLine>), typeof(ExternalExampleFixRichTextBox), new PropertyMetadata(OnLinesChanged));
+        private static readonly SolidColorBrush redBrush = VSColorTheme.GetThemedColor(EnvironmentColors.VizSurfaceRedDarkBrushKey).ToBrush();
+        private static readonly SolidColorBrush greenBrush = VSColorTheme.GetThemedColor(EnvironmentColors.VizSurfaceGreenDarkBrushKey).ToBrush();
 
         /// <summary>
         /// Gets or sets lines of code in editor.
@@ -47,7 +51,7 @@
                 foreach (var line in lines)
                 {
                     var lineDecorations = GetLineDecorations(line.LineChange);
-
+                    
                     var paragraph = new Paragraph();
                     paragraph.Margin = new Thickness(0);
                     paragraph.Padding = new Thickness(2);
@@ -75,18 +79,16 @@
         {
             string lineChangeSymbol = string.Empty;
             SolidColorBrush backgroundBrush = null;
-
             switch (lineChange)
             {
                 case "added":
                     lineChangeSymbol = "+";
-                    backgroundBrush = Brushes.DarkSeaGreen;
+                    backgroundBrush = greenBrush;
 
                     break;
                 case "removed":
                     lineChangeSymbol = "-";
-                    backgroundBrush = Brushes.PaleVioletRed;
-
+                    backgroundBrush = redBrush;
                     break;
                 default:
                     break;

--- a/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykCode/ExternalExampleFixRichTextBox.cs
+++ b/Snyk.VisualStudio.Extension.Shared/UI/Toolwindow/SnykCode/ExternalExampleFixRichTextBox.cs
@@ -41,10 +41,7 @@
 
                 var lines = evenArgs.NewValue as ObservableCollection<FixLine>;
 
-                if (lines == null)
-                {
-                    return;
-                }
+                if (lines == null) return;
 
                 FlowDocument flowDocument = new FlowDocument();
 
@@ -84,7 +81,6 @@
                 case "added":
                     lineChangeSymbol = "+";
                     backgroundBrush = greenBrush;
-
                     break;
                 case "removed":
                     lineChangeSymbol = "-";


### PR DESCRIPTION
### Description
Replace background color for fixes lines in the ``ExternalExampleFixRichTextBox`` with IDE colors instead of static colors.
For Green:
``EnvironmentColors.VizSurfaceGreenDarkBrushKey``
For Red:
``EnvironmentColors.VizSurfaceRedDarkBrushKey``

For Reference:
All VS Colors: https://vscolor.sboulema.nl

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

Before for all themes: 
![image](https://github.com/snyk/snyk-visual-studio-plugin/assets/6913627/5691119d-a2a7-4b8f-be57-64955d01aa08)

After:
![image](https://github.com/snyk/snyk-visual-studio-plugin/assets/6913627/fa84603e-9a44-4147-9888-537f1322f9fd)
![image](https://github.com/snyk/snyk-visual-studio-plugin/assets/6913627/d63e9b57-b1ae-4025-a2b6-f5d3607408ab)
