### PR TITLE
feat: add GlobalSettingsApplier and wire inbound $/snyk.configuration handler [IDE-1653]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClientCustomTarget.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClientCustomTarget.cs
@@ -311,9 +311,12 @@ namespace Snyk.VisualStudio.Extension.Language
             var param = arg.TryParse<LspConfigurationParam>();
             if (param == null) return;
 
-            // TODO (IDE-1653 flip): apply param.Settings and param.FolderConfigs to serviceProvider.Options
-            // Full inbound settings application is implemented in phase 4 (PR-4).
-            Logger.Debug("$/snyk.configuration received: {FolderConfigCount} folder config(s)", param.FolderConfigs?.Count ?? 0);
+            var options = serviceProvider.Options;
+            GlobalSettingsApplier.Apply(param.Settings, options);
+            // Persist without re-triggering DidChangeConfigurationAsync (avoids feedback loop).
+            this.serviceProvider.SnykOptionsManager.Save(options, false);
+            Logger.Debug("$/snyk.configuration applied: {KeyCount} global setting(s), {FolderCount} folder config(s)",
+                param.Settings?.Count ?? 0, param.FolderConfigs?.Count ?? 0);
         }
 
         [JsonRpcMethod(LsConstants.SnykAddTrustedFolders)]

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/GlobalSettingsApplier.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/GlobalSettingsApplier.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
+using Serilog;
 using Snyk.VisualStudio.Extension.Authentication;
 using Snyk.VisualStudio.Extension.Settings;
 
