### PR TITLE
fix: remove blank template replacements [IDE-1050]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.cs
@@ -58,11 +58,13 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             html = html.Replace("var(--ide-background-color)", isDarkTheme ? "#242424" : "#FBFBFB");
             html = html.Replace("var(--dimmed-text-color)", VSColorTheme.GetThemedColor(EnvironmentColors.ScrollBarThumbPressedBackgroundBrushKey).ToHex());
 
-            html = html.Replace("${headerEnd}", "");
+            // Must not have blank template replacements, as they could be used to skip the "${nonce}" injection check
+            // and still end up with the nonce injected, e.g. "${nonce${resolvesToEmpty}}" becomes "${nonce}" - See IDE-1050.
+            html = html.Replace("${headerEnd}", " ");
             var nonce = GetNonce();
             html = html.Replace("${nonce}", nonce);
             html = html.Replace("ideNonce", nonce);
-            html = html.Replace("${ideScript}", "");
+            html = html.Replace("${ideScript}", " ");
 
             return html;
         }

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.cs
@@ -26,7 +26,9 @@ namespace Snyk.VisualStudio.Extension.UI.Html
 
         public override string ReplaceCssVariables(string html)
         {
-            html = html.Replace("${ideStyle}", "");
+            // Must not have blank template replacements, as they could be used to skip the "${nonce}" injection check
+            // and still end up with the nonce injected, e.g. "${nonce${resolvesToEmpty}}" becomes "${nonce}" - See IDE-1050.
+            html = html.Replace("${ideStyle}", " ");
             return base.ReplaceCssVariables(html);
         }
 


### PR DESCRIPTION
### Description

This PR, aims to fix a potential cross-site scripting (XSS) vulnerability in the HTML reports.
By using a space for replacements, the attacker cannot use a bypass using "${nonce${resolvesToEmpty}}".

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
