### PR TITLE
fix: allow ignores to be created/viewed from Secrets issues [IDE-1843]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Integrating security checks early in your development lifecycle helps you pass security reviews seamlessly and avoid expensive fixes down the line.
 
 The Snyk Visual Studio extension allows you to analyze your code, infrastructure configuration, and open-source dependencies. With actionable insights directly in your IDE, you can address issues as they arise.
+hi1
 
 **Key features:**
 


### PR DESCRIPTION
## Summary

Allow users to view ignore status and create new ignore requests for Secrets findings in Visual Studio 2022, matching the ignore workflow available for other product types.

## Test plan

- [ ] Ignored Secrets finding shows Ignored badge on tree node
- [ ] Ignore reason / ignorer name shown in detail view
- [ ] Right-click on active Secrets finding shows Ignore option (with permission)
- [ ] Ignore form/dialog appears and submits to Snyk backend
- [ ] Finding shows pending/ignored state after submission
- [ ] Non-ignored findings show no Ignored badge