@@ -10,6 +12,8 @@ namespace Snyk.VisualStudio.Extension.Language
     // PATCH semantics: absent or null-value entries are skipped (existing values preserved).
     internal static class GlobalSettingsApplier
     {
+        private static readonly ILogger Logger = LogManager.ForContext(typeof(GlobalSettingsApplier));
+
         public static void Apply(Dictionary<string, ConfigSetting> settings, ISnykOptions options)
         {
             if (settings == null || settings.Count == 0) return;
@@ -22,60 +26,71 @@ namespace Snyk.VisualStudio.Extension.Language
             if (setting?.Value == null) return;
             var val = setting.Value is JToken jt ? jt : JToken.FromObject(setting.Value);
 
-            switch (key)
+            try
             {
-                case PflagKeys.SnykOssEnabled:       options.OssEnabled = val.Value<bool>(); break;
-                case PflagKeys.SnykCodeEnabled:      options.SnykCodeSecurityEnabled = val.Value<bool>(); break;
-                case PflagKeys.SnykIacEnabled:       options.IacEnabled = val.Value<bool>(); break;
-                case PflagKeys.SnykSecretsEnabled:   options.SecretsEnabled = val.Value<bool>(); break;
+                switch (key)
+                {
+                    case PflagKeys.SnykOssEnabled:       options.OssEnabled = val.Value<bool>(); break;
+                    case PflagKeys.SnykCodeEnabled:      options.SnykCodeSecurityEnabled = val.Value<bool>(); break;
+                    case PflagKeys.SnykIacEnabled:       options.IacEnabled = val.Value<bool>(); break;
+                    case PflagKeys.SnykSecretsEnabled:   options.SecretsEnabled = val.Value<bool>(); break;
 
-                case PflagKeys.ScanAutomatic:        options.AutoScan = val.Value<bool>(); break;
-                case PflagKeys.ScanNetNew:           options.EnableDeltaFindings = val.Value<bool>(); break;
+                    case PflagKeys.ScanAutomatic:        options.AutoScan = val.Value<bool>(); break;
+                    case PflagKeys.ScanNetNew:           options.EnableDeltaFindings = val.Value<bool>(); break;
 
-                case PflagKeys.SeverityFilterCritical: options.FilterCritical = val.Value<bool>(); break;
-                case PflagKeys.SeverityFilterHigh:     options.FilterHigh     = val.Value<bool>(); break;
-                case PflagKeys.SeverityFilterMedium:   options.FilterMedium   = val.Value<bool>(); break;
-                case PflagKeys.SeverityFilterLow:      options.FilterLow      = val.Value<bool>(); break;
+                    case PflagKeys.SeverityFilterCritical: options.FilterCritical = val.Value<bool>(); break;
+                    case PflagKeys.SeverityFilterHigh:     options.FilterHigh     = val.Value<bool>(); break;
+                    case PflagKeys.SeverityFilterMedium:   options.FilterMedium   = val.Value<bool>(); break;
+                    case PflagKeys.SeverityFilterLow:      options.FilterLow      = val.Value<bool>(); break;
 
-                case PflagKeys.IssueViewOpenIssues:    options.OpenIssuesEnabled    = val.Value<bool>(); break;
-                case PflagKeys.IssueViewIgnoredIssues: options.IgnoredIssuesEnabled = val.Value<bool>(); break;
+                    case PflagKeys.IssueViewOpenIssues:    options.OpenIssuesEnabled    = val.Value<bool>(); break;
+                    case PflagKeys.IssueViewIgnoredIssues: options.IgnoredIssuesEnabled = val.Value<bool>(); break;
 
-                case PflagKeys.RiskScoreThreshold:   options.RiskScoreThreshold = val.Value<int?>(); break;
+                    case PflagKeys.RiskScoreThreshold:   options.RiskScoreThreshold = val.Value<int?>(); break;
 
-                case PflagKeys.ApiEndpoint:          options.CustomEndpoint  = val.Value<string>(); break;
-                case PflagKeys.Organization:         options.Organization    = val.Value<string>(); break;
-                case PflagKeys.ProxyInsecure:        options.IgnoreUnknownCA = val.Value<bool>(); break;
+                    case PflagKeys.ApiEndpoint:          options.CustomEndpoint  = val.Value<string>(); break;
+                    case PflagKeys.Organization:         options.Organization    = val.Value<string>(); break;
+                    case PflagKeys.ProxyInsecure:        options.IgnoreUnknownCA = val.Value<bool>(); break;
 
-                case PflagKeys.AutomaticDownload:    options.BinariesAutoUpdate = val.Value<bool>(); break;
-                case PflagKeys.CliPath:              options.CliCustomPath      = val.Value<string>(); break;
-                case PflagKeys.BinaryBaseUrl:        options.CliBaseDownloadURL = val.Value<string>(); break;
-                case PflagKeys.CliReleaseChannel:    options.CliReleaseChannel  = val.Value<string>(); break;
+                    case PflagKeys.AutomaticDownload:    options.BinariesAutoUpdate = val.Value<bool>(); break;
+                    case PflagKeys.CliPath:              options.CliCustomPath      = val.Value<string>(); break;
+                    case PflagKeys.BinaryBaseUrl:        options.CliBaseDownloadURL = val.Value<string>(); break;
+                    case PflagKeys.CliReleaseChannel:    options.CliReleaseChannel  = val.Value<string>(); break;
 
-                case PflagKeys.AdditionalEnvironment: options.AdditionalEnv = val.Value<string>(); break;
+                    case PflagKeys.AdditionalEnvironment: options.AdditionalEnv = val.Value<string>(); break;
 
-                case PflagKeys.TrustedFolders:
-                    var list = val.ToObject<List<string>>();
-                    options.TrustedFolders = new HashSet<string>(
-                        list ?? Enumerable.Empty<string>());
-                    break;
+                    case PflagKeys.TrustedFolders:
+                        var list = val.ToObject<List<string>>();
+                        options.TrustedFolders = new HashSet<string>(
+                            list ?? Enumerable.Empty<string>());
+                        break;
 
-                case PflagKeys.AuthenticationMethod:
-                    options.AuthenticationMethod = ParseAuthMethod(val.Value<string>());
-                    break;
+                    case PflagKeys.AuthenticationMethod:
+                        options.AuthenticationMethod = ParseAuthMethod(val.Value<string>());
+                        break;
 
-                case PflagKeys.Token:
-                    var tokenStr = val.Value<string>();
-                    if (tokenStr != null)
-                        options.ApiToken = new AuthenticationToken(options.AuthenticationMethod, tokenStr);
-                    break;
+                    // token is declared writeOnly:true in snyk-ls (ldx_sync_config.go) and is
+                    // never included in $/snyk.configuration payloads sent to the IDE, so the
+                    // ordering dependency on AuthenticationMethod is a non-issue in production.
+                    // The case is kept for completeness if Apply is reused in other contexts.
+                    case PflagKeys.Token:
+                        var tokenStr = val.Value<string>();
+                        if (tokenStr != null)
+                            options.ApiToken = new AuthenticationToken(options.AuthenticationMethod, tokenStr);
+                        break;
 
-                // Read-only / metadata keys sent by LS — safe to ignore on inbound.
-                case PflagKeys.ClientProtocolVersion:
-                case PflagKeys.DeviceId:
-                case PflagKeys.AutoDeterminedOrg:
-                case PflagKeys.OrgSetByUser:
-                case PflagKeys.BaseBranch:
-                    break;
+                    // Read-only / metadata keys sent by LS — safe to ignore on inbound.
+                    case PflagKeys.ClientProtocolVersion:
+                    case PflagKeys.DeviceId:
+                    case PflagKeys.AutoDeterminedOrg:
+                    case PflagKeys.OrgSetByUser:
+                    case PflagKeys.BaseBranch:
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "GlobalSettingsApplier: failed to apply key '{Key}', skipping", key);
             }
         }
 

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/GlobalSettingsApplier.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/GlobalSettingsApplier.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Snyk.VisualStudio.Extension.Authentication;
+using Snyk.VisualStudio.Extension.Settings;
+
+namespace Snyk.VisualStudio.Extension.Language
+{
+    // Applies a pflag-keyed settings map (from $/snyk.configuration) to ISnykOptions.
+    // PATCH semantics: absent or null-value entries are skipped (existing values preserved).
+    internal static class GlobalSettingsApplier
+    {
+        public static void Apply(Dictionary<string, ConfigSetting> settings, ISnykOptions options)
+        {
+            if (settings == null || settings.Count == 0) return;
+            foreach (var kvp in settings)
+                ApplyOne(kvp.Key, kvp.Value, options);
+        }
+
+        private static void ApplyOne(string key, ConfigSetting setting, ISnykOptions options)
+        {
+            if (setting?.Value == null) return;
+            var val = setting.Value is JToken jt ? jt : JToken.FromObject(setting.Value);
+
+            switch (key)
+            {
+                case PflagKeys.SnykOssEnabled:       options.OssEnabled = val.Value<bool>(); break;
+                case PflagKeys.SnykCodeEnabled:      options.SnykCodeSecurityEnabled = val.Value<bool>(); break;
+                case PflagKeys.SnykIacEnabled:       options.IacEnabled = val.Value<bool>(); break;
+                case PflagKeys.SnykSecretsEnabled:   options.SecretsEnabled = val.Value<bool>(); break;
+
+                case PflagKeys.ScanAutomatic:        options.AutoScan = val.Value<bool>(); break;
+                case PflagKeys.ScanNetNew:           options.EnableDeltaFindings = val.Value<bool>(); break;
+
+                case PflagKeys.SeverityFilterCritical: options.FilterCritical = val.Value<bool>(); break;
+                case PflagKeys.SeverityFilterHigh:     options.FilterHigh     = val.Value<bool>(); break;
+                case PflagKeys.SeverityFilterMedium:   options.FilterMedium   = val.Value<bool>(); break;
+                case PflagKeys.SeverityFilterLow:      options.FilterLow      = val.Value<bool>(); break;
+
+                case PflagKeys.IssueViewOpenIssues:    options.OpenIssuesEnabled    = val.Value<bool>(); break;
+                case PflagKeys.IssueViewIgnoredIssues: options.IgnoredIssuesEnabled = val.Value<bool>(); break;
+
+                case PflagKeys.RiskScoreThreshold:   options.RiskScoreThreshold = val.Value<int?>(); break;
+
+                case PflagKeys.ApiEndpoint:          options.CustomEndpoint  = val.Value<string>(); break;
+                case PflagKeys.Organization:         options.Organization    = val.Value<string>(); break;
+                case PflagKeys.ProxyInsecure:        options.IgnoreUnknownCA = val.Value<bool>(); break;
+
+                case PflagKeys.AutomaticDownload:    options.BinariesAutoUpdate = val.Value<bool>(); break;
+                case PflagKeys.CliPath:              options.CliCustomPath      = val.Value<string>(); break;
+                case PflagKeys.BinaryBaseUrl:        options.CliBaseDownloadURL = val.Value<string>(); break;
+                case PflagKeys.CliReleaseChannel:    options.CliReleaseChannel  = val.Value<string>(); break;
+
+                case PflagKeys.AdditionalEnvironment: options.AdditionalEnv = val.Value<string>(); break;
+
+                case PflagKeys.TrustedFolders:
+                    var list = val.ToObject<List<string>>();
+                    options.TrustedFolders = new HashSet<string>(
+                        list ?? Enumerable.Empty<string>());
+                    break;
+
+                case PflagKeys.AuthenticationMethod:
+                    options.AuthenticationMethod = ParseAuthMethod(val.Value<string>());
+                    break;
+
+                case PflagKeys.Token:
+                    var tokenStr = val.Value<string>();
+                    if (tokenStr != null)
+                        options.ApiToken = new AuthenticationToken(options.AuthenticationMethod, tokenStr);
+                    break;
+
+                // Read-only / metadata keys sent by LS — safe to ignore on inbound.
+                case PflagKeys.ClientProtocolVersion:
+                case PflagKeys.DeviceId:
+                case PflagKeys.AutoDeterminedOrg:
+                case PflagKeys.OrgSetByUser:
+                case PflagKeys.BaseBranch:
+                    break;
+            }
+        }
+
+        private static AuthenticationType ParseAuthMethod(string method) =>
+            (method?.ToLowerInvariant().Trim()) switch
+            {
+                "token" => AuthenticationType.Token,
+                "pat"   => AuthenticationType.Pat,
+                _       => AuthenticationType.OAuth,
+            };
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Language\V25\LspConfigurationParam.cs" />
     <Compile Include="Language\V25\InitializationOptionsV25.cs" />
     <Compile Include="Language\V25\LsSettingsV25.cs" />
+    <Compile Include="Language\V25\GlobalSettingsApplier.cs" />
     <Compile Include="Language\LsAnalysisResult.cs" />
     <Compile Include="Language\SatisfyImportExtension.cs" />
     <Compile Include="Language\SnykContentDefinition.cs" />

--- a/Snyk.VisualStudio.Extension.Tests/Language/GlobalSettingsApplierTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/GlobalSettingsApplierTests.cs
@@ -164,5 +164,20 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             GlobalSettingsApplier.Apply(settings, options);
             Assert.True(options.OssEnabled);
         }
+
+        [Fact]
+        public void Apply_ShouldSkipKey_WhenValueHasWrongType()
+        {
+            var options = MakeOptions();
+            options.OssEnabled = true;
+            // Send a string where a bool is expected
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.SnykOssEnabled] = new ConfigSetting { Value = JToken.FromObject("not-a-bool"), Changed = true }
+            };
+            // Must not throw; OssEnabled must remain unchanged
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.True(options.OssEnabled);
+        }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/Language/GlobalSettingsApplierTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/GlobalSettingsApplierTests.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using Moq;
+using Newtonsoft.Json.Linq;
+using Snyk.VisualStudio.Extension.Authentication;
+using Snyk.VisualStudio.Extension.Language;
+using Snyk.VisualStudio.Extension.Settings;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.Language
+{
+    public class GlobalSettingsApplierTests
+    {
+        private ISnykOptions MakeOptions()
+        {
+            var mock = new Mock<ISnykOptions>();
+            mock.SetupAllProperties();
+            return mock.Object;
+        }
+
+        [Fact]
+        public void Apply_ShouldBeNoOp_WhenSettingsIsNull()
+        {
+            var options = MakeOptions();
+            GlobalSettingsApplier.Apply(null, options);
+            // no exception
+        }
+
+        [Fact]
+        public void Apply_ShouldSetOssEnabled_WhenKeyPresent()
+        {
+            var options = MakeOptions();
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.SnykOssEnabled] = ConfigSetting.Of(true)
+            };
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.True(options.OssEnabled);
+        }
+
+        [Fact]
+        public void Apply_ShouldSetSecretsEnabled_WhenKeyPresent()
+        {
+            var options = MakeOptions();
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.SnykSecretsEnabled] = ConfigSetting.Of(false)
+            };
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.False(options.SecretsEnabled);
+        }
+
+        [Fact]
+        public void Apply_ShouldSetSeverityFilters()
+        {
+            var options = MakeOptions();
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.SeverityFilterCritical] = ConfigSetting.Of(true),
+                [PflagKeys.SeverityFilterHigh] = ConfigSetting.Of(false),
+                [PflagKeys.SeverityFilterMedium] = ConfigSetting.Of(true),
+                [PflagKeys.SeverityFilterLow] = ConfigSetting.Of(false),
+            };
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.True(options.FilterCritical);
+            Assert.False(options.FilterHigh);
+            Assert.True(options.FilterMedium);
+            Assert.False(options.FilterLow);
+        }
+
+        [Fact]
+        public void Apply_ShouldSetTrustedFolders_FromJArray()
+        {
+            var options = MakeOptions();
+            var list = new List<string> { "/foo", "/bar" };
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.TrustedFolders] = ConfigSetting.Of(list)
+            };
+            // Simulate how ConfigSetting.Value comes back as JToken after deserialization
+            settings[PflagKeys.TrustedFolders].Value = JToken.FromObject(list);
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.Contains("/foo", options.TrustedFolders);
+            Assert.Contains("/bar", options.TrustedFolders);
+        }
+
+        [Fact]
+        public void Apply_ShouldSetAuthMethod_OAuth()
+        {
+            var options = MakeOptions();
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.AuthenticationMethod] = ConfigSetting.Of("oauth")
+            };
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.Equal(AuthenticationType.OAuth, options.AuthenticationMethod);
+        }
+
+        [Fact]
+        public void Apply_ShouldSetAuthMethod_Token()
+        {
+            var options = MakeOptions();
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.AuthenticationMethod] = ConfigSetting.Of("token")
+            };
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.Equal(AuthenticationType.Token, options.AuthenticationMethod);
+        }
+
+        [Fact]
+        public void Apply_ShouldIgnoreUnknownKeys()
+        {
+            var options = MakeOptions();
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                ["unknown_future_key"] = ConfigSetting.Of("some_value")
+            };
+            GlobalSettingsApplier.Apply(settings, options); // must not throw
+        }
+
+        [Fact]
+        public void Apply_ShouldSkipEntry_WhenValueIsNull()
+        {
+            var options = MakeOptions();
+            options.OssEnabled = true;
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.SnykOssEnabled] = new ConfigSetting { Value = null, Changed = false }
+            };
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.True(options.OssEnabled); // unchanged
+        }
+
+        [Fact]
+        public void Apply_ShouldSetRiskScoreThreshold()
+        {
+            var options = MakeOptions();
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.RiskScoreThreshold] = ConfigSetting.Of(42)
+            };
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.Equal(42, options.RiskScoreThreshold);
+        }
+
+        [Fact]
+        public void Apply_ShouldSetApiEndpoint()
+        {
+            var options = MakeOptions();
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.ApiEndpoint] = ConfigSetting.Of("https://api.example.com")
+            };
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.Equal("https://api.example.com", options.CustomEndpoint);
+        }
+
+        [Fact]
+        public void Apply_ShouldSetOssEnabled_FromDeserializedJson()
+        {
+            var options = MakeOptions();
+            var json = @"{""snyk_oss_enabled"":{""value"":true,""changed"":true}}";
+            var settings = Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, ConfigSetting>>(json);
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.True(options.OssEnabled);
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
@@ -529,5 +529,23 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             // Act — must not throw
             await cut.OnSnykConfiguration(arg);
         }
