### PR TITLE
fix: update custom endpoint description [IDE-1081]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykGeneralSettingsUserControl.Designer.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykGeneralSettingsUserControl.Designer.cs
@@ -33,6 +33,7 @@ namespace Snyk.VisualStudio.Extension.Settings
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SnykGeneralSettingsUserControl));
             this.customEndpointTextBox = new System.Windows.Forms.TextBox();
             this.customEndpointLabel = new System.Windows.Forms.Label();
             this.organizationLabel = new System.Windows.Forms.Label();
@@ -62,7 +63,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             // 
             // customEndpointTextBox
             // 
-            this.customEndpointTextBox.Location = new System.Drawing.Point(169, 260);
+            this.customEndpointTextBox.Location = new System.Drawing.Point(169, 274);
             this.customEndpointTextBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.customEndpointTextBox.Name = "customEndpointTextBox";
             this.customEndpointTextBox.Size = new System.Drawing.Size(399, 20);
@@ -73,7 +74,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             // customEndpointLabel
             // 
             this.customEndpointLabel.AutoSize = true;
-            this.customEndpointLabel.Location = new System.Drawing.Point(5, 262);
+            this.customEndpointLabel.Location = new System.Drawing.Point(5, 276);
             this.customEndpointLabel.Name = "customEndpointLabel";
             this.customEndpointLabel.Size = new System.Drawing.Size(89, 13);
             this.customEndpointLabel.TabIndex = 1;
@@ -82,7 +83,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             // organizationLabel
             // 
             this.organizationLabel.AutoSize = true;
-            this.organizationLabel.Location = new System.Drawing.Point(5, 317);
+            this.organizationLabel.Location = new System.Drawing.Point(5, 331);
             this.organizationLabel.Name = "organizationLabel";
             this.organizationLabel.Size = new System.Drawing.Size(69, 13);
             this.organizationLabel.TabIndex = 2;
@@ -90,7 +91,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             // 
             // organizationTextBox
             // 
-            this.organizationTextBox.Location = new System.Drawing.Point(169, 317);
+            this.organizationTextBox.Location = new System.Drawing.Point(169, 331);
             this.organizationTextBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.organizationTextBox.Name = "organizationTextBox";
             this.organizationTextBox.Size = new System.Drawing.Size(399, 20);
@@ -120,7 +121,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             // ignoreUnknownCACheckBox
             // 
             this.ignoreUnknownCACheckBox.AutoSize = true;
-            this.ignoreUnknownCACheckBox.Location = new System.Drawing.Point(172, 284);
+            this.ignoreUnknownCACheckBox.Location = new System.Drawing.Point(172, 298);
             this.ignoreUnknownCACheckBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.ignoreUnknownCACheckBox.Name = "ignoreUnknownCACheckBox";
             this.ignoreUnknownCACheckBox.Size = new System.Drawing.Size(120, 17);
@@ -174,7 +175,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             // 
             this.SnykRegionsLink.AutoSize = true;
             this.SnykRegionsLink.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.SnykRegionsLink.Location = new System.Drawing.Point(175, 238);
+            this.SnykRegionsLink.Location = new System.Drawing.Point(175, 256);
             this.SnykRegionsLink.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.SnykRegionsLink.Name = "SnykRegionsLink";
             this.SnykRegionsLink.Size = new System.Drawing.Size(114, 13);
@@ -191,11 +192,9 @@ namespace Snyk.VisualStudio.Extension.Settings
             this.endpointDescriptionText.Margin = new System.Windows.Forms.Padding(4);
             this.endpointDescriptionText.Name = "endpointDescriptionText";
             this.endpointDescriptionText.ReadOnly = true;
-            this.endpointDescriptionText.Size = new System.Drawing.Size(571, 46);
+            this.endpointDescriptionText.Size = new System.Drawing.Size(571, 68);
             this.endpointDescriptionText.TabIndex = 20;
-            this.endpointDescriptionText.Text = "If you\'re using OAuth2, API endpoint configuration is automatic. \nFor private ins" +
-    "tances, contact your team or account manager.\nOtherwise, for public regional ins" +
-    "tances, see the docs:\n";
+            this.endpointDescriptionText.Text = resources.GetString("endpointDescriptionText.Text");
             // 
             // authMethodDescription
             // 
@@ -236,7 +235,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             // OrganizationInfoLink
             // 
             this.OrganizationInfoLink.AutoSize = true;
-            this.OrganizationInfoLink.Location = new System.Drawing.Point(175, 393);
+            this.OrganizationInfoLink.Location = new System.Drawing.Point(175, 403);
             this.OrganizationInfoLink.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.OrganizationInfoLink.Name = "OrganizationInfoLink";
             this.OrganizationInfoLink.Size = new System.Drawing.Size(150, 13);
