### PR TITLE
fix: total issue counts for code scans [IDE-944]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Snyk Security Changelog
+## [2.1.1]
+### Fixed
+- Fixed total issue counts for code scans being wrong.
+
 ## [2.1.0]
 ### Changed
 - New Summary Panel for scan information and Net New Issues filtering.

--- a/Snyk.VisualStudio.Extension.2022/UI/Tree/SnykFilterableTree.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Tree/SnykFilterableTree.xaml.cs
@@ -129,6 +129,7 @@ namespace Snyk.VisualStudio.Extension.UI.Tree
                 return;
             }
             rootNode.Clean();
+            var totalIssueCount = 0;
             var criticalSeverityCount = 0;
             var highSeverityCount = 0;
             var mediumSeverityCount = 0;
@@ -155,14 +156,16 @@ namespace Snyk.VisualStudio.Extension.UI.Tree
 
                 ignoredIssueCount += issueList.Count(suggestion => suggestion.IsIgnored);
 
-                issueList = FilterIgnoredIssues(options, issueList).ToList();
-                
+                totalIssueCount += issueList.Count;
+
                 criticalSeverityCount += issueList.Count(suggestion => suggestion.Severity == Severity.Critical);
                 highSeverityCount += issueList.Count(suggestion => suggestion.Severity == Severity.High);
                 mediumSeverityCount += issueList.Count(suggestion => suggestion.Severity == Severity.Medium);
                 lowSeverityCount += issueList.Count(suggestion => suggestion.Severity == Severity.Low);
 
                 fixableIssueCount += issueList.Count(suggestion => suggestion.HasFix());
+
+                issueList = FilterIgnoredIssues(options, issueList).ToList();
 
                 issueList.Sort((issue1, issue2) => Severity.ToInt(issue2.Severity) - Severity.ToInt(issue1.Severity));
 
@@ -178,10 +181,6 @@ namespace Snyk.VisualStudio.Extension.UI.Tree
                     fileTreeNodes.Add(fileNode);
                 }
             }
-
-            var totalIssueCount = scanResultDictionary
-                .Where(x => x.Key.Replace("\\", "/").TrimEnd('/').Contains(currentFolder))
-                .SelectMany(x => x.Value).Count();
 
             AddInfoTreeNodes(rootNode, totalIssueCount, ignoredIssueCount, fixableIssueCount, options);
 


### PR DESCRIPTION
### Description

Previously the total issue counts for "Code Security" and "Code Quality" were being combined in the tree navigation.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

<img width="346" alt="Screenshot 2025-02-28 at 13 51 28" src="https://github.com/user-attachments/assets/f910ac4b-d5df-4d3f-83e0-6dee73d6b533" />
<img width="365" alt="Screenshot 2025-02-28 at 14 03 48" src="https://github.com/user-attachments/assets/2ae24ed8-00d0-424c-b92e-3c205676ea5b" />