+
+        [Fact]
+        public async Task OnSnykConfiguration_ShouldSaveOptions_WhenValidSettingsReceived()
+        {
+            // Arrange
+            var arg = JObject.Parse(@"{
+                ""settings"": {
+                    ""snyk_oss_enabled"": { ""value"": true, ""changed"": true }
+                },
+                ""folderConfigs"": []
+            }");
+
+            // Act
+            await cut.OnSnykConfiguration(arg);
+
+            // Assert — options are persisted without re-triggering DidChangeConfigurationAsync (triggerSettingsChangedEvent=false)
+            snykOptionsManagerMock.Verify(m => m.Save(It.IsAny<IPersistableOptions>(), false), Times.Once());
+        }
     }
 }


### PR DESCRIPTION
### **User description**
## Summary
- Adds `GlobalSettingsApplier` — a static helper that applies a pflag-keyed `Dictionary<string, ConfigSetting>` to `ISnykOptions` with PATCH semantics (absent/null entries are no-ops, preserving existing values)
- Wires `OnSnykConfiguration` in `SnykLanguageClientCustomTarget` to call `GlobalSettingsApplier.Apply()` then `Save(options, false)` — prevents feedback loop back to `DidChangeConfigurationAsync`
- Covers all non-folder, non-readonly pflag keys: products, scan, severity filters, issue view, connection, CLI, trusted folders, auth
- 12 unit tests: per-key coverage, JToken deserialization path, Save-with-false contract verification

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR4["#484 PR-4 ← YOU ARE HERE\nGlobalSettingsApplier + inbound handler"]
    PR5["#485 PR-5\nHtmlSettingsScriptingBridge tests"]
    PR6["#486 PR-6\nV25 flip + v24 cleanup"]
    main --> PR4 --> PR5 --> PR6
    style PR4 fill:#ffd700,color:#000