@@ -248,7 +247,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             // OrgDescriptionText
             // 
             this.OrgDescriptionText.AutoSize = true;
-            this.OrgDescriptionText.Location = new System.Drawing.Point(166, 339);
+            this.OrgDescriptionText.Location = new System.Drawing.Point(166, 353);
             this.OrgDescriptionText.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.OrgDescriptionText.Name = "OrgDescriptionText";
             this.OrgDescriptionText.Size = new System.Drawing.Size(376, 39);

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykGeneralSettingsUserControl.Designer.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykGeneralSettingsUserControl.Designer.cs
@@ -43,6 +43,8 @@ namespace Snyk.VisualStudio.Extension.Settings
             this.authenticateButton = new System.Windows.Forms.Button();
             this.errorProvider = new System.Windows.Forms.ErrorProvider(this.components);
             this.generalSettingsGroupBox = new System.Windows.Forms.GroupBox();
+            this.SnykRegionsLink = new System.Windows.Forms.LinkLabel();
+            this.endpointDescriptionText = new System.Windows.Forms.RichTextBox();
             this.authMethodDescription = new System.Windows.Forms.RichTextBox();
             this.authType = new System.Windows.Forms.ComboBox();
             this.label2 = new System.Windows.Forms.Label();
@@ -60,10 +62,10 @@ namespace Snyk.VisualStudio.Extension.Settings
             // 
             // customEndpointTextBox
             // 
-            this.customEndpointTextBox.Location = new System.Drawing.Point(172, 197);
+            this.customEndpointTextBox.Location = new System.Drawing.Point(169, 260);
             this.customEndpointTextBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.customEndpointTextBox.Name = "customEndpointTextBox";
-            this.customEndpointTextBox.Size = new System.Drawing.Size(399, 22);
+            this.customEndpointTextBox.Size = new System.Drawing.Size(399, 20);
             this.customEndpointTextBox.TabIndex = 0;
             this.customEndpointTextBox.LostFocus += new System.EventHandler(this.CustomEndpointTextBox_LostFocus);
             this.customEndpointTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.CustomEndpointTextBox_Validating);
@@ -71,27 +73,27 @@ namespace Snyk.VisualStudio.Extension.Settings
             // customEndpointLabel
             // 
             this.customEndpointLabel.AutoSize = true;
-            this.customEndpointLabel.Location = new System.Drawing.Point(5, 201);
+            this.customEndpointLabel.Location = new System.Drawing.Point(5, 262);
             this.customEndpointLabel.Name = "customEndpointLabel";
-            this.customEndpointLabel.Size = new System.Drawing.Size(110, 16);
+            this.customEndpointLabel.Size = new System.Drawing.Size(89, 13);
             this.customEndpointLabel.TabIndex = 1;
             this.customEndpointLabel.Text = "Custom endpoint:";
             // 
             // organizationLabel
             // 
             this.organizationLabel.AutoSize = true;
-            this.organizationLabel.Location = new System.Drawing.Point(5, 257);
+            this.organizationLabel.Location = new System.Drawing.Point(5, 317);
             this.organizationLabel.Name = "organizationLabel";
-            this.organizationLabel.Size = new System.Drawing.Size(85, 16);
+            this.organizationLabel.Size = new System.Drawing.Size(69, 13);
             this.organizationLabel.TabIndex = 2;
             this.organizationLabel.Text = "Organization:";
             // 
             // organizationTextBox
             // 
-            this.organizationTextBox.Location = new System.Drawing.Point(172, 256);
+            this.organizationTextBox.Location = new System.Drawing.Point(169, 317);
             this.organizationTextBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.organizationTextBox.Name = "organizationTextBox";
-            this.organizationTextBox.Size = new System.Drawing.Size(399, 22);
+            this.organizationTextBox.Size = new System.Drawing.Size(399, 20);
             this.organizationTextBox.TabIndex = 3;
             this.organizationTextBox.TextChanged += new System.EventHandler(this.organizationTextBox_TextChanged);
             // 
@@ -100,17 +102,17 @@ namespace Snyk.VisualStudio.Extension.Settings
             this.tokenLabel.AutoSize = true;
             this.tokenLabel.Location = new System.Drawing.Point(5, 161);
             this.tokenLabel.Name = "tokenLabel";
-            this.tokenLabel.Size = new System.Drawing.Size(49, 16);
+            this.tokenLabel.Size = new System.Drawing.Size(41, 13);
             this.tokenLabel.TabIndex = 4;
             this.tokenLabel.Text = "Token:";
             // 
             // tokenTextBox
             // 
-            this.tokenTextBox.Location = new System.Drawing.Point(172, 158);
+            this.tokenTextBox.Location = new System.Drawing.Point(169, 158);
             this.tokenTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.tokenTextBox.Name = "tokenTextBox";
             this.tokenTextBox.PasswordChar = '*';
