### PR TITLE
fix: downgrade serilog to 3.0.1 and remove bindingredirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Security Changelog
 
+## [1.1.60]
+
+### Fixed
+- Fix an issue with extension failing to load in VS 2022 < 17.10.
+
 ## [1.1.59]
 
 ### Fixed

--- a/Snyk.Common/Snyk.Common.csproj
+++ b/Snyk.Common/Snyk.Common.csproj
@@ -125,7 +125,7 @@
       <Version>8.4.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Extensions.Logging">
-      <Version>8.0.0</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.File">
       <Version>5.0.0</Version>

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -110,7 +110,7 @@
       <Version>4.6.2</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
-      <Version>3.1.1</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="SerilogAnalyzer">
       <Version>0.15.0</Version>

--- a/Snyk.VisualStudio.Extension.Shared/Settings/SnykGeneralSettingsUserControl.cs
+++ b/Snyk.VisualStudio.Extension.Shared/Settings/SnykGeneralSettingsUserControl.cs
@@ -308,28 +308,18 @@
 
         private void UpdateSnykCodeEnablementSettings(SastSettings sastSettings)
         {
-            if (sastSettings == null)
-            {
-                this.snykCodeDisabledInfoLabel.Text = "Snyk Code is disabled.";
-
-                this.snykCodeDisabledInfoLabel.Visible = true;
-                this.snykCodeSettingsLinkLabel.Visible = true;
-                this.checkAgainLinkLabel.Visible = true;
-            }
-
             bool snykCodeEnabled = sastSettings?.SnykCodeEnabled ?? false;
-
-            this.codeSecurityEnabledCheckBox.Enabled = snykCodeEnabled;
-            this.codeQualityEnabledCheckBox.Enabled = snykCodeEnabled;
 
             if (!snykCodeEnabled)
             {
                 this.snykCodeDisabledInfoLabel.Text = "Snyk Code is disabled by your organisation\'s configuration:";
-
-                this.snykCodeDisabledInfoLabel.Visible = !snykCodeEnabled;
-                this.snykCodeSettingsLinkLabel.Visible = !snykCodeEnabled;
-                this.checkAgainLinkLabel.Visible = !snykCodeEnabled;
             }
+
+            this.codeSecurityEnabledCheckBox.Enabled = snykCodeEnabled;
+            this.codeQualityEnabledCheckBox.Enabled = snykCodeEnabled;
+            this.snykCodeDisabledInfoLabel.Visible = !snykCodeEnabled;
+            this.snykCodeSettingsLinkLabel.Visible = !snykCodeEnabled;
+            this.checkAgainLinkLabel.Visible = !snykCodeEnabled;
         }
 
         private async Task StartSastEnablementCheckLoopAsync()

--- a/Snyk.VisualStudio.Extension/Properties/AssemblyInfo.cs
+++ b/Snyk.VisualStudio.Extension/Properties/AssemblyInfo.cs
@@ -31,7 +31,3 @@ using Microsoft.VisualStudio.Shell;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-
-[assembly: ProvideBindingRedirection(AssemblyName = "System.Diagnostics.DiagnosticSource",
-      NewVersion = "8.0.0.0", OldVersionLowerBound = "7.0.0.0",
-      OldVersionUpperBound = "8.0.0.0")]

--- a/Snyk.VisualStudio.Extension/Snyk.VisualStudio.Extension.csproj
+++ b/Snyk.VisualStudio.Extension/Snyk.VisualStudio.Extension.csproj
@@ -103,7 +103,7 @@
       <Version>4.6.2</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
-      <Version>3.1.1</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="SerilogAnalyzer">
       <Version>0.15.0</Version>


### PR DESCRIPTION
### Description

VS 2022 Version < 17.9 don't have the required binding redirect for System.Diagnostics.DiagnosticSource. 
System.Diagnostics.DiagnosticSource is required by Serilog > 3.0.1.
For now, we can just downgrade to 3.0.1.

Fix a small bug with enable Snyk code label


### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
