### PR TITLE
feat(IDE-1701): settings page auth flow — bridge persist and forward apiUrl

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/Language/ILanguageClientManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/ILanguageClientManager.cs
@@ -21,6 +21,7 @@ namespace Snyk.VisualStudio.Extension.Language
         Task<SastSettings> InvokeGetSastEnabled(CancellationToken cancellationToken);
         Task<string> InvokeLogin(CancellationToken cancellationToken);
         Task<object> InvokeLogout(CancellationToken cancellationToken);
+        Task<object> InvokeExecuteCommandAsync(string command, object[] args, CancellationToken cancellationToken);
         Task<object> DidChangeConfigurationAsync(CancellationToken cancellationToken);
         Task<string> InvokeCopyLinkAsync(CancellationToken cancellationToken);
         Task<string> InvokeGenerateIssueDescriptionAsync(string issueId, CancellationToken cancellationToken);

--- a/Snyk.VisualStudio.Extension.2022/Language/LsConstants.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/LsConstants.cs
@@ -2,7 +2,7 @@
 {
     public static class LsConstants
     {
-        public const string ProtocolVersion = "23";
+        public const string ProtocolVersion = "25";
         
         // Notifications
         public const string SnykHasAuthenticated = "$/snyk.hasAuthenticated";

--- a/Snyk.VisualStudio.Extension.2022/Language/LsConstants.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/LsConstants.cs
@@ -2,7 +2,7 @@
 {
     public static class LsConstants
     {
-        public const string ProtocolVersion = "25";
+        public const string ProtocolVersion = "24";
         
         // Notifications
         public const string SnykHasAuthenticated = "$/snyk.hasAuthenticated";

--- a/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClient.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClient.cs
@@ -362,6 +362,16 @@ namespace Snyk.VisualStudio.Extension.Language
             return isEnabled;
         }
 
+        public async Task<object> InvokeExecuteCommandAsync(string command, object[] args, CancellationToken cancellationToken)
+        {
+            var param = new LSP.ExecuteCommandParams
+            {
+                Command = command,
+                Arguments = args
+            };
+            return await InvokeWithParametersAsync<object>(LsConstants.WorkspaceExecuteCommand, param, cancellationToken);
+        }
+
         public async Task<string> InvokeCopyLinkAsync(CancellationToken cancellationToken)
         {
             var param = new LSP.ExecuteCommandParams

--- a/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClientCustomTarget.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClientCustomTarget.cs
@@ -268,20 +268,30 @@ namespace Snyk.VisualStudio.Extension.Language
             }
 
             var token = arg["token"].ToString();
-
             var apiUrl = arg["apiUrl"]?.ToString();
+
+            var oldToken = serviceProvider.Options.ApiToken?.ToString() ?? string.Empty;
+
+            // Always notify the HTML settings window so the token field updates immediately.
+            HtmlSettingsWindow.Instance?.UpdateAuthToken(token, apiUrl);
+
             if (!string.IsNullOrEmpty(apiUrl))
             {
                 serviceProvider.Options.CustomEndpoint = apiUrl;
             }
 
             serviceProvider.Options.ApiToken = new AuthenticationToken(serviceProvider.Options.AuthenticationMethod, token);
-            serviceProvider.SnykOptionsManager.Save(serviceProvider.Options);
+
+            // Persist without triggering SettingsChanged → DidChangeConfigurationAsync back to the LS.
+            serviceProvider.SnykOptionsManager.Save(serviceProvider.Options, false);
+
+            // Scan only when this is a new login (old token was blank).
+            // Token refresh also has old token non-blank, so no scan.
+            var isNewLogin = string.IsNullOrEmpty(oldToken) && !string.IsNullOrEmpty(token);
+            if (!isNewLogin)
+                return;
 
             await serviceProvider.GeneralOptionsDialogPage.HandleAuthenticationSuccess(token, apiUrl);
-
-            // Notify HTML settings window of auth token change
-            HtmlSettingsWindow.Instance?.UpdateAuthToken(token);
 
             if (!serviceProvider.Options.ApiToken.IsValid())
                 return;

--- a/Snyk.VisualStudio.Extension.2022/LogManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/LogManager.cs
@@ -46,7 +46,7 @@ namespace Snyk.VisualStudio.Extension
                     shared: true)
                 .CreateLogger();
 
-        private static ILogger ForContext(Type type) => Logger.Value.ForContext(type)
+        public static ILogger ForContext(Type type) => Logger.Value.ForContext(type)
             .ForContext("ShortSourceContext", type.Name);
     }
 

--- a/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
@@ -93,6 +93,7 @@ namespace Snyk.VisualStudio.Extension.Settings
                 SettingsBrowser.UpdateLayout();
 
                 html = HtmlResourceLoader.ApplyTheme(html);
+                html = InjectBridgeScriptIntoHtml(html);
                 SettingsBrowser.NavigateToString(html);
             }
             catch (Exception ex)
@@ -170,8 +171,35 @@ namespace Snyk.VisualStudio.Extension.Settings
             return HtmlResourceLoader.LoadFallbackHtml(serviceProvider.Options);
         }
 
+        private static string BuildIdeBridgeScript() =>
+            @"window.__saveIdeConfig__ = function(jsonString) { window.external.__saveIdeConfig__(jsonString); };
+            window.__onFormDirtyChange__ = function(isDirty) { window.external.__onFormDirtyChange__(isDirty); };
+            window.__ideSaveAttemptFinished__ = function(status) { window.external.__ideSaveAttemptFinished__(status); };"
+            + ExecuteCommandBridge.BuildClientScript();
+
+        /// <summary>
+        /// Injects IDE bridge functions into the HTML string before it is loaded by the browser.
+        /// This ensures the functions are defined before the page's own scripts run, which is
+        /// required for the LS HTML page to wire up its auth and command buttons correctly.
+        /// </summary>
+        protected virtual string InjectBridgeScriptIntoHtml(string html)
+        {
+            var script = BuildIdeBridgeScript();
+            var scriptTag = $"<script type=\"text/javascript\">{script}</script>";
+
+            var headIndex = html.IndexOf("<head>", StringComparison.OrdinalIgnoreCase);
+            if (headIndex >= 0)
+            {
+                return html.Insert(headIndex + "<head>".Length, scriptTag);
+            }
+
+            // Fallback: prepend if no <head> found
+            return scriptTag + html;
+        }
+
         /// <summary>
         /// Injects IDE bridge functions into the HTML window object for save and command operations.
+        /// Called after LoadCompleted as a secondary injection to ensure functions are (re-)applied.
         /// </summary>
         protected virtual void InjectIdeBridgeFunctions()
         {
@@ -180,22 +208,9 @@ namespace Snyk.VisualStudio.Extension.Settings
                 dynamic doc = SettingsBrowser.Document;
                 if (doc == null) return;
 
-                // Inject bridge functions that LS HTML expects
-                var script = @"
-                    window.__saveIdeConfig__ = function(jsonString) {
-                        window.external.__saveIdeConfig__(jsonString);
-                    };
-                    window.__onFormDirtyChange__ = function(isDirty) {
-                        window.external.__onFormDirtyChange__(isDirty);
-                    };
-                    window.__ideSaveAttemptFinished__ = function(status) {
-                        window.external.__ideSaveAttemptFinished__(status);
-                    };
-                " + ExecuteCommandBridge.BuildClientScript();
-
                 var scriptElement = doc.CreateElement("script");
                 scriptElement.SetAttribute("type", "text/javascript");
-                scriptElement.InnerText = script;
+                scriptElement.InnerText = BuildIdeBridgeScript();
                 doc.GetElementsByTagName("head")[0].AppendChild(scriptElement);
             }
             catch (Exception ex)

--- a/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
@@ -254,7 +254,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             }
         }
 
-        public void UpdateAuthToken(string token)
+        public void UpdateAuthToken(string token, string apiUrl = null)
         {
             try
             {
@@ -264,7 +264,7 @@ namespace Snyk.VisualStudio.Extension.Settings
 
                     if (SettingsBrowser?.Document != null)
                     {
-                        InvokeSetAuthToken(token);
+                        InvokeSetAuthToken(token, apiUrl);
                     }
                 });
             }
