### PR TITLE
feat: handle summary panel notification and render it in toolwindow [IDE-893]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Snyk Security Changelog
+## [2.1.0]
+### Changed
+- New Summary Panel for scan information and Net New Issues filtering.
 
 ## [2.0.1]
 ### Changed

--- a/Snyk.VisualStudio.Extension.2022/Language/CustomInitializationOptions.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/CustomInitializationOptions.cs
@@ -52,6 +52,10 @@ namespace Snyk.VisualStudio.Extension.Language
     {
         public List<FolderConfig> FolderConfigs { get; set; }
     }
+    public class ScanSummaryParam
+    {
+        public string ScanSummary { get; set; }
+    }
 
     public class FilterSeverityOptions
     {

--- a/Snyk.VisualStudio.Extension.2022/Language/LsConstants.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/LsConstants.cs
@@ -13,6 +13,7 @@
         // This notification is needed because we are sending Issue data in the Diagnostic.Data field and Visual Studio filters it out.
         // We had to send the same notification but with a different to avoid Visual Studio's filtering behavior.
         public const string OnPublishDiagnostics316 = "$/snyk.publishDiagnostics316";
+        public const string SnykScanSummary = "$/snyk.scanSummary";
         
         // Requests
         public const string WorkspaceChangeConfiguration = "workspace/didChangeConfiguration";

--- a/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClientCustomTarget.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClientCustomTarget.cs
@@ -113,6 +113,19 @@ namespace Snyk.VisualStudio.Extension.Language
             serviceProvider.SnykOptionsManager.Save(serviceProvider.Options);
         }
 
