### PR TITLE
fix: use Range.Start.Line + 1 for issue tree display line number [IDE-1009]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/Language/LsAnalysisResult.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/LsAnalysisResult.cs
@@ -222,7 +222,8 @@ namespace Snyk.VisualStudio.Extension.Language
             var fixIcon = HasFix() ? "⚡" : "";
 
             var ignoredPrefix = this.IsIgnored ? "[ Ignored ] " : "";
-            var line = "line " + this.Range?.End?.Line + ": " + this.GetDisplayTitle();
+            var startLine = this.Range?.Start != null ? (int?)(this.Range.Start.Line + 1) : null;
+            var line = "line " + startLine + ": " + this.GetDisplayTitle();
 
             return fixIcon + ignoredPrefix + line;
         }

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsAnalysisResultTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsAnalysisResultTest.cs
@@ -6,6 +6,47 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 {
     public class LsAnalysisResultTest
     {
+        [Fact]
+        public void GetDisplayTitleWithLineNumber_ShouldUseStartLinePlusOne()
+        {
+            // LSP lines are 0-based; Start indicates issue location.
+            // Range.Start.Line == 4 → displayed as "line 5: ..."
+            var issue = new Issue
+            {
+                Title = "SQL Injection",
+                Range = new Range
+                {
+                    Start = new Start { Line = 4, Character = 0 },
+                    End = new End { Line = 4, Character = 20 }
+                },
+                Product = Product.Code,
+                AdditionalData = new AdditionalData { PriorityScore = 0 }
+            };
+
+            var result = issue.GetDisplayTitleWithLineNumber();
+
+            Assert.Contains("line 5:", result);
+            Assert.Contains("SQL Injection", result);
+        }
+
+        [Fact]
+        public void GetDisplayTitleWithLineNumber_NullRange_ShouldNotThrow()
+        {
+            var issue = new Issue
+            {
+                Title = "XSS",
+                Range = null,
+                Product = Product.Code,
+                AdditionalData = new AdditionalData { PriorityScore = 0 }
+            };
+
+            var result = issue.GetDisplayTitleWithLineNumber();
+
+            // Should still contain the title; line portion may be "line : " or similar
+            Assert.Contains("XSS", result);
+        }
+
+
         [Theory]
         [InlineData("critical", 4_000_000)]
         [InlineData("high", 3_000_000)]


### PR DESCRIPTION
### **User description**
## Summary
- `LsAnalysisResult.GetDisplayTitleWithLineNumber` now uses `Range.Start.Line + 1` instead of `Range.End.Line` for the issue-tree line label.

## Why
LSP `Range` is 0-based and `Start` marks the issue location while `End` marks the end of the span. The previous code produced the wrong line number (off-by-one or end-of-span). The navigation code in `SnykToolWindowControl.xaml.cs` already uses `Range.Start.Line` — this PR aligns the tree renderer with that.

## Test plan
- [x] Added `GetDisplayTitleWithLineNumber_ShouldUseStartLinePlusOne` (happy path).
- [x] Added `GetDisplayTitleWithLineNumber_NullRange_ShouldNotThrow` (null Range).
- [ ] Manual: open a workspace with a Code finding on line 5; tree should display "line 5: …".

Jira: [IDE-1009](https://snyksec.atlassian.net/browse/IDE-1009)
Triage: [Buglist](https://snyksec.atlassian.net/wiki/spaces/IDE/pages/4860444692/Buglist)

[IDE-1009]: https://snyksec.atlassian.net/browse/IDE-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes incorrect line number display in issue tree.

- Updates logic to use `Range.Start.Line + 1`.

- Adds new unit tests for validation.

- Handles null ranges gracefully to prevent errors.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Snyk.VisualStudio.Extension.2022/Language/LsAnalysisResult.cs"] -- "Updates line number logic in GetDisplayTitleWithLineNumber" --> B(Issue Tree Display)
  A -- "Adds new unit tests" --> C["Snyk.VisualStudio.Extension.Tests/Language/LsAnalysisResultTest.cs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LsAnalysisResult.cs</strong><dd><code>Correct issue tree line number calculation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Snyk.VisualStudio.Extension.2022/Language/LsAnalysisResult.cs

<ul><li>Modified <code>GetDisplayTitleWithLineNumber</code> to correctly calculate the line <br>number for display.<br> <li> The implementation now uses <code>this.Range.Start.Line + 1</code> to account for <br>0-based LSP ranges, ensuring human-readable 1-based line numbers.<br> <li> Added null check for <code>this.Range?.Start</code> to prevent potential null <br>reference exceptions.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/498/changes#diff-56eb65d62c15b376bb4d24b5a1faca46485fec89a70fb09d2c069027490f2f01">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LsAnalysisResultTest.cs</strong><dd><code>Add tests for line number display logic.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Snyk.VisualStudio.Extension.Tests/Language/LsAnalysisResultTest.cs

<ul><li>Added a new unit test <br><code>GetDisplayTitleWithLineNumber_ShouldUseStartLinePlusOne</code> to verify the <br>corrected line number display logic.<br> <li> Added a new unit test <br><code>GetDisplayTitleWithLineNumber_NullRange_ShouldNotThrow</code> to ensure the <br>method handles null <code>Range</code> values without crashing.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/498/changes#diff-b26b3840468013914ddc97d9d0aae5010a0028f7b4cb898547ffacf954af27d5">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