```

Note: PR-1 (#481), PR-2 (#482), and PR-3 (#483) are merged into main.

## Deferred to later PRs
- Per-folder `FolderConfigs` application (PR-5)
- `IdeConfigData` dictionary-backed refactor (PR-5)
- Locked-key UI enforcement (PR-5 or later)
- Protocol flip to `"25"` and `V25Feature.Enabled = true` (PR-6)

## Test plan
- [ ] `GlobalSettingsApplierTests` — 12 tests: null safety, PATCH semantics, JToken deserialization path, all key categories
- [ ] `SnykLanguageClientCustomTargetTests.OnSnykConfiguration_ShouldSaveOptions_WhenValidSettingsReceived` — verifies `Save(options, false)` contract


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduces `GlobalSettingsApplier` for applying settings from language server.

- Integrates inbound settings with `OnSnykConfiguration` handler.

- Enhances robustness with error handling for malformed settings.

- Adds comprehensive unit tests for new applier logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  LS["Language Server"] --> Event["$/snyk.configuration Event"]
  Event --> Handler["SnykLanguageClientCustomTarget.OnSnykConfiguration"]
  Handler --> Applier["GlobalSettingsApplier.Apply"]
  Applier --> Options["ISnykOptions"]
  Handler --> Save["SnykOptionsManager.Save(..., false)"]
  Options --> Save
```