+        [JsonRpcMethod(LsConstants.SnykScanSummary)]
+        public async Task OnScanSummary(JToken arg)
+        {
+            var html = arg;
+            var scanSummaryParam = arg.TryParse<ScanSummaryParam>();
+            if (scanSummaryParam?.ScanSummary == null || serviceProvider?.ToolWindow?.SummaryPanel == null) return;
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                serviceProvider.ToolWindow.SummaryPanel.SetContent(scanSummaryParam.ScanSummary, "summary");
+            }).FireAndForget();
+        }
+
         [JsonRpcMethod(LsConstants.SnykHasAuthenticated)]
         public async Task OnHasAuthenticated(JToken arg)
         {

--- a/Snyk.VisualStudio.Extension.2022/Resources/LoadingSummary.html
+++ b/Snyk.VisualStudio.Extension.2022/Resources/LoadingSummary.html
@@ -1,0 +1,102 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv='Content-Type' content='text/html; charset=unicode' />
+    <meta http-equiv='X-UA-Compatible' content='IE=edge' />
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy"
+          content="style-src 'self' 'nonce-${nonce}' 'nonce-ideNonce' https://fonts.googleapis.com;
+  script-src 'nonce-${nonce}' https://fonts.googleapis.com;
+  font-src 'self' https://fonts.gstatic.com;" />
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');
+
+        :root {
+            font-size: var(--main-font-size);
+            --default-font: "SF Pro Text", "Segoe UI", "Ubuntu", Geneva, Verdana, Tahoma, sans-serif;
+            --ide-background-color: var(--vscode-sideBar-background);
+            --text-color: var(--vscode-foreground);
+            --input-border: var(--vscode-input-border);
+        }
+
+        p {
+            font-size: 1.3rem;
+            margin: .8rem 0;
+        }
+
+        hr {
+            margin: 2rem 0;
+        }
+
+        body {
+            background-color: var(--ide-background-color);
+            color: var(--text-color);
+            font-family: var(--default-font);
+        }
+
+        .snx-loader {
+            display: inline-block;
+            width: 12px;
+            height: 12px;
+            border: 2px solid rgba(125,125,125,.65);
+            border-bottom-color: transparent;
+            border-radius: 50%;
+            margin-right: .8rem;
+            animation: spin 1s linear infinite;
+        }
+
+        .size-s {
+            width: 12px;
+            height: 12px;
+            border-width: 2px
+        }
+
+        @keyframes spin {
+            from {
+                transform: rotate(0deg);
+            }
+
+            to {
+                transform: rotate(360deg);
+            }
+        }
+
+        .snx-h1 {
+            font-size: 2rem;
+            font-weight: 600;
+            margin: .8rem 0;
+        }
+
+        .snx-status {
+            display: flex;
+            align-items: center;
+            padding: .4rem 1.2rem;
+            background-color: rgba(255,255,255,.1);
+            border-radius: 1rem;
+        }
+
+        .snx-header {
+            display: flex;
+            gap: 1.6rem;
+        }
+
+        .snx-message {
+            display: flex;
+            align-items: center
+        }
+    </style>
+</head>
+<body>
+
+    <div class="snx-header">
+        <h1 class="snx-title snx-h1">Snyk Security is loading...</h1>
+    </div>
+    <div class="snx-summary">
+        <div class="snx-status">
+            <span class="snx-loader size-s"></span>
+            <p class="snx-message">Waiting for the Snyk CLI to be downloaded and the Language Server to be initialized. </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -117,6 +117,10 @@
     <Resource Include="Resources\branch-dark.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Resource>
+    <Content Include="Resources\LoadingSummary.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="Resources\SnykLsInit.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -242,6 +242,8 @@
     <Compile Include="UI\Html\ColorExtension.cs" />
     <Compile Include="UI\Html\IacHtmlProvider.cs" />
     <Compile Include="UI\Html\IHtmlProvider.cs" />
+    <Compile Include="UI\Html\StaticHtmlProvider.cs" />
+    <Compile Include="UI\Html\SummaryHtmlProvider.cs" />
     <Compile Include="UI\Html\OssHtmlProvider.cs" />
     <Compile Include="UI\Html\CodeHtmlProvider.cs" />
     <Compile Include="UI\Html\HtmlProviderFactory.cs" />
@@ -253,6 +255,9 @@
     <Compile Include="UI\ResourceLoader.cs" />
     <Compile Include="UI\SeverityFilter.cs" />
     <Compile Include="UI\SnykIconProvider.cs" />
+    <Compile Include="UI\Toolwindow\SummaryHtmlPanel.xaml.cs">
+      <DependentUpon>SummaryHtmlPanel.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UI\Toolwindow\HtmlDescriptionPanel.xaml.cs">
       <DependentUpon>HtmlDescriptionPanel.xaml</DependentUpon>
     </Compile>
@@ -386,6 +391,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="UI\Controls\TextField.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="UI\Toolwindow\SummaryHtmlPanel.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/Snyk.VisualStudio.Extension.2022/Theme/ColorExtension.cs
+++ b/Snyk.VisualStudio.Extension.2022/Theme/ColorExtension.cs
@@ -4,9 +4,9 @@ namespace Snyk.VisualStudio.Extension.Theme
 {
     public static class ColorExtension
     {
-        public static System.Windows.Media.SolidColorBrush ToBrush(this System.Drawing.Color color)
+        public static SolidColorBrush ToBrush(this System.Drawing.Color color)
         {
-            return new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromArgb(color.A, color.R, color.G, color.B));
+            return new SolidColorBrush(Color.FromArgb(color.A, color.R, color.G, color.B));
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Theme/ColorExtension.cs
+++ b/Snyk.VisualStudio.Extension.2022/Theme/ColorExtension.cs
@@ -1,10 +1,23 @@
-﻿namespace Snyk.VisualStudio.Extension.Theme
+﻿using System.Windows.Media;
+
+namespace Snyk.VisualStudio.Extension.Theme
 {
     public static class ColorExtension
     {
         public static System.Windows.Media.SolidColorBrush ToBrush(this System.Drawing.Color color)
         {
             return new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromArgb(color.A, color.R, color.G, color.B));
+        }
+        public static System.Windows.Media.Color ToColor(this System.Windows.Media.Brush brush)
+        {
+            if (brush is SolidColorBrush solidColorBrush)
+            {
+                // Extract the color from the SolidColorBrush
+                var mediaColor = solidColorBrush.Color;
+                return Color.FromArgb(mediaColor.A, mediaColor.R, mediaColor.G, mediaColor.B);
+            }
+
+            return Color.FromArgb(0, 0, 0, 0);
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Theme/ColorExtension.cs
+++ b/Snyk.VisualStudio.Extension.2022/Theme/ColorExtension.cs
@@ -8,16 +8,5 @@ namespace Snyk.VisualStudio.Extension.Theme
         {
             return new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromArgb(color.A, color.R, color.G, color.B));
         }
-        public static System.Windows.Media.Color ToColor(this System.Windows.Media.Brush brush)
-        {
-            if (brush is SolidColorBrush solidColorBrush)
-            {
-                // Extract the color from the SolidColorBrush
-                var mediaColor = solidColorBrush.Color;
-                return Color.FromArgb(mediaColor.A, mediaColor.R, mediaColor.G, mediaColor.B);
-            }
-
-            return Color.FromArgb(0, 0, 0, 0);
-        }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.cs
@@ -60,7 +60,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             html = html.Replace("var(--circle-color)", borderColor);
             html = html.Replace("var(--input-border)", borderColor);
             
-            html = html.Replace("var(--ide-background-color)", isDarkTheme ? "#242424" : "#fbfbfb");
+            html = html.Replace("var(--ide-background-color)", isDarkTheme ? "#242424" : "#FBFBFB");
             var ideHeaders = """
                              <head>
                              <meta http-equiv='Content-Type' content='text/html; charset=unicode' />

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.cs
@@ -59,14 +59,8 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             html = html.Replace("var(--code-background-color)", VSColorTheme.GetThemedColor(EnvironmentColors.EditorExpansionFillBrushKey).ToHex());
             html = html.Replace("var(--circle-color)", borderColor);
             html = html.Replace("var(--input-border)", borderColor);
-            
+            html = html.Replace("var(--main-font-size)", "15px");
             html = html.Replace("var(--ide-background-color)", isDarkTheme ? "#242424" : "#FBFBFB");
-            var ideHeaders = """
-                             <head>
-                             <meta http-equiv='Content-Type' content='text/html; charset=unicode' />
-                             <meta http-equiv='X-UA-Compatible' content='IE=edge' /> 
-                             """;
-            html = html.Replace("<head>", ideHeaders);
             html = html.Replace("${headerEnd}", "");
             var nonce = GetNonce();
             html = html.Replace("${nonce}", nonce);

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System;
 using Microsoft.VisualStudio.PlatformUI;
+using Snyk.VisualStudio.Extension.Theme;
 
 namespace Snyk.VisualStudio.Extension.UI.Html
 {
@@ -40,6 +41,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
 
         public virtual string ReplaceCssVariables(string html)
         {
+            var isDarkTheme = ThemeInfo.IsDarkTheme();
             var css = "<style nonce=\"${nonce}\">";
             css += GetCss();
 
@@ -56,7 +58,9 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             html = html.Replace("var(--horizontal-border-color)", VSColorTheme.GetThemedColor(EnvironmentColors.ClassDesignerDefaultShapeTextBrushKey).ToHex());
             html = html.Replace("var(--code-background-color)", VSColorTheme.GetThemedColor(EnvironmentColors.EditorExpansionFillBrushKey).ToHex());
             html = html.Replace("var(--circle-color)", borderColor);
-
+            html = html.Replace("var(--input-border)", borderColor);
+            
+            html = html.Replace("var(--ide-background-color)", isDarkTheme ? "#242424" : "#fbfbfb");
             var ideHeaders = """
                              <head>
                              <meta http-equiv='Content-Type' content='text/html; charset=unicode' />

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/ColorExtension.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/ColorExtension.cs
@@ -5,6 +5,9 @@
         public static string ToHex(this System.Drawing.Color c)
             => $"#{c.R:X2}{c.G:X2}{c.B:X2}";
 
+        public static string ToHex(this System.Windows.Media.Color c)
+            => $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+
         private static string ToRGB(this System.Drawing.Color c)
             => $"rgb({c.R},{c.G},{c.B}, {c.A})";
     }

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlProviderFactory.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlProviderFactory.cs
@@ -2,9 +2,9 @@
 {
     public static class HtmlProviderFactory
     {
-        public static IHtmlProvider GetHtmlProvider(string product)
+        public static IHtmlProvider GetHtmlProvider(string provider)
         {
-            switch (product)
+            switch (provider)
             {
                 case Product.Code:
                     return CodeHtmlProvider.Instance;
@@ -12,9 +12,13 @@
                     return OssHtmlProvider.Instance;
                 case Product.Iac:
                     return IacHtmlProvider.Instance;
+                case "summary":
+                    return SummaryHtmlProvider.Instance;
+                case "static":
+                    return StaticHtmlProvider.Instance;
+                default:
+                    return null;
             }
-
-            return null;
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.cs
@@ -1,0 +1,80 @@
+﻿namespace Snyk.VisualStudio.Extension.UI.Html
+{
+    public class StaticHtmlProvider : BaseHtmlProvider
+    {
+        private static StaticHtmlProvider _instance;
+
+        public static StaticHtmlProvider Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new StaticHtmlProvider();
+                }
+                return _instance;
+            }
+        }
+        public override string GetInitScript()
+        {
+            return string.Empty;
+        }
+
+        public string GetInitHtml()
+        {
+            return @"
+                <!DOCTYPE html>
+                <html>
+                <head>
+                <meta http-equiv='Content-Type' content='text/html; charset=unicode' />
+                <meta http-equiv='X-UA-Compatible' content='IE=edge' />
+                <meta charset=""utf-8"" />
+                <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"" />
+                <meta http-equiv=""Content-Security-Policy""
+                      content=""style-src 'self' 'nonce-${nonce}' 'nonce-ideNonce' https://fonts.googleapis.com;
+                           script-src 'nonce-${nonce}' https://fonts.googleapis.com;
+                           font-src 'self' https://fonts.gstatic.com;"" />
+                  <style>
+                :root {
+                  font-size:15px;
+                }
+                p { font-size:1.3rem; margin: .8rem 0;  }
+                body { background-color: var(--ide-background-color); color: var(--text-color); font-family: sans-serif; padding: 12px; opacity: 0.4;}
+                .snx-loader { display:inline-block; width: 12px; height: 12px; border: 2px solid rgba(125,125,125,.65); border-bottom-color: transparent; border-radius: 50%; margin-right:.8rem; animation: spin 1s linear infinite;
+                }
+                .size-s { width: 12px; height: 12px; border-width:2px }
+                .size-m { width: 16px; height: 16px; border-width:3px; }
+                .size-l { width: 24px; height: 24px; border-width:4px; }
+                .hidden {display: none}
+                @keyframes spin {
+                  from { transform: rotate(0deg); }
+                  to { transform: rotate(360deg); }
+                }
+
+                .snx-h1 { font-size: 2rem; font-weight: 600; margin: .8rem 0; }
+
+                .snx-status { display:flex; align-items:center; padding: .4rem 1.2rem; background-color: rgba(255,255,255,.1); border-radius: 1rem; }
+
+                .snx-header { display: flow-root; gap:1.6rem; }
+                .snx-message { display: flex; align-items: center }
+
+                  </style>
+                </head>
+                <body>
+  
+                  <div class=""snx-header"">
+                    <h1 class=""snx-title snx-h1"">Snyk Security is loading...</h1>
+                  </div>
+                  <div class=""snx-summary"">
+                    <div class=""snx-status"">
+                      <span class=""snx-loader size-s""></span>
+                      <p class=""snx-message"">Waiting for the Snyk CLI to be downloaded and the Language Server to be initialized. </p>
+                    </div>
+                  </div>
+                </body>
+                </html>
+            ";
+        }
+
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.cs
@@ -17,7 +17,7 @@
         }
         public override string GetInitScript()
         {
-            return string.Empty;
+          return @"";
         }
 
         public string GetInitHtml()
@@ -39,7 +39,7 @@
                   font-size:15px;
                 }
                 p { font-size:1.3rem; margin: .8rem 0;  }
-                body { background-color: var(--ide-background-color); color: var(--text-color); font-family: sans-serif; padding: 12px; opacity: 0.4;}
+                body { background-color: var(--ide-background-color); color: var(--text-color); font-family: sans-serif; padding: 12px; }
                 .snx-loader { display:inline-block; width: 12px; height: 12px; border: 2px solid rgba(125,125,125,.65); border-bottom-color: transparent; border-radius: 50%; margin-right:.8rem; animation: spin 1s linear infinite;
                 }
                 .size-s { width: 12px; height: 12px; border-width:2px }

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.cs
@@ -1,4 +1,9 @@
-﻿namespace Snyk.VisualStudio.Extension.UI.Html
+﻿using Microsoft.VisualStudio.Shell;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Snyk.VisualStudio.Extension.UI.Html
 {
     public class StaticHtmlProvider : BaseHtmlProvider
     {
@@ -20,61 +25,19 @@
           return @"";
         }
 
-        public string GetInitHtml()
+        public async Task<string> GetInitHtmlAsync()
         {
-            return @"
-                <!DOCTYPE html>
-                <html>
-                <head>
-                <meta http-equiv='Content-Type' content='text/html; charset=unicode' />
-                <meta http-equiv='X-UA-Compatible' content='IE=edge' />
-                <meta charset=""utf-8"" />
-                <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"" />
-                <meta http-equiv=""Content-Security-Policy""
-                      content=""style-src 'self' 'nonce-${nonce}' 'nonce-ideNonce' https://fonts.googleapis.com;
-                           script-src 'nonce-${nonce}' https://fonts.googleapis.com;
-                           font-src 'self' https://fonts.gstatic.com;"" />
-                  <style>
-                :root {
-                  font-size:15px;
+            return await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                var assemblyLocation = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+                if (assemblyLocation == null) return string.Empty;
+                var path = Path.Combine(assemblyLocation, "Resources", "LoadingSummary.html");
+                using (var stream = new StreamReader(path))
+                {
+                    var html = await stream.ReadToEndAsync();
+                    return html;
                 }
-                p { font-size:1.3rem; margin: .8rem 0;  }
-                body { background-color: var(--ide-background-color); color: var(--text-color); font-family: sans-serif; padding: 12px; }
-                .snx-loader { display:inline-block; width: 12px; height: 12px; border: 2px solid rgba(125,125,125,.65); border-bottom-color: transparent; border-radius: 50%; margin-right:.8rem; animation: spin 1s linear infinite;
-                }
-                .size-s { width: 12px; height: 12px; border-width:2px }
-                .size-m { width: 16px; height: 16px; border-width:3px; }
-                .size-l { width: 24px; height: 24px; border-width:4px; }
-                .hidden {display: none}
-                @keyframes spin {
-                  from { transform: rotate(0deg); }
-                  to { transform: rotate(360deg); }
-                }
-
-                .snx-h1 { font-size: 2rem; font-weight: 600; margin: .8rem 0; }
-
-                .snx-status { display:flex; align-items:center; padding: .4rem 1.2rem; background-color: rgba(255,255,255,.1); border-radius: 1rem; }
-
-                .snx-header { display: flow-root; gap:1.6rem; }
-                .snx-message { display: flex; align-items: center }
-
-                  </style>
-                </head>
-                <body>
-  
-                  <div class=""snx-header"">
-                    <h1 class=""snx-title snx-h1"">Snyk Security is loading...</h1>
-                  </div>
-                  <div class=""snx-summary"">
-                    <div class=""snx-status"">
-                      <span class=""snx-loader size-s""></span>
-                      <p class=""snx-message"">Waiting for the Snyk CLI to be downloaded and the Language Server to be initialized. </p>
-                    </div>
-                  </div>
-                </body>
-                </html>
-            ";
+            });
         }
-
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.Shell;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
 

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/SummaryHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/SummaryHtmlProvider.cs
@@ -18,15 +18,6 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                 return _instance;
             }
         }
-        public override string GetInitScript()
-        {
-            var initScript = base.GetInitScript();
-            return initScript + @"
-             // Hide scrollbar
-             document.body.style.overflow = 'hidden';
-            ";
-        }
-      
         public override string ReplaceCssVariables(string html)
         {
             html = html.Replace("${ideFunc}", "window.external.EnableDelta(isEnabled);");

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/SummaryHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/SummaryHtmlProvider.cs
@@ -22,25 +22,24 @@ namespace Snyk.VisualStudio.Extension.UI.Html
         {
             var initScript = base.GetInitScript();
             return initScript + @"
-             if(document.getElementById('totalIssues')){
-                document.getElementById('totalIssues').onclick = function(e) {
-                    window.external.ToggleDelta(false);
-                    };
-                }
-            if(document.getElementById('newIssues')){
-                document.getElementById('newIssues').onclick = function(e) {
-                    window.external.ToggleDelta(true);
-                    };
-            }
+             // Hide scrollbar
+             document.body.style.overflow = 'hidden';
             ";
         }
-
+      
         public override string ReplaceCssVariables(string html)
         {
+            html = html.Replace("${ideFunc}", "window.external.EnableDelta(isEnabled);");
             html = base.ReplaceCssVariables(html);
 
             return html;
         }
-
+        public override string GetCss()
+        {
+            return @"
+            body { overflow: hidden; }
+            .body-padding { padding: 0px 4px 8px 4px; }
+";
+        }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/SummaryHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/SummaryHtmlProvider.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.VisualStudio.PlatformUI;
+using System;
+
+namespace Snyk.VisualStudio.Extension.UI.Html
+{
+    public class SummaryHtmlProvider : BaseHtmlProvider
+    {
+        private static SummaryHtmlProvider _instance;
+
+        public static SummaryHtmlProvider Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new SummaryHtmlProvider();
+                }
+                return _instance;
+            }
+        }
+        public override string GetInitScript()
+        {
+            var initScript = base.GetInitScript();
+            return initScript + @"
+             if(document.getElementById('totalIssues')){
+                document.getElementById('totalIssues').onclick = function(e) {
+                    window.external.ToggleDelta(false);
+                    };
+                }
+            if(document.getElementById('newIssues')){
+                document.getElementById('newIssues').onclick = function(e) {
+                    window.external.ToggleDelta(true);
+                    };
+            }
+            ";
+        }
+
+        public override string ReplaceCssVariables(string html)
+        {
+            html = base.ReplaceCssVariables(html);
+
+            return html;
+        }
+
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/SummaryHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/SummaryHtmlProvider.cs
@@ -34,12 +34,13 @@ namespace Snyk.VisualStudio.Extension.UI.Html
 
             return html;
         }
