### PR TITLE
chore: add folder path to analytics event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Security Changelog
 
+## [1.1.56]
+
+### Fixed
+- Send current solution folder path when sending Analytics.
+
 ## [1.1.55]
 
 ### Fixed

--- a/Snyk.VisualStudio.Extension.Shared/Service/SnykService.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Service/SnykService.cs
@@ -116,7 +116,7 @@
                 if (ideAnalyticsService == null)
                 {
                     ideAnalyticsService =
-                        new SnykIdeAnalyticsService(Package,  this, TasksService);
+                        new SnykIdeAnalyticsService(Package,  this, TasksService, SolutionService);
                 }
 
                 return ideAnalyticsService;

--- a/Snyk.VisualStudio.Extension.Shared/analytics/ScanDoneEvent.cs
+++ b/Snyk.VisualStudio.Extension.Shared/analytics/ScanDoneEvent.cs
@@ -34,7 +34,9 @@ namespace Snyk.VisualStudio.Extension.Shared.CLI
             IntegrationEnvironment = options.IntegrationEnvironment;
             IntegrationEnvironmentVersion = options.IntegrationEnvironmentVersion;
         }
-
+        
+        public string Path { get; set; }
+        
         public string DeviceId { get;  }
         
         public string Application { get;  }


### PR DESCRIPTION
### Description
- Before sending analytics get the current folder/solution path and assign it to the ScanDoneEvent attributes.

Note: This change was tested with older CLI versions. 
The additional property "path" is ignored in older CLI version.

### Checklist

- [x] Tests added and all succeed
- [ ] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