-            this.tokenTextBox.Size = new System.Drawing.Size(399, 22);
+            this.tokenTextBox.Size = new System.Drawing.Size(399, 20);
             this.tokenTextBox.TabIndex = 5;
             this.tokenTextBox.TextChanged += new System.EventHandler(this.TokenTextBox_TextChanged);
             this.tokenTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.TokenTextBox_Validating);
@@ -118,10 +120,10 @@ namespace Snyk.VisualStudio.Extension.Settings
             // ignoreUnknownCACheckBox
             // 
             this.ignoreUnknownCACheckBox.AutoSize = true;
-            this.ignoreUnknownCACheckBox.Location = new System.Drawing.Point(172, 223);
+            this.ignoreUnknownCACheckBox.Location = new System.Drawing.Point(172, 284);
             this.ignoreUnknownCACheckBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.ignoreUnknownCACheckBox.Name = "ignoreUnknownCACheckBox";
-            this.ignoreUnknownCACheckBox.Size = new System.Drawing.Size(143, 20);
+            this.ignoreUnknownCACheckBox.Size = new System.Drawing.Size(120, 17);
             this.ignoreUnknownCACheckBox.TabIndex = 6;
             this.ignoreUnknownCACheckBox.Text = "Ignore unknown CA";
             this.ignoreUnknownCACheckBox.UseVisualStyleBackColor = true;
@@ -144,6 +146,8 @@ namespace Snyk.VisualStudio.Extension.Settings
             // 
             // generalSettingsGroupBox
             // 
+            this.generalSettingsGroupBox.Controls.Add(this.SnykRegionsLink);
+            this.generalSettingsGroupBox.Controls.Add(this.endpointDescriptionText);
             this.generalSettingsGroupBox.Controls.Add(this.authMethodDescription);
             this.generalSettingsGroupBox.Controls.Add(this.authType);
             this.generalSettingsGroupBox.Controls.Add(this.label2);
@@ -161,16 +165,43 @@ namespace Snyk.VisualStudio.Extension.Settings
             this.generalSettingsGroupBox.Margin = new System.Windows.Forms.Padding(11, 10, 11, 10);
             this.generalSettingsGroupBox.Name = "generalSettingsGroupBox";
             this.generalSettingsGroupBox.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.generalSettingsGroupBox.Size = new System.Drawing.Size(747, 402);
+            this.generalSettingsGroupBox.Size = new System.Drawing.Size(747, 427);
             this.generalSettingsGroupBox.TabIndex = 17;
             this.generalSettingsGroupBox.TabStop = false;
             this.generalSettingsGroupBox.Text = "General Settings";
+            // 
+            // SnykRegionsLink
+            // 
+            this.SnykRegionsLink.AutoSize = true;
+            this.SnykRegionsLink.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.SnykRegionsLink.Location = new System.Drawing.Point(175, 238);
+            this.SnykRegionsLink.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.SnykRegionsLink.Name = "SnykRegionsLink";
+            this.SnykRegionsLink.Size = new System.Drawing.Size(114, 13);
+            this.SnykRegionsLink.TabIndex = 21;
+            this.SnykRegionsLink.TabStop = true;
+            this.SnykRegionsLink.Text = "Available Snyk regions";
+            this.SnykRegionsLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.SnykRegionsLink_LinkClicked);
+            // 
+            // endpointDescriptionText
+            // 
+            this.endpointDescriptionText.BackColor = System.Drawing.SystemColors.Control;
+            this.endpointDescriptionText.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.endpointDescriptionText.Location = new System.Drawing.Point(169, 186);
+            this.endpointDescriptionText.Margin = new System.Windows.Forms.Padding(4);
+            this.endpointDescriptionText.Name = "endpointDescriptionText";
+            this.endpointDescriptionText.ReadOnly = true;
+            this.endpointDescriptionText.Size = new System.Drawing.Size(571, 46);
+            this.endpointDescriptionText.TabIndex = 20;
+            this.endpointDescriptionText.Text = "If you\'re using OAuth2, API endpoint configuration is automatic. \nFor private ins" +
+    "tances, contact your team or account manager.\nOtherwise, for public regional ins" +
+    "tances, see the docs:\n";
             // 
             // authMethodDescription
             // 
             this.authMethodDescription.BackColor = System.Drawing.SystemColors.Control;
             this.authMethodDescription.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.authMethodDescription.Location = new System.Drawing.Point(169, 65);
+            this.authMethodDescription.Location = new System.Drawing.Point(169, 64);
             this.authMethodDescription.Margin = new System.Windows.Forms.Padding(4);
             this.authMethodDescription.Name = "authMethodDescription";
             this.authMethodDescription.ReadOnly = true;
