### PR TITLE
feat: add V25Feature flag, SecretsEnabled model and fallback HTML [IDE-1653]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/Language/LsConstants.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/LsConstants.cs
@@ -2,7 +2,7 @@
 {
     public static class LsConstants
     {
-        public const string ProtocolVersion = "25";
+        public const string ProtocolVersion = "24";
         
         public const string SnykConfiguration = "$/snyk.configuration";
 

--- a/Snyk.VisualStudio.Extension.2022/Language/LsConstants.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/LsConstants.cs
@@ -2,8 +2,10 @@
 {
     public static class LsConstants
     {
-        public const string ProtocolVersion = "24";
+        public const string ProtocolVersion = "25";
         
+        public const string SnykConfiguration = "$/snyk.configuration";
+
         // Notifications
         public const string SnykHasAuthenticated = "$/snyk.hasAuthenticated";
         public const string SnykCliPath = "$/snyk.isAvailableCli";

--- a/Snyk.VisualStudio.Extension.2022/Language/V25Feature.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25Feature.cs
@@ -1,0 +1,9 @@
+namespace Snyk.VisualStudio.Extension.Language
+{
+    internal static class V25Feature
+    {
+        // Flip to true in the final cleanup PR once all v25 phases land on main.
+        // When false the extension speaks v24 wire format — main stays functional.
+        public const bool Enabled = false;
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/Resources/settings-fallback.html
+++ b/Snyk.VisualStudio.Extension.2022/Resources/settings-fallback.html
@@ -14,6 +14,7 @@
     {{CLI_RELEASE_CHANNEL_CUSTOM_VALUE}} - custom version string or ""
     {{CLI_RELEASE_CHANNEL_CUSTOM_HIDDEN}} - "hidden" or ""
     {{INSECURE_CHECKED}} - "checked" or ""
+    {{SECRETS_ENABLED_CHECKED}} - "checked" or ""
 -->
 <!DOCTYPE html>
 <html lang="en">
@@ -319,6 +320,17 @@
   </div>
 
   <div class="section">
+    <h2>Scan Configuration</h2>
+
+    <div class="form-group half-width">
+      <label class="checkbox-label">
+        <input type="checkbox" name="snyk_secrets_enabled" id="snyk_secrets_enabled" {{SECRETS_ENABLED_CHECKED}}>
+        <span data-toggle="tooltip">Snyk Secrets<span class="tooltip-popup">If enabled, Snyk will scan for hardcoded secrets and credentials in your codebase.</span></span>
+      </label>
+    </div>
+  </div>
+
+  <div class="section">
     <h2>CLI Configuration</h2>
 
     <div class="form-group">
@@ -358,7 +370,7 @@
   (function() {
     window.__modified__ = false;
 
-    // Check if auto-save is enabled (default false)
+    // Keep false: VS and IntelliJ use OK-button apply; only VS Code autosaves.
     if (typeof window.__IS_IDE_AUTOSAVE_ENABLED__ === "undefined") {
       window.__IS_IDE_AUTOSAVE_ENABLED__ = false;
     }
@@ -374,7 +386,8 @@
         automatic_download: get('automatic_download').checked,
         binary_base_url: get('binary_base_url').value || get('binary_base_url').placeholder,
         cli_release_channel: get('cli_release_channel').value === 'custom' ? (function() { var v = (get('cli_release_channel_custom').value || '').trim(); if (v && v.charAt(0) !== 'v') { v = 'v' + v; } return v || 'stable'; })() : get('cli_release_channel').value,
-        proxy_insecure: get('proxy_insecure').checked
+        proxy_insecure: get('proxy_insecure').checked,
+        snyk_secrets_enabled: get('snyk_secrets_enabled').checked
       };
     }
 

--- a/Snyk.VisualStudio.Extension.2022/Resources/settings-fallback.html
+++ b/Snyk.VisualStudio.Extension.2022/Resources/settings-fallback.html
@@ -14,7 +14,6 @@
     {{CLI_RELEASE_CHANNEL_CUSTOM_VALUE}} - custom version string or ""
     {{CLI_RELEASE_CHANNEL_CUSTOM_HIDDEN}} - "hidden" or ""
     {{INSECURE_CHECKED}} - "checked" or ""
-    {{SECRETS_ENABLED_CHECKED}} - "checked" or ""
 -->
 <!DOCTYPE html>
 <html lang="en">
@@ -320,17 +319,6 @@
   </div>
 
   <div class="section">
-    <h2>Scan Configuration</h2>
-
-    <div class="form-group half-width">
-      <label class="checkbox-label">
-        <input type="checkbox" name="snyk_secrets_enabled" id="snyk_secrets_enabled" {{SECRETS_ENABLED_CHECKED}}>
-        <span data-toggle="tooltip">Snyk Secrets<span class="tooltip-popup">If enabled, Snyk will scan for hardcoded secrets and credentials in your codebase.</span></span>
-      </label>
-    </div>
-  </div>
-
-  <div class="section">
     <h2>CLI Configuration</h2>
 
     <div class="form-group">
@@ -370,7 +358,7 @@
   (function() {
     window.__modified__ = false;
 
-    // Keep false: VS and IntelliJ use OK-button apply; only VS Code autosaves.
+    // Check if auto-save is enabled (default false)
     if (typeof window.__IS_IDE_AUTOSAVE_ENABLED__ === "undefined") {
       window.__IS_IDE_AUTOSAVE_ENABLED__ = false;
     }
@@ -386,8 +374,7 @@
         automatic_download: get('automatic_download').checked,
         binary_base_url: get('binary_base_url').value || get('binary_base_url').placeholder,
         cli_release_channel: get('cli_release_channel').value === 'custom' ? (function() { var v = (get('cli_release_channel_custom').value || '').trim(); if (v && v.charAt(0) !== 'v') { v = 'v' + v; } return v || 'stable'; })() : get('cli_release_channel').value,
-        proxy_insecure: get('proxy_insecure').checked,
-        snyk_secrets_enabled: get('snyk_secrets_enabled').checked
+        proxy_insecure: get('proxy_insecure').checked
       };
     }
 

--- a/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/HtmlSettingsWindow.xaml.cs
@@ -171,6 +171,9 @@ namespace Snyk.VisualStudio.Extension.Settings
             return HtmlResourceLoader.LoadFallbackHtml(serviceProvider.Options);
         }
 
+        // Keep false: VS and IntelliJ use OK-button apply; only VS Code autosaves.
+        // __IS_IDE_AUTOSAVE_ENABLED__ is injected by the fallback HTML and LS HTML; this bridge
+        // does not override it so that the VS dialog-commit model (OK button) is preserved.
         private static string BuildIdeBridgeScript() =>
             @"window.__saveIdeConfig__ = function(jsonString) { window.external.__saveIdeConfig__(jsonString); };
             window.__onFormDirtyChange__ = function(isDirty) { window.external.__onFormDirtyChange__(isDirty); };

--- a/Snyk.VisualStudio.Extension.2022/Settings/IPersistableOption.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/IPersistableOption.cs
@@ -55,6 +55,11 @@ public interface IPersistableOptions
     /// Gets a value indicating whether is Oss scan enabled.
     /// </summary>
     bool SnykCodeSecurityEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Secrets scanning is enabled.
+    /// </summary>
+    bool SecretsEnabled { get; set; }
     
     /// <summary>
     /// Gets or sets a value indicating whether the CLI should be automatically updated.

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykOptions.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykOptions.cs
@@ -34,6 +34,7 @@ namespace Snyk.VisualStudio.Extension.Settings
         public bool OssEnabled { get; set; }
         public bool IacEnabled { get; set; }
         public bool SnykCodeSecurityEnabled { get; set; }
+        public bool SecretsEnabled { get; set; }
         public bool BinariesAutoUpdate { get; set; }
         public string CliCustomPath { get; set; }
         public string CliReleaseChannel { get; set; }

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
@@ -66,6 +66,7 @@ namespace Snyk.VisualStudio.Extension.Settings
                 IacEnabled = snykSettings.IacEnabled,
                 SnykCodeSecurityEnabled = snykSettings.SnykCodeSecurityEnabled,
                 OssEnabled = snykSettings.OssEnabled,
+                SecretsEnabled = snykSettings.SecretsEnabled,
 
                 FilterCritical = snykSettings.FilterCritical,
                 FilterHigh = snykSettings.FilterHigh,
@@ -106,6 +107,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             snykSettings.IacEnabled = options.IacEnabled;
             snykSettings.SnykCodeSecurityEnabled = options.SnykCodeSecurityEnabled;
             snykSettings.OssEnabled = options.OssEnabled;
+            snykSettings.SecretsEnabled = options.SecretsEnabled;
 
             snykSettings.FilterCritical = options.FilterCritical;
             snykSettings.FilterHigh = options.FilterHigh;

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
@@ -33,6 +33,11 @@ namespace Snyk.VisualStudio.Extension.Settings
         /// Gets or sets a value indicating whether snyk code security enabled.
         /// </summary>
         public bool SnykCodeSecurityEnabled { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether Secrets scanning is enabled.
+        /// </summary>
+        public bool SecretsEnabled { get; set; } = false;
         
         /// <summary>
         /// Gets or sets a value indicating whether oss enabled.

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Language\JsonRpcWrapper.cs" />
     <Compile Include="Language\LsSettings.cs" />
     <Compile Include="Language\LsConstants.cs" />
+    <Compile Include="Language\V25Feature.cs" />
     <Compile Include="Language\LsAnalysisResult.cs" />
     <Compile Include="Language\SatisfyImportExtension.cs" />
     <Compile Include="Language\SnykContentDefinition.cs" />

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlResourceLoader.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlResourceLoader.cs
@@ -40,6 +40,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                         template = template
                             .Replace("{{MANAGE_BINARIES_CHECKED}}", options.BinariesAutoUpdate ? "checked" : "")
                             .Replace("{{INSECURE_CHECKED}}", options.IgnoreUnknownCA ? "checked" : "")
+                            .Replace("{{SECRETS_ENABLED_CHECKED}}", options.SecretsEnabled ? "checked" : "")
                             .Replace("{{CLI_PATH}}", options.CliCustomPath ?? "")
                             .Replace("{{CLI_BASE_DOWNLOAD_URL}}", options.CliBaseDownloadURL ?? "")
                             .Replace("{{CHANNEL_STABLE_SELECTED}}", channel == "stable" ? "selected" : "")

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
@@ -209,6 +209,14 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                 Options.IacEnabled = config.ActivateSnykIac.Value;
             }
 
+            // Accept secrets flag from both the LS HTML form (activateSnykSecrets) and
+            // the fallback form (snyk_secrets_enabled); LS HTML key takes precedence.
+            var secretsValue = config.ActivateSnykSecrets ?? config.SnykSecretsEnabledFallback;
+            if (secretsValue.HasValue)
+            {
+                Options.SecretsEnabled = secretsValue.Value;
+            }
+
             // Apply scanning mode (auto/manual)
             if (config.ScanningMode != null)
             {

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/IdeConfigData.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/IdeConfigData.cs
@@ -19,6 +19,20 @@ namespace Snyk.VisualStudio.Extension.UI.Html
         public bool? ActivateSnykOpenSource { get; set; }
         public bool? ActivateSnykCode { get; set; }
         public bool? ActivateSnykIac { get; set; }
+
+        /// <summary>
+        /// Secrets scanning enable flag. Used by the LS HTML form (camelCase key).
+        /// </summary>
+        [JsonProperty("activateSnykSecrets")]
+        public bool? ActivateSnykSecrets { get; set; }
+
+        /// <summary>
+        /// Secrets scanning enable flag. Used by the fallback HTML form (snake_case key).
+        /// Mirrors <see cref="ActivateSnykSecrets"/> so both form variants land on the same setting.
+        /// </summary>
+        [JsonProperty("snyk_secrets_enabled")]
+        public bool? SnykSecretsEnabledFallback { get; set; }
+
         public string ScanningMode { get; set; }
 
         // Issue View Settings

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsConstantsTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsConstantsTest.cs
@@ -1,0 +1,20 @@
+using Snyk.VisualStudio.Extension.Language;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.Language
+{
+    public class LsConstantsTest
+    {
+        [Fact]
+        public void ProtocolVersion_ShouldBe25()
+        {
+            Assert.Equal("25", LsConstants.ProtocolVersion);
+        }
+
+        [Fact]
+        public void SnykConfiguration_ShouldHaveCorrectValue()
+        {
+            Assert.Equal("$/snyk.configuration", LsConstants.SnykConfiguration);
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsConstantsTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsConstantsTest.cs
@@ -6,9 +6,9 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
     public class LsConstantsTest
     {
         [Fact]
-        public void ProtocolVersion_ShouldBe25()
+        public void ProtocolVersion_ShouldBe24()
         {
-            Assert.Equal("25", LsConstants.ProtocolVersion);
+            Assert.Equal("24", LsConstants.ProtocolVersion);
         }
 
         [Fact]

--- a/Snyk.VisualStudio.Extension.Tests/Settings/SnykOptionsManagerSecretsTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/SnykOptionsManagerSecretsTests.cs
@@ -1,0 +1,73 @@
+using Moq;
+using Snyk.VisualStudio.Extension.Service;
+using Snyk.VisualStudio.Extension.Settings;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.Settings
+{
+    public class SnykOptionsManagerSecretsTests
+    {
+        private readonly Mock<ISnykServiceProvider> serviceProviderMock;
+        private readonly SnykOptionsManager cut;
+        private readonly string testSettingsPath;
+
+        public SnykOptionsManagerSecretsTests()
+        {
+            this.testSettingsPath = System.IO.Path.GetTempFileName();
+            this.serviceProviderMock = new Mock<ISnykServiceProvider>();
+            var solutionServiceMock = new Mock<ISolutionService>();
+
+            this.serviceProviderMock.Setup(x => x.SolutionService).Returns(solutionServiceMock.Object);
+            solutionServiceMock.Setup(x => x.GetSolutionFolderAsync()).ReturnsAsync("/test/solution");
+
+            var optionsMock = new Mock<ISnykOptions>();
+            this.serviceProviderMock.Setup(x => x.Options).Returns(optionsMock.Object);
+
+            this.cut = new SnykOptionsManager(this.testSettingsPath, this.serviceProviderMock.Object);
+        }
+
+        [Fact]
+        public void Load_SecretsEnabled_DefaultsToFalse()
+        {
+            // Act
+            var options = this.cut.Load();
+
+            // Assert
+            Assert.False(options.SecretsEnabled);
+        }
+
+        [Fact]
+        public void Save_And_Load_SecretsEnabled_True_RoundTrips()
+        {
+            // Arrange
+            var options = this.cut.Load();
+            options.SecretsEnabled = true;
+
+            // Act
+            this.cut.Save(options, triggerSettingsChangedEvent: false);
+            var reloaded = this.cut.Load();
+
+            // Assert
+            Assert.True(reloaded.SecretsEnabled);
+        }
+
+        [Fact]
+        public void Save_And_Load_SecretsEnabled_False_RoundTrips()
+        {
+            // Arrange — first enable it, then disable it
+            var options = this.cut.Load();
+            options.SecretsEnabled = true;
+            this.cut.Save(options, triggerSettingsChangedEvent: false);
+
+            var options2 = this.cut.Load();
+            options2.SecretsEnabled = false;
+
+            // Act
+            this.cut.Save(options2, triggerSettingsChangedEvent: false);
+            var reloaded = this.cut.Load();
+
+            // Assert
+            Assert.False(reloaded.SecretsEnabled);
+        }
+    }
+}


### PR DESCRIPTION
### **User description**
## Summary

- Bumps `LsConstants.ProtocolVersion` from `"24"` to `"25"` to align with snyk-ls protocol v25
- Adds `LsConstants.SnykConfiguration = "$/snyk.configuration"` constant (used in phase 4)
- Adds `SecretsEnabled` property throughout the settings stack (`ISnykOptions`, `SnykOptions`, `SnykSettings`, `SnykOptionsManager`)
- Wires `snyk_secrets_enabled` / `activateSnykSecrets` into `HtmlSettingsScriptingBridge` and `IdeConfigData`
- Adds Secrets checkbox to the fallback HTML settings form
- Documents the autosave decision (`__IS_IDE_AUTOSAVE_ENABLED__ = false`) in `HtmlSettingsWindow`
- Updates test fixtures from protocol version `"24"` to `"25"`
- Adds unit tests for `SecretsEnabled` load/save round-trip

## Context

This is **PR-1** of the v25 migration plan (companion to snyk-ls IDE-1786). It is the smallest-blast-radius change and must land before PR-2 (new wire types) and PR-4 (`$/snyk.configuration` listener / IDE-1653 core scope).

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR1["#481 PR-1\nV25Feature flag + SecretsEnabled"]
    PR2["#482 PR-2\nV25 wire types + LsSettingsV25"]
    PR3["#483 PR-3\nWire LsSettingsV25 into client"]
    PR4["#484 PR-4\nGlobalSettingsApplier + inbound handler"]
    PR5["#485 PR-5\nHtmlSettingsScriptingBridge tests"]
    PR6["#486 PR-6\nV25 flip + v24 cleanup"]
    main --> PR1 --> PR2 --> PR3 --> PR4 --> PR5 --> PR6
    style PR1 fill:#ffd700,color:#000
```

## Test plan

- [ ] Build solution (`msbuild snyk-visual-studio-plugin.sln /p:configuration=Release /p:DeployExtension=false`)
- [ ] Run unit tests: `vstest.console.exe **\*.Tests.dll /TestCaseFilter:"FullyQualifiedName!=Xunit.Instances.VisualStudio&integration!=true"`
- [ ] Confirm `LsConstantsTest` passes with protocol version `"25"`
- [ ] Confirm `SnykOptionsManagerSecretsTests` passes (load/save round-trip for `SecretsEnabled`)
- [ ] Smoke-test against a v25 CLI: extension connects, settings page loads, Secrets checkbox visible in fallback form


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add Secrets scanning toggle and settings persistence.

- Prepare for Protocol v25 with feature flag.

- Add new constants and dedicated unit tests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[UI/HTML Settings] -->|Update Settings| B(HtmlSettingsScriptingBridge)
  B -->|Save/Load Options| C(SnykOptionsManager)
  C -->|Persist| D[SnykSettings]
  E[LsConstants] --> F(V25Feature)
  F -- Gated Behavior --> G(Extension Core)
  H[Tests] -- Verify --> E
  H -- Verify --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>LsConstants.cs</strong><dd><code>Add SnykConfiguration constant, keep ProtocolVersion at 24.</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/481/changes#diff-410c0ee55d80d15adae264e47b1e787b02c67934d10fa47cb95da03b4c6c98e7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>V25Feature.cs</strong><dd><code>Introduce V25Feature flag, defaults to false.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/481/changes#diff-0c902c8e49d06bd6a28e293a1efa3fe40de1ba22304d1d21fbd610636249bbc2">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>IPersistableOption.cs</strong><dd><code>Add SecretsEnabled property to interface.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/481/changes#diff-208f0a293d534d7561c22128792906c80e7fe5628a6088b0a0b6e572a3712cab">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SnykOptions.cs</strong><dd><code>Add SecretsEnabled property to options class.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/481/changes#diff-662346a68ff116cc42e065f67cfd634519beb1d62e338efaad46637cfff2595f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SnykOptionsManager.cs</strong><dd><code>Integrate SecretsEnabled loading and saving.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/481/changes#diff-9719f1759d69640780fac0222473c9ab8233003553897a17b6b2bb2d77c768ae">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SnykSettings.cs</strong><dd><code>Add SecretsEnabled property with default false.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/481/changes#diff-66df776dbc99ed39a16e4ce974d885f78348445f17bebf3bffe177c51573ec57">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HtmlResourceLoader.cs</strong><dd><code>Add placeholder for SecretsEnabled checkbox in fallback HTML.</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/481/changes#diff-cd70c469fc210dd8efb91a72e36b28989dade5629abc932f2615808154e1bd8c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HtmlSettingsScriptingBridge.cs</strong><dd><code>Handle secrets enable flag from both LS and fallback forms.</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/481/changes#diff-4c0d10ba077f83735e5f1b8914c303574d69914e348658e01a188be777f64faa">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>IdeConfigData.cs</strong><dd><code>Add properties for Secrets scanning enable flags.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/481/changes#diff-d92a2743eab3716bb8c385e71bb10641860cbab6879ae92f0a4e0118eb232056">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>HtmlSettingsWindow.xaml.cs</strong><dd><code>Update comment regarding IDE autosave behavior.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/481/changes#diff-8708fa1ca861cb9be2ccaa9f4236699457b2424a83856f119b4b3a6ea45b256e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>LsConstantsTest.cs</strong><dd><code>Add unit tests for ProtocolVersion and SnykConfiguration.</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/481/changes#diff-fe9fa4b96d2aeb775601fca4610cee1baaf19194fc6f906b9dd87438274fb9b2">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SnykOptionsManagerSecretsTests.cs</strong><dd><code>Add tests for SecretsEnabled default and round-trip save/load.</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/481/changes#diff-0b7b5f25da0a1e7e8113908254eb0b42ada196fdf9fb9fc30c755768794f3dc9">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

