### PR TITLE
fix: rename IaC section [PROG-2876]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/UI/Tree/SnykIacRootTreeNode.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Tree/SnykIacRootTreeNode.cs
@@ -9,7 +9,7 @@
         /// <summary>
         /// Title text for open source root node.
         /// </summary>
-        public const string SnykIacTitle = "Configuration";
+        public const string SnykIacTitle = "Infrastructure As Code";
 
         public SnykIacRootTreeNode(IRefreshable tree)
             : base(tree)


### PR DESCRIPTION
### Description

The "Configuration" section within the IDE plugin's IaC area caused confusion, as users often mistakenly associated it with general Snyk Code settings rather than its specific purpose for Infrastructure as Code analysis.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