+
         public override string GetCss()
         {
             return @"
             body { overflow: hidden; }
             .body-padding { padding: 0px 4px 8px 4px; }
-";
+            ";
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SnykScriptManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SnykScriptManager.cs
@@ -47,12 +47,12 @@ namespace Snyk.VisualStudio.Extension.UI.Toolwindow
             Process.Start(link);
         }
 
-        public void ToggleDelta(bool isEnabled)
+        public void EnableDelta(bool isEnabled)
         {
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 this.serviceProvider.Options.EnableDeltaFindings = isEnabled;
-                this.serviceProvider.SnykOptionsManager.Save(this.serviceProvider.Options);
+                this.serviceProvider.SnykOptionsManager.Save(this.serviceProvider.Options, false);
                 await LanguageClientHelper.LanguageClientManager().DidChangeConfigurationAsync(SnykVSPackage.Instance.DisposalToken);
 
             }).FireAndForget();

--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SnykScriptManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SnykScriptManager.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Serilog;
+using Snyk.VisualStudio.Extension.Language;
 
 namespace Snyk.VisualStudio.Extension.UI.Toolwindow
 {
@@ -12,12 +13,17 @@ namespace Snyk.VisualStudio.Extension.UI.Toolwindow
     public class SnykScriptManager
     {
         private static readonly ILogger Logger = LogManager.ForContext<SnykScriptManager>();
+        private readonly ISnykServiceProvider serviceProvider;
 
+        public SnykScriptManager(ISnykServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+        }
         public void OpenFileInEditor(string filePath, string startLine, string endLine, string startCharacter, string endCharacter)
         {
             try
             {
-                Task.Run(async () =>
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     VsCodeService.Instance.OpenAndNavigate(
@@ -39,6 +45,17 @@ namespace Snyk.VisualStudio.Extension.UI.Toolwindow
             if (string.IsNullOrEmpty(link) || !link.StartsWith("http"))
                 return;
             Process.Start(link);
+        }
+
+        public void ToggleDelta(bool isEnabled)
+        {
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                this.serviceProvider.Options.EnableDeltaFindings = isEnabled;
+                this.serviceProvider.SnykOptionsManager.Save(this.serviceProvider.Options);
+                await LanguageClientHelper.LanguageClientManager().DidChangeConfigurationAsync(SnykVSPackage.Instance.DisposalToken);
+
+            }).FireAndForget();
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SnykToolWindowControl.xaml
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SnykToolWindowControl.xaml
@@ -20,13 +20,19 @@
         <Grid.ColumnDefinitions>
             <ColumnDefinition></ColumnDefinition>
         </Grid.ColumnDefinitions>
-        <Grid Grid.Row="3" Grid.Column="0" Name="mainGrid">
+        <Grid Grid.Row="1" Grid.Column="0" Name="mainGrid">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="3*"/>
                 <ColumnDefinition Width="5"/>
                 <ColumnDefinition Width="6*"/>
             </Grid.ColumnDefinitions>
-            <tree:SnykFilterableTree x:Name="resultsTree" SelectedVulnerabilityChanged="VulnerabilitiesTree_SelectetVulnerabilityChanged"/>
+            <window:SummaryHtmlPanel  
+ x:Name="SummaryPanel" 
+Height="115"
+                            VerticalAlignment="Top"
+                            
+                            />
+            <tree:SnykFilterableTree x:Name="resultsTree" SelectedVulnerabilityChanged="VulnerabilitiesTree_SelectetVulnerabilityChanged" Margin="0, 115, 0, 0"/>
 
             <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" Background="{DynamicResource VsBrush.Window}" Foreground="{DynamicResource VsBrush.WindowText}"/>
 

--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SnykToolWindowControl.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SnykToolWindowControl.xaml.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -14,6 +16,7 @@ using Snyk.VisualStudio.Extension.Commands;
 using Snyk.VisualStudio.Extension.Language;
 using Snyk.VisualStudio.Extension.Service;
 using Snyk.VisualStudio.Extension.Settings;
+using Snyk.VisualStudio.Extension.Theme;
 using Snyk.VisualStudio.Extension.UI.Notifications;
 using Snyk.VisualStudio.Extension.UI.Tree;
 using Task = System.Threading.Tasks.Task;
@@ -47,9 +50,14 @@ namespace Snyk.VisualStudio.Extension.UI.Toolwindow
 
             this.DescriptionPanel.Init();
 
+            this.SummaryPanel.Init();
             this.messagePanel.Context = this.context;
         }
 
+        public System.Windows.Media.Color GetBackgroundColor()
+        {
+            return this.Background.ToColor();         
+        }
         /// <summary>
         /// Gets a value indicating whether VulnerabilitiesTree.
         /// </summary>

--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SnykToolWindowControl.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SnykToolWindowControl.xaml.cs
@@ -54,10 +54,6 @@ namespace Snyk.VisualStudio.Extension.UI.Toolwindow
             this.messagePanel.Context = this.context;
         }
 
-        public System.Windows.Media.Color GetBackgroundColor()
-        {
-            return this.Background.ToColor();         
-        }
         /// <summary>
         /// Gets a value indicating whether VulnerabilitiesTree.
         /// </summary>

--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SummaryHtmlPanel.xaml
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SummaryHtmlPanel.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"              
+             xmlns:toolkit="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
+             x:Class="Snyk.VisualStudio.Extension.UI.Toolwindow.SummaryHtmlPanel"
+             toolkit:Themes.UseVsTheme="True"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Border BorderBrush="{x:Static SystemColors.WindowFrameBrush}" BorderThickness="1">
+    <Grid>
+        <WebBrowser Name="SummaryHtmlViewer" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
+                    />
+    </Grid>
+    </Border>
+</UserControl>

--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SummaryHtmlPanel.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SummaryHtmlPanel.xaml.cs
@@ -5,22 +5,22 @@ using UserControl = System.Windows.Controls.UserControl;
 
 namespace Snyk.VisualStudio.Extension.UI.Toolwindow
 {
-    public partial class HtmlDescriptionPanel : UserControl
+    public partial class SummaryHtmlPanel : UserControl
     {
         private IHtmlProvider htmlProvider;
         private WebBrowserHostUIHandler _wbHandler;
 
-        public HtmlDescriptionPanel()
+        public SummaryHtmlPanel()
         {
             this.InitializeComponent();
 
-            _wbHandler = new WebBrowserHostUIHandler(HtmlViewer)
+            _wbHandler = new WebBrowserHostUIHandler(SummaryHtmlViewer)
             {
                 IsWebBrowserContextMenuEnabled = false,
                 ScriptErrorsSuppressed = true,
             };
 
-            HtmlViewer.ObjectForScripting = new SnykScriptManager(SnykVSPackage.ServiceProvider);
+            SummaryHtmlViewer.ObjectForScripting = new SnykScriptManager(SnykVSPackage.ServiceProvider);
             _wbHandler.LoadCompleted += HtmlViewerOnLoadCompleted;
         }
 
@@ -30,36 +30,37 @@ namespace Snyk.VisualStudio.Extension.UI.Toolwindow
             {
                 if (htmlProvider == null)
                     return;
-                HtmlViewer.InvokeScript("eval", new string[] { htmlProvider.GetInitScript() });
+                SummaryHtmlViewer.InvokeScript("eval", new string[] { htmlProvider.GetInitScript() });
             }
             catch
             {
 
             }
         }
-
         public void SetContent(string html, string product)
         {
             if (string.IsNullOrEmpty(html))
                 return;
-            HtmlViewer.Visibility = Visibility.Visible;
 
-            this.htmlProvider = HtmlProviderFactory.GetHtmlProvider(product);
+            this.htmlProvider = HtmlProviderFactory.GetHtmlProvider("summary");
             if (this.htmlProvider == null)
                 return;
-            HtmlViewer.InvalidateVisual();
-            HtmlViewer.UpdateLayout();
             html = htmlProvider.ReplaceCssVariables(html);
-            HtmlViewer.NavigateToString(html);
+            SummaryHtmlViewer.NavigateToString(html);
+            SummaryHtmlViewer.InvalidateVisual();
+            SummaryHtmlViewer.UpdateLayout();
         }
 
         public void Init()
         {
-            HtmlViewer.Visibility = Visibility.Collapsed;
-            HtmlViewer.NavigateToString("<html><body style='margin:0;padding:0;'>Loading...</body></html>");
-            HtmlViewer.InvalidateVisual();
-            HtmlViewer.UpdateLayout();
+            var provider = (StaticHtmlProvider) HtmlProviderFactory.GetHtmlProvider("static");
+            SummaryHtmlViewer.NavigateToString(provider.ReplaceCssVariables(provider.GetInitHtml()));
+            
+            SummaryHtmlViewer.InvalidateVisual();
+            SummaryHtmlViewer.UpdateLayout();
         }
+
+        
     }
 }
 

--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SummaryHtmlPanel.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SummaryHtmlPanel.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using System.Windows.Navigation;
+using Microsoft.VisualStudio.Shell;
 using Snyk.VisualStudio.Extension.UI.Html;
 using UserControl = System.Windows.Controls.UserControl;
 
@@ -53,11 +54,18 @@ namespace Snyk.VisualStudio.Extension.UI.Toolwindow
 
         public void Init()
         {
-            var provider = (StaticHtmlProvider) HtmlProviderFactory.GetHtmlProvider("static");
-            SummaryHtmlViewer.NavigateToString(provider.ReplaceCssVariables(provider.GetInitHtml()));
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                var provider = (StaticHtmlProvider)HtmlProviderFactory.GetHtmlProvider("static");
+                var html = provider.ReplaceCssVariables(await provider.GetInitHtmlAsync());
+                
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                SummaryHtmlViewer.NavigateToString(html);
+
+                SummaryHtmlViewer.InvalidateVisual();
+                SummaryHtmlViewer.UpdateLayout();
+            });
             
-            SummaryHtmlViewer.InvalidateVisual();
-            SummaryHtmlViewer.UpdateLayout();
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SummaryHtmlPanel.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SummaryHtmlPanel.xaml.cs
@@ -59,8 +59,6 @@ namespace Snyk.VisualStudio.Extension.UI.Toolwindow
             SummaryHtmlViewer.InvalidateVisual();
             SummaryHtmlViewer.UpdateLayout();
         }
-
-        
     }
 }
 


### PR DESCRIPTION
### Description

This PR introduces the HTML Summary Panel which we get through the `$/snyk.scanSummary` notification and handle toggling Delta Findings option on/off trough the HTML toggle element.

- Create `ToolWindow` for the Summary Panel
- Handle `$/snyk.scanSummary` notification and update the content of the SummaryPanel ToolWindow with the recieved HTML
- Add additional IDE-specific styling and add needed CSS variables
- Handle toggling the Delta Setting by sending a `didChangeConfiguration` when toggling between the **New** and **All Issues** in the summary panel. 
### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
![image](https://github.com/user-attachments/assets/c7fc2a88-0fb9-47c8-bc8b-00063bc32e43)


_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
