### PR TITLE
chore: remove unused toolkit 17 from test suite

### DIFF
--- a/Snyk.VisualStudio.Extension.Tests/Snyk.VisualStudio.Extension.Tests.csproj
+++ b/Snyk.VisualStudio.Extension.Tests/Snyk.VisualStudio.Extension.Tests.csproj
@@ -54,7 +54,6 @@
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="17.4.1068" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.8" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.6.40" />
-    <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.394" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

The presence of the toolkit in the test suite causes warning when compiling and running the tests. It appears to be unused, so can be removed.

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
