### PR TITLE
fix: title for OSS issue tree node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Security Changelog
 
+## [2.1.1]
+### Changed
+### Fixed
+- Title for OSS issue tree node.
+
 ## [2.1.0]
 ### Changed
 - New Summary Panel for scan information and Net New Issues filtering.

--- a/Snyk.VisualStudio.Extension.2022/UI/Tree/OssFileTreeNode.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Tree/OssFileTreeNode.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 
 namespace Snyk.VisualStudio.Extension.UI.Tree
@@ -6,10 +7,19 @@ namespace Snyk.VisualStudio.Extension.UI.Tree
     public class OssFileTreeNode : FileTreeNode
     {
         public OssFileTreeNode(TreeNode parent) : base(parent) { }
-        public override string Title => this.ProjectName.Replace("/", "\\") + "\\" + this.DisplayTargetFile;
+
+        public override string Title
+        {
+            get
+            {
+                var mainDirUri = new Uri(FolderName);
+                var fileUri = new Uri(FileName);
+                var relativeUri = mainDirUri.MakeRelativeUri(fileUri);
+                return Uri.UnescapeDataString(relativeUri.ToString()).Replace("/", "\\");
+            }
+        }
+
         public override string Icon => SnykIconProvider.GetPackageManagerIcon(this.PackageManager);
-        private string ProjectName => this.IssueList.FirstOrDefault()?.AdditionalData?.ProjectName ?? "";
         private string PackageManager => this.IssueList.FirstOrDefault()?.AdditionalData?.PackageManager ?? "";
-        private string DisplayTargetFile => Path.GetFileName(this.IssueList.FirstOrDefault()?.AdditionalData?.DisplayTargetFile ?? "");
     }
 }


### PR DESCRIPTION
### Description
In a multi-project setup OSS issue tree node was showing "rootFolder/project.assets.json"
Making it very hard to distinguish in which this specific OSS issue was found.

This fix will instead calculate a relative path from currentFolder and the absolute filePath where the OSS issue was found.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