@@ -303,7 +303,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             }
         }
 
-        private void InvokeSetAuthToken(string token)
+        private void InvokeSetAuthToken(string token, string apiUrl)
         {
             try
             {
@@ -316,10 +316,11 @@ namespace Snyk.VisualStudio.Extension.Settings
                 }
 
                 var escapedToken = token.Replace("'", "\\'").Replace("\"", "\\\"");
+                var escapedApiUrl = (apiUrl ?? string.Empty).Replace("'", "\\'").Replace("\"", "\\\"");
                 var script = $@"
                     (function() {{
                         if (typeof window.setAuthToken === 'function') {{
-                            window.setAuthToken('{escapedToken}');
+                            window.setAuthToken('{escapedToken}', '{escapedApiUrl}');
                         }} else {{
                             console.warn('window.setAuthToken is not available');
                         }}
@@ -331,7 +332,7 @@ namespace Snyk.VisualStudio.Extension.Settings
                 scriptElement.InnerText = script;
                 doc.GetElementsByTagName("head")[0].AppendChild(scriptElement);
 
-                Logger.Information("Invoked window.setAuthToken with token");
+                Logger.Information("Invoked window.setAuthToken with token and apiUrl");
             }
             catch (Exception ex)
             {

--- a/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
@@ -187,10 +187,11 @@ namespace Snyk.VisualStudio.Extension.Settings
             var script = BuildIdeBridgeScript();
             var scriptTag = $"<script type=\"text/javascript\">{script}</script>";
 
-            var headIndex = html.IndexOf("<head>", StringComparison.OrdinalIgnoreCase);
+            const string headTag = "<head>";
+            var headIndex = html.IndexOf(headTag, StringComparison.OrdinalIgnoreCase);
             if (headIndex >= 0)
             {
-                return html.Insert(headIndex + "<head>".Length, scriptTag);
+                return html.Insert(headIndex + headTag.Length, scriptTag);
             }
 
             // Fallback: prepend if no <head> found
@@ -291,6 +292,12 @@ namespace Snyk.VisualStudio.Extension.Settings
 
         private void InvokeCommandCallback(string callbackId, string resultJson)
         {
+            if (!ExecuteCommandBridge.IsValidCallbackId(callbackId))
+            {
+                Logger.Warning("Rejected callbackId with unexpected format: {CallbackId}", callbackId);
+                return;
+            }
+
             try
             {
                 ThreadHelper.JoinableTaskFactory.Run(async () =>
@@ -300,13 +307,7 @@ namespace Snyk.VisualStudio.Extension.Settings
                     dynamic doc = SettingsBrowser.Document;
                     if (doc == null) return;
 
-                    if (!ExecuteCommandBridge.IsValidCallbackId(callbackId))
-                    {
-                        Logger.Warning("Rejected callbackId with unexpected format: {CallbackId}", callbackId);
-                        return;
-                    }
-
-                    var escapedCallbackId = callbackId.Replace("\\", "\\\\").Replace("'", "\\'");
+                    var escapedCallbackId = ExecuteCommandBridge.EscapeForJsString(callbackId);
                     var script = $"if(window.__ideCallbacks__&&window.__ideCallbacks__['{escapedCallbackId}']){{" +
                                  $"var cb=window.__ideCallbacks__['{escapedCallbackId}'];" +
                                  $"delete window.__ideCallbacks__['{escapedCallbackId}'];" +
@@ -336,8 +337,8 @@ namespace Snyk.VisualStudio.Extension.Settings
                     return;
                 }
 
-                var escapedToken = token.Replace("\\", "\\\\").Replace("'", "\\'");
-                var escapedApiUrl = (apiUrl ?? string.Empty).Replace("\\", "\\\\").Replace("'", "\\'");
+                var escapedToken = ExecuteCommandBridge.EscapeForJsString(token);
+                var escapedApiUrl = ExecuteCommandBridge.EscapeForJsString(apiUrl ?? string.Empty);
                 var script = $@"
                     (function() {{
                         if (typeof window.setAuthToken === 'function') {{

--- a/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
@@ -171,7 +171,7 @@ namespace Snyk.VisualStudio.Extension.Settings
         }
 
         /// <summary>
-        /// Injects IDE bridge functions into the HTML window object for save/login/logout operations.
+        /// Injects IDE bridge functions into the HTML window object for save and command operations.
         /// </summary>
         protected virtual void InjectIdeBridgeFunctions()
         {
@@ -182,19 +182,8 @@ namespace Snyk.VisualStudio.Extension.Settings
 
                 // Inject bridge functions that LS HTML expects
                 var script = @"
-                    window.__ideCallbacks__ = {};
-                    var __cbCounter_ide = 0;
                     window.__saveIdeConfig__ = function(jsonString) {
                         window.external.__saveIdeConfig__(jsonString);
-                    };
-                    window.__ideExecuteCommand__ = function(command, args, callback) {
-                        var callbackId = '';
-                        if (typeof callback === 'function') {
-                            callbackId = '__cb_' + (++__cbCounter_ide);
-                            window.__ideCallbacks__[callbackId] = callback;
-                        }
-                        var argsJson = JSON.stringify(args || []);
-                        window.external.__ideExecuteCommand__(command, argsJson, callbackId);
                     };
                     window.__onFormDirtyChange__ = function(isDirty) {
                         window.external.__onFormDirtyChange__(isDirty);
@@ -202,7 +191,7 @@ namespace Snyk.VisualStudio.Extension.Settings
                     window.__ideSaveAttemptFinished__ = function(status) {
                         window.external.__ideSaveAttemptFinished__(status);
                     };
-                ";
+                " + ExecuteCommandBridge.BuildClientScript();
 
                 var scriptElement = doc.CreateElement("script");
                 scriptElement.SetAttribute("type", "text/javascript");

--- a/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
@@ -113,7 +113,8 @@ namespace Snyk.VisualStudio.Extension.Settings
             scriptingBridge = new HtmlSettingsScriptingBridge(
                 serviceProvider,
                 onModified: () => IsDirty = true,
-                onReset: () => IsDirty = false);
+                onReset: () => IsDirty = false,
+                onCommandResult: (callbackId, resultJson) => InvokeCommandCallback(callbackId, resultJson));
 
             // Set the scripting bridge as the ObjectForScripting
             SettingsBrowser.ObjectForScripting = scriptingBridge;
@@ -181,14 +182,19 @@ namespace Snyk.VisualStudio.Extension.Settings
 
                 // Inject bridge functions that LS HTML expects
                 var script = @"
+                    window.__ideCallbacks__ = {};
+                    var __cbCounter_ide = 0;
                     window.__saveIdeConfig__ = function(jsonString) {
                         window.external.__saveIdeConfig__(jsonString);
                     };
-                    window.__ideLogin__ = function() {
-                        window.external.__ideLogin__();
-                    };
-                    window.__ideLogout__ = function() {
-                        window.external.__ideLogout__();
+                    window.__ideExecuteCommand__ = function(command, args, callback) {
+                        var callbackId = '';
+                        if (typeof callback === 'function') {
+                            callbackId = '__cb_' + (++__cbCounter_ide);
+                            window.__ideCallbacks__[callbackId] = callback;
+                        }
+                        var argsJson = JSON.stringify(args || []);
+                        window.external.__ideExecuteCommand__(command, argsJson, callbackId);
                     };
                     window.__onFormDirtyChange__ = function(isDirty) {
                         window.external.__onFormDirtyChange__(isDirty);
@@ -276,6 +282,35 @@ namespace Snyk.VisualStudio.Extension.Settings
             catch (Exception ex)
             {
                 Logger.Error(ex, "Error updating auth token in HTML settings");
+            }
+        }
+
+        private void InvokeCommandCallback(string callbackId, string resultJson)
+        {
+            try
+            {
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    dynamic doc = SettingsBrowser.Document;
+                    if (doc == null) return;
+
+                    var escapedCallbackId = callbackId.Replace("\\", "\\\\").Replace("'", "\\'");
+                    var script = $"if(window.__ideCallbacks__&&window.__ideCallbacks__['{escapedCallbackId}']){{" +
+                                 $"var cb=window.__ideCallbacks__['{escapedCallbackId}'];" +
+                                 $"delete window.__ideCallbacks__['{escapedCallbackId}'];" +
+                                 $"cb({resultJson});}}";
+
+                    var scriptElement = doc.CreateElement("script");
+                    scriptElement.SetAttribute("type", "text/javascript");
+                    scriptElement.InnerText = script;
+                    doc.GetElementsByTagName("head")[0].AppendChild(scriptElement);
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Error invoking command callback {CallbackId}", callbackId);
             }
         }
 

--- a/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
@@ -22,7 +22,7 @@ namespace Snyk.VisualStudio.Extension.Settings
     public partial class HtmlSettingsWindow : DialogWindow
     {
         protected static readonly ILogger Logger = LogManager.ForContext<HtmlSettingsWindow>();
-        private static HtmlSettingsWindow instance;
+        private static volatile HtmlSettingsWindow instance;
 
         public static HtmlSettingsWindow Instance => instance;
 
@@ -285,6 +285,12 @@ namespace Snyk.VisualStudio.Extension.Settings
                     dynamic doc = SettingsBrowser.Document;
                     if (doc == null) return;
 
+                    if (!ExecuteCommandBridge.IsValidCallbackId(callbackId))
+                    {
+                        Logger.Warning("Rejected callbackId with unexpected format: {CallbackId}", callbackId);
+                        return;
+                    }
+
                     var escapedCallbackId = callbackId.Replace("\\", "\\\\").Replace("'", "\\'");
                     var script = $"if(window.__ideCallbacks__&&window.__ideCallbacks__['{escapedCallbackId}']){{" +
                                  $"var cb=window.__ideCallbacks__['{escapedCallbackId}'];" +
@@ -315,8 +321,8 @@ namespace Snyk.VisualStudio.Extension.Settings
                     return;
                 }
 
-                var escapedToken = token.Replace("'", "\\'").Replace("\"", "\\\"");
-                var escapedApiUrl = (apiUrl ?? string.Empty).Replace("'", "\\'").Replace("\"", "\\\"");
+                var escapedToken = token.Replace("\\", "\\\\").Replace("'", "\\'");
+                var escapedApiUrl = (apiUrl ?? string.Empty).Replace("\\", "\\\\").Replace("'", "\\'");
                 var script = $@"
                     (function() {{
                         if (typeof window.setAuthToken === 'function') {{

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -251,6 +251,7 @@
     </Compile>
     <Compile Include="UI\Html\BaseHtmlProvider.cs" />
     <Compile Include="UI\Html\ColorExtension.cs" />
+    <Compile Include="UI\Html\ExecuteCommandBridge.cs" />
     <Compile Include="UI\Html\HtmlSettingsScriptingBridge.cs" />
     <Compile Include="UI\Html\IdeConfigData.cs" />
     <Compile Include="UI\Html\HtmlResourceLoader.cs" />

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/ExecuteCommandBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/ExecuteCommandBridge.cs
@@ -1,0 +1,84 @@
+// ABOUTME: Shared bridge for the window.__ideExecuteCommand__ JS<->IDE contract.
+// ABOUTME: Reusable by any WebBrowser panel (settings, tree view, etc.).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Serilog;
+using Snyk.VisualStudio.Extension;
+using Snyk.VisualStudio.Extension.Language;
+
+namespace Snyk.VisualStudio.Extension.UI.Html
+{
+    /// <summary>
+    /// Shared bridge for the <c>window.__ideExecuteCommand__</c> JS↔IDE contract.
+    /// Reusable by any WebBrowser panel (settings window, tree view, etc.).
+    ///
+    /// Responsibilities:
+    /// <list type="bullet">
+    ///   <item>Provide the ES5-compatible JS that defines <c>window.__ideExecuteCommand__</c>.</item>
+    ///   <item>Dispatch incoming commands to the Language Server.</item>
+    ///   <item>Return results to the JS callback via <c>window.__ideCallbacks__</c>.</item>
+    /// </list>
+    /// </summary>
+    public static class ExecuteCommandBridge
+    {
+        private static readonly ILogger Logger = LogManager.ForContext<ExecuteCommandBridge>();
+
+        /// <summary>
+        /// Returns the ES5-compatible JavaScript that defines <c>window.__ideExecuteCommand__</c>.
+        /// Assumes <c>window.external.__ideExecuteCommand__(command, argsJson, callbackId)</c>
+        /// is provided by the COM bridge (<see cref="HtmlSettingsScriptingBridge"/>).
+        /// </summary>
+        public static string BuildClientScript()
+        {
+            return @"
+                window.__ideCallbacks__ = {};
+                var __cbCounter_ide = 0;
+                window.__ideExecuteCommand__ = function(command, args, callback) {
+                    var callbackId = '';
+                    if (typeof callback === 'function') {
+                        callbackId = '__cb_' + (++__cbCounter_ide);
+                        window.__ideCallbacks__[callbackId] = callback;
+                    }
+                    var argsJson = JSON.stringify(args || []);
+                    window.external.__ideExecuteCommand__(command, argsJson, callbackId);
+                };
+            ";
+        }
+
+        /// <summary>
+        /// Dispatches a command to the Language Server and invokes <paramref name="onCommandResult"/>
+        /// with the serialized result when a <paramref name="callbackId"/> is provided.
+        /// </summary>
+        public static async Task DispatchAsync(
+            ILanguageClientManager languageClientManager,
+            string command,
+            string argsJson,
+            string callbackId,
+            Action<string, string> onCommandResult,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var args = string.IsNullOrEmpty(argsJson)
+                    ? Array.Empty<object>()
+                    : JsonConvert.DeserializeObject<object[]>(argsJson);
+
+                var result = await languageClientManager.InvokeExecuteCommandAsync(
+                    command, args, cancellationToken);
+
+                if (!string.IsNullOrEmpty(callbackId))
+                {
+                    var resultJson = result != null ? JsonConvert.SerializeObject(result) : "null";
+                    onCommandResult?.Invoke(callbackId, resultJson);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Error executing command {Command} from HTML bridge", command);
+            }
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/ExecuteCommandBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/ExecuteCommandBridge.cs
@@ -38,6 +38,13 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             CallbackIdPattern.IsMatch(callbackId ?? string.Empty);
 
         /// <summary>
+        /// Returns true if <paramref name="command"/> is in the <c>snyk.*</c> namespace and may be
+        /// dispatched from a webview.
+        /// </summary>
+        public static bool IsAllowedCommand(string command) =>
+            !string.IsNullOrEmpty(command) && command.StartsWith("snyk.");
+
+        /// <summary>
         /// Returns the ES5-compatible JavaScript that defines <c>window.__ideExecuteCommand__</c>.
         /// Assumes <c>window.external.__ideExecuteCommand__(command, argsJson, callbackId)</c>
         /// is provided by the COM bridge (<see cref="HtmlSettingsScriptingBridge"/>).
@@ -73,6 +80,12 @@ namespace Snyk.VisualStudio.Extension.UI.Html
         {
             try
             {
+                if (!IsAllowedCommand(command))
+                {
+                    Logger.Warning("Webview attempted to execute disallowed command: {Command}", command);
+                    return;
+                }
+
                 var args = string.IsNullOrEmpty(argsJson)
                     ? Array.Empty<object>()
                     : JsonConvert.DeserializeObject<object[]>(argsJson);

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/ExecuteCommandBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/ExecuteCommandBridge.cs
@@ -31,6 +31,13 @@ namespace Snyk.VisualStudio.Extension.UI.Html
         private static readonly Regex CallbackIdPattern = new Regex(@"^(__cb_\d+)?$", RegexOptions.Compiled);
 
         /// <summary>
+        /// Escapes a string for safe embedding inside a single-quoted JavaScript string literal.
+        /// Handles backslashes first, then single quotes, to avoid double-escaping.
+        /// </summary>
+        public static string EscapeForJsString(string value) =>
+            (value ?? string.Empty).Replace("\\", "\\\\").Replace("'", "\\'");
+
+        /// <summary>
         /// Returns true if <paramref name="callbackId"/> matches the expected format produced by
         /// <see cref="BuildClientScript"/>. Used as an XSS guard before injecting the id back into JS.
         /// </summary>

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/ExecuteCommandBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/ExecuteCommandBridge.cs
@@ -25,7 +25,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
     /// </summary>
     public static class ExecuteCommandBridge
     {
-        private static readonly ILogger Logger = LogManager.ForContext<ExecuteCommandBridge>();
+        private static readonly ILogger Logger = LogManager.ForContext(typeof(ExecuteCommandBridge));
 
         // Allowlist regex for callbackIds produced by BuildClientScript: "" or "__cb_<digits>"
         private static readonly Regex CallbackIdPattern = new Regex(@"^(__cb_\d+)?$", RegexOptions.Compiled);

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/ExecuteCommandBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/ExecuteCommandBridge.cs
@@ -2,6 +2,7 @@
 // ABOUTME: Reusable by any WebBrowser panel (settings, tree view, etc.).
 
 using System;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -25,6 +26,16 @@ namespace Snyk.VisualStudio.Extension.UI.Html
     public static class ExecuteCommandBridge
     {
         private static readonly ILogger Logger = LogManager.ForContext<ExecuteCommandBridge>();
+
+        // Allowlist regex for callbackIds produced by BuildClientScript: "" or "__cb_<digits>"
+        private static readonly Regex CallbackIdPattern = new Regex(@"^(__cb_\d+)?$", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Returns true if <paramref name="callbackId"/> matches the expected format produced by
+        /// <see cref="BuildClientScript"/>. Used as an XSS guard before injecting the id back into JS.
+        /// </summary>
+        public static bool IsValidCallbackId(string callbackId) =>
+            CallbackIdPattern.IsMatch(callbackId ?? string.Empty);
 
         /// <summary>
         /// Returns the ES5-compatible JavaScript that defines <c>window.__ideExecuteCommand__</c>.
@@ -71,6 +82,12 @@ namespace Snyk.VisualStudio.Extension.UI.Html
 
                 if (!string.IsNullOrEmpty(callbackId))
                 {
+                    if (!IsValidCallbackId(callbackId))
+                    {
+                        Logger.Warning("Rejected callbackId with unexpected format: {CallbackId}", callbackId);
+                        return;
+                    }
+
                     var resultJson = result != null ? JsonConvert.SerializeObject(result) : "null";
                     onCommandResult?.Invoke(callbackId, resultJson);
                 }

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
@@ -175,7 +175,14 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             {
                 ApplyScanSettings(config);
                 ApplyIssueViewSettings(config);
+                var previousAuthMethod = Options.AuthenticationMethod;
                 ApplyAuthenticationSettings(config);
+                // Clear stored token when auth method changes: a token from one method is not valid for another.
+                if (config.AuthenticationMethod != null && Options.AuthenticationMethod != previousAuthMethod)
+                {
+                    Options.ApiToken = new AuthenticationToken(Options.AuthenticationMethod, string.Empty);
+                }
+
                 ApplyConnectionSettings(config);
                 ApplyTrustedFolders(config);
                 ApplyFilterSettings(config);

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
@@ -29,6 +29,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
         private readonly Action onModified;
         private readonly Action onReset;
         private readonly Action<string> onAuthTokenChanged;
+        private readonly Action<string, string> onCommandResult;
         private volatile bool isSaveComplete;
 
         private ISnykOptions Options => serviceProvider.Options;
@@ -49,12 +50,14 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             ISnykServiceProvider serviceProvider,
             Action onModified,
             Action onReset = null,
-            Action<string> onAuthTokenChanged = null)
+            Action<string> onAuthTokenChanged = null,
+            Action<string, string> onCommandResult = null)
         {
             this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             this.onModified = onModified ?? throw new ArgumentNullException(nameof(onModified));
             this.onReset = onReset;
             this.onAuthTokenChanged = onAuthTokenChanged;
+            this.onCommandResult = onCommandResult;
         }
 
         /// <summary>
@@ -100,60 +103,33 @@ namespace Snyk.VisualStudio.Extension.UI.Html
         }
 
         /// <summary>
-        /// Called from LS HTML JavaScript: window.__ideLogin__()
-        /// Triggers the IDE's authentication flow via Language Server.
+        /// Called from LS HTML JavaScript: window.__ideExecuteCommand__(command, argsJson, callbackId)
+        /// Routes commands (login, logout, etc.) to the Language Server via workspace/executeCommand.
+        /// If callbackId is non-empty, the command result is passed back to the JS callback.
         /// </summary>
-        public void __ideLogin__()
+        public void __ideExecuteCommand__(string command, string argsJson, string callbackId)
         {
             try
             {
-                // Trigger authentication through the GeneralOptionsDialogPage
-                // This matches the pattern from SnykGeneralSettingsUserControl
-                if (serviceProvider?.GeneralOptionsDialogPage != null)
-                {
-                    serviceProvider.GeneralOptionsDialogPage.Authenticate();
-                    Logger.Information("Authentication initiated from HTML settings");
-                }
-                else
-                {
-                    Logger.Warning("Cannot authenticate: GeneralOptionsDialogPage not available");
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Error during authentication from HTML settings");
-            }
-        }
+                var args = string.IsNullOrEmpty(argsJson)
+                    ? Array.Empty<object>()
+                    : JsonConvert.DeserializeObject<object[]>(argsJson);
 
-        /// <summary>
-        /// Called from LS HTML JavaScript: window.__ideLogout__()
-        /// Clears authentication token and notifies Language Server.
-        /// </summary>
-        public void __ideLogout__()
-        {
-            try
-            {
-                // Clear the API token
-                Options.ApiToken = AuthenticationToken.EmptyToken;
-
-                // Notify Language Server of logout
-                if (serviceProvider?.LanguageClientManager != null)
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
-                    ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                    var result = await serviceProvider.LanguageClientManager.InvokeExecuteCommandAsync(
+                        command, args, SnykVSPackage.Instance.DisposalToken);
+
+                    if (!string.IsNullOrEmpty(callbackId))
                     {
-                        await serviceProvider.LanguageClientManager.InvokeLogout(
-                            SnykVSPackage.Instance.DisposalToken);
-                        Logger.Information("Logout completed - Language Server notified");
-                    }).FireAndForget();
-                }
-                else
-                {
-                    Logger.Information("Logout completed - Language Server not available");
-                }
+                        var resultJson = result != null ? JsonConvert.SerializeObject(result) : "null";
+                        onCommandResult?.Invoke(callbackId, resultJson);
+                    }
+                }).FireAndForget();
             }
             catch (Exception ex)
             {
-                Logger.Error(ex, "Error during logout from HTML settings");
+                Logger.Error(ex, "Error executing command {Command} from HTML settings", command);
             }
         }
 

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
@@ -104,33 +104,21 @@ namespace Snyk.VisualStudio.Extension.UI.Html
 
         /// <summary>
         /// Called from LS HTML JavaScript: window.__ideExecuteCommand__(command, argsJson, callbackId)
-        /// Routes commands (login, logout, etc.) to the Language Server via workspace/executeCommand.
+        /// Routes commands to the Language Server via workspace/executeCommand.
         /// If callbackId is non-empty, the command result is passed back to the JS callback.
         /// </summary>
         public void __ideExecuteCommand__(string command, string argsJson, string callbackId)
         {
-            try
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                var args = string.IsNullOrEmpty(argsJson)
-                    ? Array.Empty<object>()
-                    : JsonConvert.DeserializeObject<object[]>(argsJson);
-
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-                {
-                    var result = await serviceProvider.LanguageClientManager.InvokeExecuteCommandAsync(
-                        command, args, SnykVSPackage.Instance.DisposalToken);
-
-                    if (!string.IsNullOrEmpty(callbackId))
-                    {
-                        var resultJson = result != null ? JsonConvert.SerializeObject(result) : "null";
-                        onCommandResult?.Invoke(callbackId, resultJson);
-                    }
-                }).FireAndForget();
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Error executing command {Command} from HTML settings", command);
-            }
+                await ExecuteCommandBridge.DispatchAsync(
+                    serviceProvider.LanguageClientManager,
+                    command,
+                    argsJson,
+                    callbackId,
+                    onCommandResult,
+                    SnykVSPackage.Instance.DisposalToken);
+            }).FireAndForget();
         }
 
         /// <summary>

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
@@ -106,9 +106,36 @@ namespace Snyk.VisualStudio.Extension.UI.Html
         /// Called from LS HTML JavaScript: window.__ideExecuteCommand__(command, argsJson, callbackId)
         /// Routes commands to the Language Server via workspace/executeCommand.
         /// If callbackId is non-empty, the command result is passed back to the JS callback.
+        /// When command is "snyk.login" and args has 3+ elements, saves auth params to IDE storage
+        /// immediately without triggering DidChangeConfigurationAsync.
         /// </summary>
         public void __ideExecuteCommand__(string command, string argsJson, string callbackId)
         {
+            if (command == "snyk.login")
+            {
+                try
+                {
+                    var args = JsonConvert.DeserializeObject<object[]>(argsJson ?? "[]");
+                    if (args != null && args.Length >= 3)
+                    {
+                        var authMethodStr = args[0]?.ToString() ?? string.Empty;
+                        serviceProvider.Options.AuthenticationMethod = authMethodStr switch
+                        {
+                            "oauth" => AuthenticationType.OAuth,
+                            "pat" => AuthenticationType.Pat,
+                            "token" => AuthenticationType.Token,
+                            _ => AuthenticationType.OAuth,
+                        };
+                        serviceProvider.Options.CustomEndpoint = args[1]?.ToString() ?? string.Empty;
+                        serviceProvider.Options.IgnoreUnknownCA = args[2] is bool b ? b : Convert.ToBoolean(args[2]);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning(ex, "Failed to save login args from __ideExecuteCommand__");
+                }
+            }
+
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await ExecuteCommandBridge.DispatchAsync(

--- a/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
@@ -34,7 +34,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             solutionServiceMock = new Mock<ISolutionService>();
 
             var featureFlagServiceMock = new Mock<IFeatureFlagService>();
-            
+
             featureFlagServiceMock.Setup(x => x.RefreshAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -48,7 +48,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             serviceProviderMock.SetupGet(sp => sp.FeatureFlagService).Returns(featureFlagServiceMock.Object);
             serviceProviderMock.SetupGet(sp => sp.LanguageClientManager).Returns(languageClientManagerMock.Object);
             serviceProviderMock.SetupGet(sp => sp.SolutionService).Returns(solutionServiceMock.Object);
-            
+
             // Setup GetEffectiveOrganizationAsync mock
             snykOptionsManagerMock.Setup(s => s.GetEffectiveOrganizationAsync()).ReturnsAsync("auto-determined-org");
             optionsMock.SetupAllProperties();
@@ -120,7 +120,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             // Act
             await cut.OnPublishDiagnostics316(arg);
-            
+
             // Assert
             Assert.True(cut.GetCodeDictionary().ContainsKey("c:\\users\\user\\dir - with - space üaöä中文\\file.cs"));
         }

--- a/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
@@ -178,7 +178,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
         [Fact]
         public async Task OnHasAuthenticated_ShouldHandleAuthenticationSuccess_WhenTokenIsProvided()
         {
-            // Arrange
+            // Arrange — new login (no previous token).
             var arg = JObject.Parse("{'token':'test-token','apiUrl':'https://api.snyk.io'}");
             generalSettingsPageMock.Setup(o => o.HandleAuthenticationSuccess("test-token", "https://api.snyk.io")).Returns(Task.CompletedTask);
             optionsMock.SetupGet(o => o.AuthenticationMethod).Returns(AuthenticationType.OAuth);
@@ -186,10 +186,47 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             // Act
             await cut.OnHasAuthenticated(arg);
 
-            // Assert
+            // Assert — token and endpoint stored, saved without triggering didChangeConfiguration loop
             optionsMock.VerifySet(o => o.CustomEndpoint = "https://api.snyk.io");
             optionsMock.VerifySet(o => o.ApiToken = It.Is<AuthenticationToken>(t => t.Type == AuthenticationType.OAuth && t.ToString() == "test-token"));
+            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false), Times.Once);
             generalSettingsPageMock.Verify(o => o.HandleAuthenticationSuccess("test-token", "https://api.snyk.io"), Times.Once);
+        }
+
+        [Fact]
+        public async Task OnHasAuthenticated_WithExistingToken_OnlySavesQuietly()
+        {
+            // Arrange — token refresh (existing token non-blank).
+            var arg = JObject.Parse("{'token':'refreshed-token','apiUrl':'https://api.snyk.io'}");
+            optionsMock.SetupGet(o => o.AuthenticationMethod).Returns(AuthenticationType.OAuth);
+            // Simulate existing token so isNewLogin=false
+            optionsMock.SetupGet(o => o.ApiToken).Returns(new AuthenticationToken(AuthenticationType.OAuth, "existing-token"));
+
+            // Act
+            await cut.OnHasAuthenticated(arg);
+
+            // Assert — Save must be called with triggerSettingsChangedEvent=false to avoid the loop
+            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false), Times.Once);
+            // HandleAuthenticationSuccess must NOT be called — not a new login
+            generalSettingsPageMock.Verify(o => o.HandleAuthenticationSuccess(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            // No scan on refresh — old token was non-blank
+            tasksServiceMock.Verify(t => t.ScanAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task OnHasAuthenticated_AlwaysUpdatesTokenAndEndpoint()
+        {
+            // Arrange — always stores token and endpoint regardless of whether it is a new login or refresh.
+            var arg = JObject.Parse("{'token':'refreshed-token','apiUrl':'https://api.eu.snyk.io'}");
+            optionsMock.SetupGet(o => o.AuthenticationMethod).Returns(AuthenticationType.OAuth);
+            optionsMock.SetupGet(o => o.ApiToken).Returns(new AuthenticationToken(AuthenticationType.OAuth, "existing-token"));
+
+            // Act
+            await cut.OnHasAuthenticated(arg);
+
+            // Assert — token and endpoint must be stored
+            optionsMock.VerifySet(o => o.CustomEndpoint = "https://api.eu.snyk.io");
+            optionsMock.VerifySet(o => o.ApiToken = It.Is<AuthenticationToken>(t => t.ToString() == "refreshed-token"));
         }
 
         [Fact]

--- a/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientTest.cs
@@ -56,9 +56,9 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             var result = await cut.DidChangeConfigurationAsync(CancellationToken.None);
 
             // Assert
-            jsonRpcMock.Verify(x=>x.InvokeWithParameterObjectAsync<object>(LsConstants.WorkspaceChangeConfiguration, 
-                It.IsAny<LSP.DidChangeConfigurationParams>(), 
-                It.IsAny<CancellationToken>()), 
+            jsonRpcMock.Verify(x => x.InvokeWithParameterObjectAsync<object>(LsConstants.WorkspaceChangeConfiguration,
+                It.IsAny<LSP.DidChangeConfigurationParams>(),
+                It.IsAny<CancellationToken>()),
                 Times.Never);
             Assert.Null(result);
         }
@@ -76,8 +76,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             // Assert
             jsonRpcMock.Verify(x => x.InvokeWithParameterObjectAsync<object>(LsConstants.WorkspaceChangeConfiguration,
-                It.IsAny<LSP.DidChangeConfigurationParams>(), 
-                It.IsAny<CancellationToken>()), 
+                It.IsAny<LSP.DidChangeConfigurationParams>(),
+                It.IsAny<CancellationToken>()),
                 Times.Once);
             Assert.Null(result);
         }
@@ -123,9 +123,9 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             // Assert
             Assert.Null(result);
-            jsonRpcMock.Verify(x => x.InvokeWithParameterObjectAsync<object>(LsConstants.WorkspaceExecuteCommand, 
+            jsonRpcMock.Verify(x => x.InvokeWithParameterObjectAsync<object>(LsConstants.WorkspaceExecuteCommand,
                     It.Is<LSP.ExecuteCommandParams>(param => param.Command == LsConstants.SnykWorkspaceScan),
-                It.IsAny<CancellationToken>()), 
+                It.IsAny<CancellationToken>()),
                 Times.Never);
         }
 
@@ -142,8 +142,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             // Assert
             Assert.Null(result);
             jsonRpcMock.Verify(x => x.InvokeWithParameterObjectAsync<object>(LsConstants.WorkspaceExecuteCommand,
-                It.Is<LSP.ExecuteCommandParams>(param=> param.Command == LsConstants.SnykWorkspaceScan), 
-                It.IsAny<CancellationToken>()), 
+                It.Is<LSP.ExecuteCommandParams>(param => param.Command == LsConstants.SnykWorkspaceScan),
+                It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -161,7 +161,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.Null(result);
             jsonRpcMock.Verify(x => x.InvokeWithParameterObjectAsync<object>(LsConstants.WorkspaceExecuteCommand,
                 It.Is<LSP.ExecuteCommandParams>(param => param.Command == LsConstants.SnykWorkspaceScan),
-                It.IsAny<CancellationToken>()), 
+                It.IsAny<CancellationToken>()),
                 Times.Never);
         }
 
@@ -334,9 +334,9 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             // Assert
             Assert.Null(result);
-            jsonRpcMock.Verify(x => x.InvokeWithParameterObjectAsync<object>(LsConstants.WorkspaceExecuteCommand, 
+            jsonRpcMock.Verify(x => x.InvokeWithParameterObjectAsync<object>(LsConstants.WorkspaceExecuteCommand,
                     It.Is<LSP.ExecuteCommandParams>(param => param.Command == LsConstants.SnykLogin),
-                It.IsAny<CancellationToken>()), 
+                It.IsAny<CancellationToken>()),
                 Times.Never);
         }
 
@@ -351,9 +351,9 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             // Assert
             Assert.Null(result);
-            jsonRpcMock.Verify(x => x.InvokeWithParameterObjectAsync<object>(LsConstants.WorkspaceExecuteCommand, 
+            jsonRpcMock.Verify(x => x.InvokeWithParameterObjectAsync<object>(LsConstants.WorkspaceExecuteCommand,
                     It.Is<LSP.ExecuteCommandParams>(param => param.Command == LsConstants.SnykLogin),
-                It.IsAny<CancellationToken>()), 
+                It.IsAny<CancellationToken>()),
                 Times.Once);
         }
     }

--- a/Snyk.VisualStudio.Extension.Tests/PackageBaseTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/PackageBaseTest.cs
@@ -26,21 +26,21 @@ namespace Snyk.VisualStudio.Extension.Tests
             TasksServiceMock = new Mock<ISnykTasksService>();
             var loggerMock = new Mock<ILogger>();
             Log.Logger = loggerMock.Object;
-            
+
             ServiceProviderMock.Setup(x => x.SnykOptionsManager).Returns(OptionsManagerMock.Object);
             ServiceProviderMock.Setup(x => x.Options).Returns(OptionsMock.Object);
             ServiceProviderMock.Setup(x => x.TasksService).Returns(TasksServiceMock.Object);
-            
+
             sp.AddService(typeof(ISnykService), ServiceProviderMock.Object);
 
             VsPackage = new SnykVSPackage();
 
             var instanceField = typeof(SnykVSPackage).GetField(nameof(SnykVSPackage.Instance), BindingFlags.Static | BindingFlags.Public);
             instanceField.SetValue(null, VsPackage);
-            
+
             typeof(SnykVSPackage).GetProperty(nameof(SnykVSPackage.Options)).SetValue(VsPackage, OptionsMock.Object);
             typeof(SnykVSPackage).GetProperty(nameof(SnykVSPackage.IsInitialized)).SetValue(VsPackage, true, null);
-         
+
             VsPackage.SetServiceProvider(ServiceProviderMock.Object);
         }
     }

--- a/Snyk.VisualStudio.Extension.Tests/Settings/SnykOptionsManagerAutoOrgTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/SnykOptionsManagerAutoOrgTests.cs
@@ -18,14 +18,14 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
             this.testSettingsPath = System.IO.Path.GetTempFileName();
             this.serviceProviderMock = new Mock<ISnykServiceProvider>();
             this.solutionServiceMock = new Mock<ISolutionService>();
-            
+
             this.serviceProviderMock.Setup(x => x.SolutionService).Returns(this.solutionServiceMock.Object);
             this.solutionServiceMock.Setup(x => x.GetSolutionFolderAsync()).ReturnsAsync("/test/solution");
-            
+
             // Setup Options mock to prevent null reference exception
             var optionsMock = new Mock<ISnykOptions>();
             this.serviceProviderMock.Setup(x => x.Options).Returns(optionsMock.Object);
-            
+
             this.cut = new SnykOptionsManager(this.testSettingsPath, this.serviceProviderMock.Object);
         }
 

--- a/Snyk.VisualStudio.Extension.Tests/SnykCliDownloaderTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/SnykCliDownloaderTest.cs
@@ -26,7 +26,7 @@ namespace Snyk.VisualStudio.Extension.Tests
         [Fact]
         public async Task SnykCliDownloader_ExistingCliFilesNotCorruptedWhenDownloadFails_SuccessAsync()
         {
-            
+
             var cliDownloader = new SnykCliDownloader(optionsMock.Object);
 
             var tempCliPath = Path.Combine(Path.GetTempPath(), SnykCli.CliFileName);

--- a/Snyk.VisualStudio.Extension.Tests/SnykUserStorageSettingsServiceTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/SnykUserStorageSettingsServiceTest.cs
@@ -70,7 +70,7 @@ namespace Snyk.VisualStudio.Extension.Tests
 
             // Reload to confirm persistence
             var reloadedOptions = cut.Load();
-            
+
             Assert.True(reloadedOptions.AutoScan);
             Assert.True(reloadedOptions.IgnoreUnknownCA);
             Assert.Equal("my-org", reloadedOptions.Organization);

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/ExecuteCommandBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/ExecuteCommandBridgeTest.cs
@@ -1,0 +1,48 @@
+using Snyk.VisualStudio.Extension.UI.Html;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.UI.Html
+{
+    public class ExecuteCommandBridgeTest
+    {
+        [Fact]
+        public void BuildClientScript_ContainsIdeExecuteCommandDefinition()
+        {
+            var script = ExecuteCommandBridge.BuildClientScript();
+            Assert.Contains("window.__ideExecuteCommand__", script);
+        }
+
+        [Fact]
+        public void BuildClientScript_ContainsIdeCallbacksInitialization()
+        {
+            var script = ExecuteCommandBridge.BuildClientScript();
+            Assert.Contains("window.__ideCallbacks__", script);
+        }
+
+        [Fact]
+        public void BuildClientScript_CallsWindowExternalIdeExecuteCommand()
+        {
+            var script = ExecuteCommandBridge.BuildClientScript();
+            Assert.Contains("window.external.__ideExecuteCommand__", script);
+        }
+
+        [Fact]
+        public void BuildClientScript_IncludesCallbackIdHandling()
+        {
+            var script = ExecuteCommandBridge.BuildClientScript();
+            Assert.Contains("callbackId", script);
+            Assert.Contains("callback", script);
+        }
+
+        [Fact]
+        public void BuildClientScript_IsEs5Compatible()
+        {
+            var script = ExecuteCommandBridge.BuildClientScript();
+            // ES5: var (not const/let), function keyword (not arrow functions)
+            Assert.Contains("var ", script);
+            Assert.DoesNotContain("const ", script);
+            Assert.DoesNotContain("let ", script);
+            Assert.DoesNotContain("=>", script);
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/ExecuteCommandBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/ExecuteCommandBridgeTest.cs
@@ -44,5 +44,27 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
             Assert.DoesNotContain("let ", script);
             Assert.DoesNotContain("=>", script);
         }
+
+        [Theory]
+        [InlineData("", true)]
+        [InlineData("__cb_1", true)]
+        [InlineData("__cb_123", true)]
+        [InlineData("__cb_9999999", true)]
+        [InlineData(null, true)]
+        public void IsValidCallbackId_AcceptsValidFormats(string callbackId, bool expected)
+        {
+            Assert.Equal(expected, ExecuteCommandBridge.IsValidCallbackId(callbackId));
+        }
+
+        [Theory]
+        [InlineData("<script>alert(1)</script>")]
+        [InlineData("__cb_abc")]
+        [InlineData(";drop table--")]
+        [InlineData("__cb_1; alert(1)")]
+        [InlineData("__cb_")]
+        public void IsValidCallbackId_RejectsInvalidFormats(string callbackId)
+        {
+            Assert.False(ExecuteCommandBridge.IsValidCallbackId(callbackId));
+        }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/ExecuteCommandBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/ExecuteCommandBridgeTest.cs
@@ -66,5 +66,25 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
         {
             Assert.False(ExecuteCommandBridge.IsValidCallbackId(callbackId));
         }
+
+        [Theory]
+        [InlineData("snyk.login", true)]
+        [InlineData("snyk.logout", true)]
+        [InlineData("snyk.navigateToRange", true)]
+        [InlineData("snyk.anyCommand", true)]
+        public void IsAllowedCommand_AllowsSnykPrefixedCommands(string command, bool expected)
+        {
+            Assert.Equal(expected, ExecuteCommandBridge.IsAllowedCommand(command));
+        }
+
+        [Theory]
+        [InlineData("workbench.action.terminal.new")]
+        [InlineData("vscode.open")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void IsAllowedCommand_RejectsNonSnykCommands(string command)
+        {
+            Assert.False(ExecuteCommandBridge.IsAllowedCommand(command));
+        }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/ExecuteCommandBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/ExecuteCommandBridgeTest.cs
@@ -62,6 +62,8 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
         [InlineData(";drop table--")]
         [InlineData("__cb_1; alert(1)")]
         [InlineData("__cb_")]
+        [InlineData("_cb_8")]
+        [InlineData(" ")]
         public void IsValidCallbackId_RejectsInvalidFormats(string callbackId)
         {
             Assert.False(ExecuteCommandBridge.IsValidCallbackId(callbackId));

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.Sdk.TestFramework;
 using Moq;
 using Newtonsoft.Json;
 using Snyk.VisualStudio.Extension.Authentication;
+using Snyk.VisualStudio.Extension.Language;
 using Snyk.VisualStudio.Extension.Service;
 using Snyk.VisualStudio.Extension.Settings;
 using Snyk.VisualStudio.Extension.UI.Html;

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Moq;
 using Newtonsoft.Json;
@@ -103,6 +104,54 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
             optionsMock.VerifySet(o => o.AuthenticationMethod = It.IsAny<AuthenticationType>(), Times.Never);
             optionsMock.VerifySet(o => o.CustomEndpoint = It.IsAny<string>(), Times.Never);
             optionsMock.VerifySet(o => o.IgnoreUnknownCA = It.IsAny<bool>(), Times.Never);
+        }
+
+        [Fact]
+        public void SaveIdeConfig_ClearsToken_WhenAuthMethodChanges()
+        {
+            var setApiTokenCalls = new List<AuthenticationToken>();
+
+            optionsMock.SetupGet(o => o.AuthenticationMethod).Returns(AuthenticationType.OAuth);
+            optionsMock.SetupSet(o => o.AuthenticationMethod = It.IsAny<AuthenticationType>())
+                .Callback<AuthenticationType>(v => optionsMock.SetupGet(o => o.AuthenticationMethod).Returns(v));
+            optionsMock.SetupGet(o => o.ApiToken)
+                .Returns(new AuthenticationToken(AuthenticationType.OAuth, "existing-oauth-token"));
+            optionsMock.SetupSet(o => o.ApiToken = It.IsAny<AuthenticationToken>())
+                .Callback<AuthenticationToken>(t => setApiTokenCalls.Add(t));
+
+            var config = JsonConvert.SerializeObject(new IdeConfigData
+            {
+                AuthenticationMethod = "token",
+                Token = "new-pat-token",
+            });
+
+            bridge.__saveIdeConfig__(config);
+
+            Assert.True(setApiTokenCalls.Count >= 1, "ApiToken setter should have been called");
+            Assert.Equal(string.Empty, setApiTokenCalls[0].ToString());
+        }
+
+        [Fact]
+        public void SaveIdeConfig_DoesNotClearToken_WhenAuthMethodUnchanged()
+        {
+            var setApiTokenCalls = new List<AuthenticationToken>();
+
+            optionsMock.SetupGet(o => o.AuthenticationMethod).Returns(AuthenticationType.OAuth);
+            optionsMock.SetupGet(o => o.ApiToken)
+                .Returns(new AuthenticationToken(AuthenticationType.OAuth, "existing-token"));
+            optionsMock.SetupSet(o => o.ApiToken = It.IsAny<AuthenticationToken>())
+                .Callback<AuthenticationToken>(t => setApiTokenCalls.Add(t));
+
+            var config = JsonConvert.SerializeObject(new IdeConfigData
+            {
+                AuthenticationMethod = "oauth",
+                Token = "new-oauth-token",
+            });
+
+            bridge.__saveIdeConfig__(config);
+
+            // No clear-token call; any ApiToken set should be the new value, not empty
+            Assert.DoesNotContain(setApiTokenCalls, t => t.ToString() == string.Empty);
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
@@ -64,6 +64,19 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
             optionsMock.VerifySet(o => o.AuthenticationMethod = AuthenticationType.Token);
         }
 
+        [Theory]
+        [InlineData("unknown")]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void IdeExecuteCommand_SnykLogin_DefaultsToOAuthForInvalidMethod(string authMethod)
+        {
+            var args = JsonConvert.SerializeObject(new object[] { authMethod, "https://api.snyk.io", false });
+
+            bridge.__ideExecuteCommand__("snyk.login", args, "");
+
+            optionsMock.VerifySet(o => o.AuthenticationMethod = AuthenticationType.OAuth);
+        }
+
         [Fact]
         public void IdeExecuteCommand_SnykLogin_SavesEndpoint()
         {

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
@@ -1,0 +1,108 @@
+using System;
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Moq;
+using Newtonsoft.Json;
+using Snyk.VisualStudio.Extension.Authentication;
+using Snyk.VisualStudio.Extension.Service;
+using Snyk.VisualStudio.Extension.Settings;
+using Snyk.VisualStudio.Extension.UI.Html;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.UI.Html
+{
+    [Collection(MockedVS.Collection)]
+    public class HtmlSettingsScriptingBridgeTest : PackageBaseTest
+    {
+        private readonly Mock<ISnykOptions> optionsMock;
+        private readonly Mock<ISnykOptionsManager> snykOptionsManagerMock;
+        private readonly HtmlSettingsScriptingBridge bridge;
+
+        public HtmlSettingsScriptingBridgeTest(GlobalServiceProvider gsp) : base(gsp)
+        {
+            var serviceProviderMock = new Mock<ISnykServiceProvider>();
+            optionsMock = new Mock<ISnykOptions>();
+            snykOptionsManagerMock = new Mock<ISnykOptionsManager>();
+
+            serviceProviderMock.SetupGet(sp => sp.Options).Returns(optionsMock.Object);
+            serviceProviderMock.SetupGet(sp => sp.SnykOptionsManager).Returns(snykOptionsManagerMock.Object);
+            serviceProviderMock.SetupGet(sp => sp.LanguageClientManager).Returns((ILanguageClientManager)null);
+
+            bridge = new HtmlSettingsScriptingBridge(
+                serviceProviderMock.Object,
+                onModified: () => { });
+        }
+
+        [Fact]
+        public void IdeExecuteCommand_SnykLogin_SavesOAuthMethod()
+        {
+            var args = JsonConvert.SerializeObject(new object[] { "oauth", "https://api.snyk.io", false });
+
+            bridge.__ideExecuteCommand__("snyk.login", args, "");
+
+            optionsMock.VerifySet(o => o.AuthenticationMethod = AuthenticationType.OAuth);
+        }
+
+        [Fact]
+        public void IdeExecuteCommand_SnykLogin_SavesPatMethod()
+        {
+            var args = JsonConvert.SerializeObject(new object[] { "pat", "https://api.snyk.io", false });
+
+            bridge.__ideExecuteCommand__("snyk.login", args, "");
+
+            optionsMock.VerifySet(o => o.AuthenticationMethod = AuthenticationType.Pat);
+        }
+
+        [Fact]
+        public void IdeExecuteCommand_SnykLogin_SavesTokenMethod()
+        {
+            var args = JsonConvert.SerializeObject(new object[] { "token", "https://api.snyk.io", false });
+
+            bridge.__ideExecuteCommand__("snyk.login", args, "");
+
+            optionsMock.VerifySet(o => o.AuthenticationMethod = AuthenticationType.Token);
+        }
+
+        [Fact]
+        public void IdeExecuteCommand_SnykLogin_SavesEndpoint()
+        {
+            var args = JsonConvert.SerializeObject(new object[] { "oauth", "https://api.eu.snyk.io", false });
+
+            bridge.__ideExecuteCommand__("snyk.login", args, "");
+
+            optionsMock.VerifySet(o => o.CustomEndpoint = "https://api.eu.snyk.io");
+        }
+
+        [Fact]
+        public void IdeExecuteCommand_SnykLogin_SavesInsecure()
+        {
+            var args = JsonConvert.SerializeObject(new object[] { "oauth", "https://api.snyk.io", true });
+
+            bridge.__ideExecuteCommand__("snyk.login", args, "");
+
+            optionsMock.VerifySet(o => o.IgnoreUnknownCA = true);
+        }
+
+        [Fact]
+        public void IdeExecuteCommand_SnykLogin_NoSaveWhenFewerThan3Args()
+        {
+            var args = JsonConvert.SerializeObject(new object[] { "oauth" });
+
+            bridge.__ideExecuteCommand__("snyk.login", args, "");
+
+            optionsMock.VerifySet(o => o.AuthenticationMethod = It.IsAny<AuthenticationType>(), Times.Never);
+            optionsMock.VerifySet(o => o.CustomEndpoint = It.IsAny<string>(), Times.Never);
+        }
+
+        [Fact]
+        public void IdeExecuteCommand_OtherCommand_DoesNotSaveAuthParams()
+        {
+            var args = JsonConvert.SerializeObject(new object[] { });
+
+            bridge.__ideExecuteCommand__("snyk.logout", args, "");
+
+            optionsMock.VerifySet(o => o.AuthenticationMethod = It.IsAny<AuthenticationType>(), Times.Never);
+            optionsMock.VerifySet(o => o.CustomEndpoint = It.IsAny<string>(), Times.Never);
+            optionsMock.VerifySet(o => o.IgnoreUnknownCA = It.IsAny<bool>(), Times.Never);
+        }
+    }
+}

--- a/Tests/Integration.Tests/ExtensionStartupTests.cs
+++ b/Tests/Integration.Tests/ExtensionStartupTests.cs
@@ -1,14 +1,14 @@
 ﻿namespace Integration.Tests
 {
-	using System;
-	using System.Threading.Tasks;
-	using Microsoft.VisualStudio.Shell;
-	using Microsoft.VisualStudio.Shell.Interop;
-	using Microsoft.VisualStudio.Threading;
-	using Snyk.VisualStudio.Extension;
-	using Xunit;
-	using Xunit.Abstractions;
-	using Task = System.Threading.Tasks.Task;
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Shell;
+    using Microsoft.VisualStudio.Shell.Interop;
+    using Microsoft.VisualStudio.Threading;
+    using Snyk.VisualStudio.Extension;
+    using Xunit;
+    using Xunit.Abstractions;
+    using Task = System.Threading.Tasks.Task;
 
 #if VS_VERSION_PRE22
 	[IdeSettings(MinVersion = VisualStudioVersion.VS2019, MaxVersion = VisualStudioVersion.VS2019)]
@@ -63,7 +63,7 @@
                 // Assert
                 Assert.True(packageObject != null, "Failed to find Snyk package");
                 Assert.IsType<SnykVSPackage>(packageObject);
-                var snykVsPackage = (SnykVSPackage) packageObject;
+                var snykVsPackage = (SnykVSPackage)packageObject;
                 Assert.True(snykVsPackage.IsInitialized, "Snyk package was not initialized");
             }
         }

--- a/Tests/Integration.Tests/GlobalSuppressions.cs
+++ b/Tests/Integration.Tests/GlobalSuppressions.cs
@@ -6,7 +6,7 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Style",
-	"VSTHRD200:Use \"Async\" suffix for async methods",
-	Justification = "Unnecessary for tests",
-	Scope = "namespaceanddescendants",
-	Target = "Integration.Tests.Shared")]
+    "VSTHRD200:Use \"Async\" suffix for async methods",
+    Justification = "Unnecessary for tests",
+    Scope = "namespaceanddescendants",
+    Target = "Integration.Tests.Shared")]


### PR DESCRIPTION
## What & Why

The settings page drives authentication via `snyk.login` with `[authMethod, endpoint, insecure]` args. Before forwarding to the LS, the IDE must persist these values locally so they survive a page close. Additionally, `$/snyk.hasAuthenticated` now carries `apiUrl` which is forwarded to the HTML settings window so the settings page can update both fields after auth.

Bridge persist writes to option properties directly — no `Save()` call means `SettingsChanged` never fires, `DidChangeConfigurationAsync` is not triggered.

## Changes

**`HtmlSettingsScriptingBridge.cs` — bridge persist**
In `__ideExecuteCommand__`, before dispatching `snyk.login` to the LS, when `args.Length >= 3`:
- Sets `Options.AuthenticationMethod` (C# switch: `"oauth"` → `OAuth`, `"pat"` → `Pat`, `"token"` → `Token`)
- Sets `Options.CustomEndpoint` from `args[1]`
- Sets `Options.IgnoreUnknownCA` from `args[2]`
- No `Save()` call — properties written in-memory only, no `SettingsChanged` event, no `DidChangeConfigurationAsync`

**`SnykLanguageClientCustomTarget.cs` — `OnHasAuthenticated`**
- Always saves `CustomEndpoint` (when non-empty) and `ApiToken`
- `Save(serviceProvider.Options, false)` — `false` suppresses `SettingsChanged` → no `DidChangeConfigurationAsync` loop
- `HtmlSettingsWindow.Instance?.UpdateAuthToken(token, apiUrl)` — always updates webview so settings page shows both fields immediately
- `isNewLogin` guard (`string.IsNullOrEmpty(oldToken) && !string.IsNullOrEmpty(token)`) gates `HandleAuthenticationSuccess` + scan — token refreshes skip scanning

**`HtmlSettingsWindow.xaml.cs`**
`UpdateAuthToken(string token, string apiUrl = null)` passes `apiUrl` through to `window.setAuthToken(escapedToken, escapedApiUrl)`.

## Tests

- `SnykLanguageClientCustomTargetTests.cs`: new tests for new login (verifies endpoint + token saved, `Save(_, false)`, `HandleAuthenticationSuccess` called), token refresh (quiet save, no `HandleAuthenticationSuccess`), and always-updates-webview cases
- `HtmlSettingsScriptingBridgeTest.cs` (new): 7 tests — auth method mapping (oauth/pat/token), endpoint, insecure, no-op on <3 args, no-op on non-login command

## Test plan

- [ ] Settings page: change endpoint + auth method → click Authenticate → IDE saves values → auth succeeds → token and apiUrl appear in settings page
- [ ] Close/reopen settings page → values persist
- [ ] Token refresh → settings page webview shows new token without triggering a scan
- [ ] No `DidChangeConfigurationAsync` fired when bridge saves auth params
- [ ] Run test suite