### PR TITLE
test: add missing HtmlSettingsScriptingBridge tests [IDE-1653]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,3 +248,5 @@ ModelManifest.xml
 Thumbs.db
 .directory
 .DS_Store
+.claude
+CLAUDE.md

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Moq;
 using Newtonsoft.Json;
@@ -195,6 +196,144 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
 
             // No clear-token call; any ApiToken set should be the new value, not empty
             Assert.DoesNotContain(setApiTokenCalls, t => t.ToString() == string.Empty);
+        }
+
+        [Fact]
+        public void SaveIdeConfig_SetsOssEnabled_FromActivateSnykOpenSource()
+        {
+            var config = JsonConvert.SerializeObject(new IdeConfigData
+            {
+                ActivateSnykOpenSource = true,
+            });
+
+            bridge.__saveIdeConfig__(config);
+
+            optionsMock.VerifySet(o => o.OssEnabled = true);
+        }
+
+        [Fact]
+        public void SaveIdeConfig_SetsSecretsEnabled_FromSnakeCaseKey()
+        {
+            var config = JsonConvert.SerializeObject(new { snyk_secrets_enabled = true });
+
+            bridge.__saveIdeConfig__(config);
+
+            optionsMock.VerifySet(o => o.SecretsEnabled = true);
+        }
+
+        [Fact]
+        public void SaveIdeConfig_SetsSecretsEnabled_FromCamelCaseKey()
+        {
+            var config = JsonConvert.SerializeObject(new { activateSnykSecrets = false });
+
+            bridge.__saveIdeConfig__(config);
+
+            optionsMock.VerifySet(o => o.SecretsEnabled = false);
+        }
+
+        [Fact]
+        public void SaveIdeConfig_SetsFilterSeverity()
+        {
+            var config = JsonConvert.SerializeObject(new IdeConfigData
+            {
+                FilterSeverity = new FilterSeverity
+                {
+                    Critical = true,
+                    High = false,
+                    Medium = true,
+                    Low = false,
+                },
+            });
+
+            bridge.__saveIdeConfig__(config);
+
+            optionsMock.VerifySet(o => o.FilterCritical = true);
+            optionsMock.VerifySet(o => o.FilterHigh = false);
+            optionsMock.VerifySet(o => o.FilterMedium = true);
+            optionsMock.VerifySet(o => o.FilterLow = false);
+        }
+
+        [Fact]
+        public void SaveIdeConfig_PartialPayload_DoesNotTouchUnprovidedSettings()
+        {
+            var config = JsonConvert.SerializeObject(new IdeConfigData
+            {
+                ActivateSnykOpenSource = true,
+                // SecretsEnabled and SnykCodeSecurityEnabled are NOT provided
+            });
+
+            bridge.__saveIdeConfig__(config);
+
+            optionsMock.VerifySet(o => o.OssEnabled = true);
+            optionsMock.VerifySet(o => o.SecretsEnabled = It.IsAny<bool>(), Times.Never);
+            optionsMock.VerifySet(o => o.SnykCodeSecurityEnabled = It.IsAny<bool>(), Times.Never);
+        }
+    }
+
+    [Collection(MockedVS.Collection)]
+    public class HtmlSettingsScriptingBridgeFolderConfigTest : PackageBaseTest
+    {
+        private readonly Mock<ISnykOptions> optionsMock;
+        private readonly Mock<ISnykOptionsManager> snykOptionsManagerMock;
+        private readonly Mock<ISolutionService> solutionServiceMock;
+        private readonly HtmlSettingsScriptingBridge bridge;
+
+        public HtmlSettingsScriptingBridgeFolderConfigTest(GlobalServiceProvider gsp) : base(gsp)
+        {
+            var serviceProviderMock = new Mock<ISnykServiceProvider>();
+            optionsMock = new Mock<ISnykOptions>();
+            snykOptionsManagerMock = new Mock<ISnykOptionsManager>();
+            solutionServiceMock = new Mock<ISolutionService>();
+
+            optionsMock.SetupAllProperties();
+            optionsMock.SetupGet(o => o.FolderConfigs).Returns((List<FolderConfig>)null);
+
+            serviceProviderMock.SetupGet(sp => sp.Options).Returns(optionsMock.Object);
+            serviceProviderMock.SetupGet(sp => sp.SnykOptionsManager).Returns(snykOptionsManagerMock.Object);
+            serviceProviderMock.SetupGet(sp => sp.LanguageClientManager).Returns((ILanguageClientManager)null);
+            serviceProviderMock.SetupGet(sp => sp.SolutionService).Returns(solutionServiceMock.Object);
+
+            solutionServiceMock.Setup(s => s.GetSolutionFolderAsync())
+                .ReturnsAsync("/path/to/solution");
+
+            snykOptionsManagerMock.Setup(m => m.SavePreferredOrgAsync(It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            snykOptionsManagerMock.Setup(m => m.SaveAutoDeterminedOrgAsync(It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            snykOptionsManagerMock.Setup(m => m.SaveAdditionalEnvAsync(It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            snykOptionsManagerMock.Setup(m => m.SaveOrgSetByUserAsync(It.IsAny<bool>()))
+                .Returns(Task.CompletedTask);
+
+            bridge = new HtmlSettingsScriptingBridge(
+                serviceProviderMock.Object,
+                onModified: () => { });
+        }
+
+        [Fact]
+        public void SaveIdeConfig_FolderConfigs_SavesAllFolderProperties()
+        {
+            var config = JsonConvert.SerializeObject(new IdeConfigData
+            {
+                FolderConfigs = new List<FolderConfigData>
+                {
+                    new FolderConfigData
+                    {
+                        PreferredOrg = "my-org",
+                        OrgSetByUser = true,
+                        AdditionalParameters = new List<string>(),
+                        AdditionalEnv = "ENV_VAR=1",
+                        AutoDeterminedOrg = "auto-org",
+                    },
+                },
+            });
+
+            bridge.__saveIdeConfig__(config);
+
+            snykOptionsManagerMock.Verify(m => m.SavePreferredOrgAsync("my-org"), Times.Once);
+            snykOptionsManagerMock.Verify(m => m.SaveOrgSetByUserAsync(true), Times.Once);
+            snykOptionsManagerMock.Verify(m => m.SaveAdditionalEnvAsync("ENV_VAR=1"), Times.Once);
+            snykOptionsManagerMock.Verify(m => m.SaveAutoDeterminedOrgAsync("auto-org"), Times.Once);
         }
     }
 }


### PR DESCRIPTION
### **User description**
## Summary
- Add 6 unit tests for untested `__saveIdeConfig__` code paths in `HtmlSettingsScriptingBridge`
- Cover `snyk_secrets_enabled` (snake_case) and `activateSnykSecrets` (camelCase) secrets toggle
- Cover `FilterSeverity` object → individual filter flag mapping
- Cover partial payload behavior (unprovided fields leave options unchanged)
- Cover `FolderConfigs` async save path with all 4 storage calls verified
- Introduce `HtmlSettingsScriptingBridgeFolderConfigTest` fixture with `SolutionService` mock

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR5["#485 PR-5 ← YOU ARE HERE\nHtmlSettingsScriptingBridge tests"]
    PR6["#486 PR-6\nV25 flip + v24 cleanup"]
    main --> PR5 --> PR6
    style PR5 fill:#ffd700,color:#000
```

Note: PR-1 (#481), PR-2 (#482), PR-3 (#483), and PR-4 (#484) are merged into main.

## Deferred to later PRs
- PR-6: cleanup — flip `V25Feature.Enabled`, bump protocol to `"25"`, remove v24 paths

## Test plan
- [ ] All 6 new tests pass on Windows with vstest.console.exe
- [ ] No regressions in existing `HtmlSettingsScriptingBridgeTest` tests


___

### **PR Type**
Tests


___

### **Description**
- Add 6 unit tests for `__saveIdeConfig__` scenarios.

- Cover secrets toggle, filter severity mapping.

- Test partial payload handling.

- Verify `FolderConfigs` async saving logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph HtmlSettingsScriptingBridgeTests
    A["Input IdeConfigData (JSON)"] --> B("__saveIdeConfig__ Method");
    B --> C["Update SnykOptions Service"];
    C --> D["OssEnabled / SecretsEnabled flags"];
    C --> E["Filter Severity flags"];
    C --> F["Handle Partial Payload"];
    B --> G["Call ISnykOptionsManager"];
    G --> H["SaveFolderConfigsAsync"];
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HtmlSettingsScriptingBridgeTest.cs</strong><dd><code>Add comprehensive unit tests for HtmlSettingsScriptingBridge</code></dd></summary>
<hr>

Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs

<ul><li>Added 6 new unit tests to <code>HtmlSettingsScriptingBridge</code>.<br> <li> Tests cover <code>__saveIdeConfig__</code> scenarios: <code>ActivateSnykOpenSource</code>, <br>secrets toggle (snake/camel case), <code>FilterSeverity</code> object mapping, and <br>partial payload handling.<br> <li> Introduced a new fixture <code>HtmlSettingsScriptingBridgeFolderConfigTest</code> <br>to specifically test the asynchronous saving of <code>FolderConfigs</code> via <br><code>ISnykOptionsManager</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/485/changes#diff-1716093281e3251a1c09073a640a50cf36fce573ca7110dea88e5e961ccac4f1">+139/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___