@@ -186,7 +217,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             this.authType.Items.AddRange(new object[] {
             "OAuth",
             "Token"});
-            this.authType.Location = new System.Drawing.Point(172, 32);
+            this.authType.Location = new System.Drawing.Point(169, 33);
             this.authType.Margin = new System.Windows.Forms.Padding(4);
             this.authType.Name = "authType";
             this.authType.Size = new System.Drawing.Size(256, 24);
@@ -198,17 +229,17 @@ namespace Snyk.VisualStudio.Extension.Settings
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(5, 36);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(144, 16);
+            this.label2.Size = new System.Drawing.Size(120, 13);
             this.label2.TabIndex = 12;
             this.label2.Text = " Authentication Method:";
             // 
             // OrganizationInfoLink
             // 
             this.OrganizationInfoLink.AutoSize = true;
-            this.OrganizationInfoLink.Location = new System.Drawing.Point(183, 343);
+            this.OrganizationInfoLink.Location = new System.Drawing.Point(175, 393);
             this.OrganizationInfoLink.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.OrganizationInfoLink.Name = "OrganizationInfoLink";
-            this.OrganizationInfoLink.Size = new System.Drawing.Size(188, 16);
+            this.OrganizationInfoLink.Size = new System.Drawing.Size(150, 13);
             this.OrganizationInfoLink.TabIndex = 11;
             this.OrganizationInfoLink.TabStop = true;
             this.OrganizationInfoLink.Text = "Learn more about organization";
@@ -217,10 +248,10 @@ namespace Snyk.VisualStudio.Extension.Settings
             // OrgDescriptionText
             // 
             this.OrgDescriptionText.AutoSize = true;
-            this.OrgDescriptionText.Location = new System.Drawing.Point(183, 283);
+            this.OrgDescriptionText.Location = new System.Drawing.Point(166, 339);
             this.OrgDescriptionText.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.OrgDescriptionText.Name = "OrgDescriptionText";
-            this.OrgDescriptionText.Size = new System.Drawing.Size(459, 48);
+            this.OrgDescriptionText.Size = new System.Drawing.Size(376, 39);
             this.OrgDescriptionText.TabIndex = 10;
             this.OrgDescriptionText.Text = "Specify an organization slug name to run tests for that organization.\r\nIt must ma" +
     "tch the URL slug as displayed in the URL of your org in the Snyk UI:\r\nhttps://ap" +
@@ -294,5 +325,7 @@ namespace Snyk.VisualStudio.Extension.Settings
         private ComboBox authType;
         private RichTextBox authMethodDescription;
         private Panel mainPanel;
+        private RichTextBox endpointDescriptionText;
+        private LinkLabel SnykRegionsLink;
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykGeneralSettingsUserControl.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykGeneralSettingsUserControl.cs
@@ -287,5 +287,11 @@ namespace Snyk.VisualStudio.Extension.Settings
         {
             return this.mainPanel;
         }
+
+        private void SnykRegionsLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            this.SnykRegionsLink.LinkVisited = true;
+            Process.Start("https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency#available-snyk-regions");
+        }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykGeneralSettingsUserControl.resx
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykGeneralSettingsUserControl.resx
@@ -124,7 +124,7 @@
     <value>156</value>
   </metadata>
   <data name="endpointDescriptionText.Text" xml:space="preserve">
-    <value>If you're using SSO with Snyk and OAuth2 the custom endpoint configuration is 
+    <value>If you're using SSO with Snyk and OAuth2, the custom endpoint configuration is 
 automatically populated. 
 For private instances, contact your team or account manager.
 Otherwise, for public regional instances, see the docs:</value>

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykGeneralSettingsUserControl.resx
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykGeneralSettingsUserControl.resx
@@ -123,6 +123,12 @@
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>156</value>
   </metadata>
+  <data name="endpointDescriptionText.Text" xml:space="preserve">
+    <value>If you're using SSO with Snyk and OAuth2 the custom endpoint configuration is 
+automatically populated. 
+For private instances, contact your team or account manager.
+Otherwise, for public regional instances, see the docs:</value>
+  </data>
   <metadata name="ossInfoToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>140, 17</value>
   </metadata>

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykGeneralSettingsUserControl.resx
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykGeneralSettingsUserControl.resx
@@ -120,6 +120,9 @@
   <metadata name="errorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>156</value>
+  </metadata>
   <metadata name="ossInfoToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>140, 17</value>
   </metadata>


### PR DESCRIPTION
### Description

In IDEs, you can configure a custom endpoint in order to target a custom region (e.g EU). The current description for this option is "Sets API endpoint to use for Snyk requests. Useful for custom Snyk setups. E.g. https://api.eu.snyk.io/.". With the recent platform changes, on OAuth using SSO, we automatically redirect to the right instance and that field does not need to be configured anymore.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
