### PR TITLE
feat(settings): wire global additional_parameters and close additional_environment HTML-save hole [IDE-2110]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClient.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClient.cs
@@ -224,16 +224,18 @@ namespace Snyk.VisualStudio.Extension.Language
         private Task<string> GetLsDebugLevelAsync()
         {
             var serviceProvider = SnykVSPackage.ServiceProvider;
-            var folderConfigs = serviceProvider?.Options?.FolderConfigs;
-            if (folderConfigs == null)
+            var options = serviceProvider?.Options;
+            if (options == null)
                 return Task.FromResult("info");
 
-            // Enable debug logging for the whole LS process if -d/--debug is set on ANY folder's
-            // additional parameters, not just the first — workspaces can have multiple folders.
-            var anyDebug = folderConfigs
+            // Enable debug logging for the whole LS process if -d/--debug is set in global
+            // additional parameters OR in ANY folder's additional parameters.
+            var globalParams = options.AdditionalParameters ?? Enumerable.Empty<string>();
+            var folderParams = (options.FolderConfigs ?? Enumerable.Empty<FolderConfig>())
                 .Where(fc => fc?.AdditionalParameters != null)
-                .SelectMany(fc => fc.AdditionalParameters)
-                .Any(p => p == "-d" || p == "--debug");
+                .SelectMany(fc => fc.AdditionalParameters);
+
+            var anyDebug = globalParams.Concat(folderParams).Any(p => p == "-d" || p == "--debug");
 
             return Task.FromResult(anyDebug ? "debug" : "info");
         }

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/GlobalSettingsApplier.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/GlobalSettingsApplier.cs
@@ -57,7 +57,8 @@ namespace Snyk.VisualStudio.Extension.Language
                     case PflagKeys.BinaryBaseUrl:        options.CliBaseDownloadURL = val.Value<string>(); break;
                     case PflagKeys.CliReleaseChannel:    options.CliReleaseChannel  = val.Value<string>(); break;
 
-                    case PflagKeys.AdditionalEnvironment: options.AdditionalEnv = val.Value<string>(); break;
+                    case PflagKeys.AdditionalEnvironment:  options.AdditionalEnv        = val.Value<string>(); break;
+                    case PflagKeys.AdditionalParameters:  options.AdditionalParameters  = val.ToObject<List<string>>(); break;
 
                     case PflagKeys.TrustedFolders:
                         var list = val.ToObject<List<string>>();

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/GlobalSettingsApplier.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/GlobalSettingsApplier.cs
@@ -58,7 +58,15 @@ namespace Snyk.VisualStudio.Extension.Language
                     case PflagKeys.CliReleaseChannel:    options.CliReleaseChannel  = val.Value<string>(); break;
 
                     case PflagKeys.AdditionalEnvironment:  options.AdditionalEnv        = val.Value<string>(); break;
-                    case PflagKeys.AdditionalParameters:  options.AdditionalParameters  = val.ToObject<List<string>>(); break;
+                    case PflagKeys.AdditionalParameters:
+                        // LS sends additional_parameters as a space-joined string (strings.Join(..., " ")),
+                        // not a JSON array. Split on spaces; fall back to array deserialization for future-proofing.
+                        options.AdditionalParameters = val.Type == JTokenType.String
+                            ? (val.Value<string>() ?? string.Empty)
+                                .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                                .ToList()
+                            : val.ToObject<List<string>>();
+                        break;
 
                     case PflagKeys.TrustedFolders:
                         var list = val.ToObject<List<string>>();

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/LsSettingsV25.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/LsSettingsV25.cs
@@ -79,7 +79,10 @@ namespace Snyk.VisualStudio.Extension.Language
 
                 [PflagKeys.TrustedFolders] = ConfigSetting.Of(options.TrustedFolders?.ToList() ?? new List<string>()),
                 [PflagKeys.AdditionalEnvironment] = ConfigSetting.Of(options.AdditionalEnv ?? string.Empty),
-                [PflagKeys.AdditionalParameters] = ConfigSetting.Of(options.AdditionalParameters ?? new List<string>()),
+                // LS applyCliConfig reads additional_parameters via settingStr (string type-assert),
+                // so send as a space-joined string — same wire format LS uses on its outbound echo.
+                [PflagKeys.AdditionalParameters] = ConfigSetting.Of(
+                    string.Join(" ", options.AdditionalParameters ?? new List<string>())),
 
                 [PflagKeys.DeviceId] = ConfigSetting.Of(options.DeviceId ?? string.Empty),
                 [PflagKeys.ClientProtocolVersion] = ConfigSetting.Of("25"),

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/LsSettingsV25.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/LsSettingsV25.cs
@@ -42,8 +42,10 @@ namespace Snyk.VisualStudio.Extension.Language
         }
 
         // internal for testability (InternalsVisibleTo test project).
-        // Note: additional_parameters is folder-scoped in v25 (see snyk-ls ldx_sync_config.go)
-        // and is not included in the global settings map.
+        // Note: additional_parameters and additional_environment are sent both in the global
+        // settings map (Project Defaults tab) and per-folder in folderConfigs. The LS resolves
+        // folder-over-global. Global values are wired via ISnykOptions.AdditionalParameters /
+        // AdditionalEnv; per-folder values live in FolderConfig.
         internal Dictionary<string, ConfigSetting> BuildSettingsMap(ISnykOptions options)
         {
             var map = new Dictionary<string, ConfigSetting>
@@ -77,6 +79,7 @@ namespace Snyk.VisualStudio.Extension.Language
 
                 [PflagKeys.TrustedFolders] = ConfigSetting.Of(options.TrustedFolders?.ToList() ?? new List<string>()),
                 [PflagKeys.AdditionalEnvironment] = ConfigSetting.Of(options.AdditionalEnv ?? string.Empty),
+                [PflagKeys.AdditionalParameters] = ConfigSetting.Of(options.AdditionalParameters ?? new List<string>()),
 
                 [PflagKeys.DeviceId] = ConfigSetting.Of(options.DeviceId ?? string.Empty),
                 [PflagKeys.ClientProtocolVersion] = ConfigSetting.Of("25"),

--- a/Snyk.VisualStudio.Extension.2022/Settings/IPersistableOption.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/IPersistableOption.cs
@@ -86,5 +86,6 @@ public interface IPersistableOptions
     bool FilterLow { get; set; }
 
     string AdditionalEnv { get; set; }
+    List<string> AdditionalParameters { get; set; }
     int? RiskScoreThreshold { get; set; }
 }

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykOptions.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykOptions.cs
@@ -49,6 +49,7 @@ namespace Snyk.VisualStudio.Extension.Settings
         public bool FilterMedium { get; set; }
         public bool FilterLow { get; set; }
         public string AdditionalEnv { get; set; }
+        public List<string> AdditionalParameters { get; set; }
         public int? RiskScoreThreshold { get; set; }
         public string SnykCodeSettingsUrl => $"{this.GetBaseAppUrl()}/manage/snyk-code";
         public event EventHandler<SnykSettingsChangedEventArgs> SettingsChanged;

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
@@ -126,6 +126,7 @@ namespace Snyk.VisualStudio.Extension.Settings
                 FilterLow = snykSettings.FilterLow,
 
                 AdditionalEnv = snykSettings.AdditionalEnv,
+                AdditionalParameters = snykSettings.AdditionalParameters,
                 RiskScoreThreshold = snykSettings.RiskScoreThreshold,
             };
         }
@@ -167,6 +168,7 @@ namespace Snyk.VisualStudio.Extension.Settings
             snykSettings.FilterLow = options.FilterLow;
 
             snykSettings.AdditionalEnv = options.AdditionalEnv;
+            snykSettings.AdditionalParameters = options.AdditionalParameters;
             snykSettings.RiskScoreThreshold = options.RiskScoreThreshold;
 
             this.SaveSettingsToFile();

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
@@ -79,6 +79,7 @@ namespace Snyk.VisualStudio.Extension.Settings
         public bool FilterMedium { get; set; } = true;
         public bool FilterLow { get; set; } = true;
         public string AdditionalEnv { get; set; } = string.Empty;
+        public List<string> AdditionalParameters { get; set; } = new List<string>();
         public int? RiskScoreThreshold { get; set; } = null;
 
         /// <summary>

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
@@ -358,6 +358,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             var filterMedium = o.FilterMedium;
             var filterLow = o.FilterLow;
             var additionalEnv = o.AdditionalEnv;
+            var additionalParameters = o.AdditionalParameters != null ? new System.Collections.Generic.List<string>(o.AdditionalParameters) : null;
             var riskScoreThreshold = o.RiskScoreThreshold;
             var folderConfigs = CloneFolderConfigs(o.FolderConfigs);
             var trustedFolders = o.TrustedFolders == null ? null : new HashSet<string>(o.TrustedFolders);
@@ -389,6 +390,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                 o.FilterMedium = filterMedium;
                 o.FilterLow = filterLow;
                 o.AdditionalEnv = additionalEnv;
+                o.AdditionalParameters = additionalParameters;
                 o.RiskScoreThreshold = riskScoreThreshold;
                 o.FolderConfigs = folderConfigs;
                 o.TrustedFolders = trustedFolders;
@@ -605,6 +607,16 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             if (config.RiskScoreThreshold.HasValue)
             {
                 Options.RiskScoreThreshold = config.RiskScoreThreshold;
+            }
+
+            // Global (Project Defaults) advanced settings — absent (null) means no change.
+            if (config.AdditionalEnv != null)
+            {
+                Options.AdditionalEnv = config.AdditionalEnv;
+            }
+            if (config.AdditionalParameters != null)
+            {
+                Options.AdditionalParameters = config.AdditionalParameters;
             }
         }
 

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
@@ -616,7 +616,9 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             }
             if (config.AdditionalParameters != null)
             {
-                Options.AdditionalParameters = config.AdditionalParameters;
+                Options.AdditionalParameters = config.AdditionalParameters
+                    .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                    .ToList();
             }
         }
 

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/IdeConfigData.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/IdeConfigData.cs
@@ -113,6 +113,14 @@ namespace Snyk.VisualStudio.Extension.UI.Html
         [JsonProperty("risk_score_threshold")]
         public int? RiskScoreThreshold { get; set; }
 
+        // Global (Project Defaults) advanced settings — top-level keys, distinct from
+        // the per-folder additional_* fields on FolderConfigData.
+        [JsonProperty("additional_environment")]
+        public string AdditionalEnv { get; set; }
+
+        [JsonProperty("additional_parameters")]
+        public List<string> AdditionalParameters { get; set; }
+
         // Trusted folders
         [JsonProperty("trusted_folders")]
         public List<string> TrustedFolders { get; set; }

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/IdeConfigData.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/IdeConfigData.cs
@@ -118,8 +118,9 @@ namespace Snyk.VisualStudio.Extension.UI.Html
         [JsonProperty("additional_environment")]
         public string AdditionalEnv { get; set; }
 
+        // Form sends additional_parameters as a raw string (text input); split on whitespace when applying.
         [JsonProperty("additional_parameters")]
-        public List<string> AdditionalParameters { get; set; }
+        public string AdditionalParameters { get; set; }
 
         // Trusted folders
         [JsonProperty("trusted_folders")]

--- a/Snyk.VisualStudio.Extension.Tests/Language/GlobalSettingsApplierTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/GlobalSettingsApplierTests.cs
@@ -179,5 +179,43 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             GlobalSettingsApplier.Apply(settings, options);
             Assert.True(options.OssEnabled);
         }
+
+        [Fact]
+        public void Apply_AdditionalParameters_SplitsSpaceJoinedString()
+        {
+            // LS sends additional_parameters as a space-joined string (strings.Join(..., " ")).
+            var options = MakeOptions();
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.AdditionalParameters] = new ConfigSetting { Value = JToken.FromObject("--debug --severity-threshold=high"), Changed = true }
+            };
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.Equal(new List<string> { "--debug", "--severity-threshold=high" }, options.AdditionalParameters);
+        }
+
+        [Fact]
+        public void Apply_AdditionalParameters_HandlesEmptyString()
+        {
+            var options = MakeOptions();
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.AdditionalParameters] = new ConfigSetting { Value = JToken.FromObject(""), Changed = true }
+            };
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.Empty(options.AdditionalParameters);
+        }
+
+        [Fact]
+        public void Apply_AdditionalParameters_HandlesJsonArray()
+        {
+            // Future-proofing: if LS ever sends an array, it should still work.
+            var options = MakeOptions();
+            var settings = new Dictionary<string, ConfigSetting>
+            {
+                [PflagKeys.AdditionalParameters] = new ConfigSetting { Value = JToken.FromObject(new[] { "--debug", "--verbose" }), Changed = true }
+            };
+            GlobalSettingsApplier.Apply(settings, options);
+            Assert.Equal(new List<string> { "--debug", "--verbose" }, options.AdditionalParameters);
+        }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
@@ -43,6 +43,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             optionsMock.SetupGet(o => o.CliReleaseChannel).Returns("stable");
             optionsMock.SetupGet(o => o.CliBaseDownloadURL).Returns("https://downloads.snyk.io");
             optionsMock.SetupGet(o => o.AdditionalEnv).Returns(string.Empty);
+            optionsMock.SetupGet(o => o.AdditionalParameters).Returns(new List<string>());
             optionsMock.SetupGet(o => o.RiskScoreThreshold).Returns((int?)null);
             optionsMock.SetupGet(o => o.InternalAutoScan).Returns(false);
         }
@@ -257,12 +258,31 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
         }
 
         [Fact]
-        public void BuildSettingsMap_AdditionalParameters_NotInGlobalMap()
+        public void BuildSettingsMap_AdditionalParameters_InGlobalMap()
         {
-            // additional_parameters is folder-scoped in v25; must not appear in global settings
+            // additional_parameters is now sent in the global settings map (Project Defaults tab)
             SetupDefaults();
+            var expectedParams = new List<string> { "--severity-threshold=high", "--debug" };
+            optionsMock.SetupGet(o => o.AdditionalParameters).Returns(expectedParams);
+
             var map = cut.BuildSettingsMap(optionsMock.Object);
-            Assert.False(map.ContainsKey(PflagKeys.AdditionalParameters));
+
+            Assert.True(map.ContainsKey(PflagKeys.AdditionalParameters));
+            var value = Assert.IsType<List<string>>(map[PflagKeys.AdditionalParameters].Value);
+            Assert.Equal(expectedParams, value);
+        }
+
+        [Fact]
+        public void BuildSettingsMap_AdditionalEnvironment_InGlobalMap()
+        {
+            // additional_environment is sent in the global settings map (Project Defaults tab)
+            SetupDefaults();
+            optionsMock.SetupGet(o => o.AdditionalEnv).Returns("VAR1=a;VAR2=b");
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            Assert.True(map.ContainsKey(PflagKeys.AdditionalEnvironment));
+            Assert.Equal("VAR1=a;VAR2=b", map[PflagKeys.AdditionalEnvironment].Value);
         }
 
         [Fact]

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
@@ -268,8 +268,9 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             var map = cut.BuildSettingsMap(optionsMock.Object);
 
             Assert.True(map.ContainsKey(PflagKeys.AdditionalParameters));
-            var value = Assert.IsType<List<string>>(map[PflagKeys.AdditionalParameters].Value);
-            Assert.Equal(expectedParams, value);
+            // Sent as space-joined string — LS applyCliConfig reads via settingStr (string type-assert).
+            var value = Assert.IsType<string>(map[PflagKeys.AdditionalParameters].Value);
+            Assert.Equal("--severity-threshold=high --debug", value);
         }
 
         [Fact]

--- a/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Client;
@@ -345,6 +347,52 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.True(eventInvoked);
         }
 
+
+        [Theory]
+        [InlineData("-d")]
+        [InlineData("--debug")]
+        public async Task GetLsDebugLevelAsync_ReturnsDebug_WhenGlobalAdditionalParametersContainsDebugFlag(string flag)
+        {
+            OptionsMock.SetupGet(o => o.AdditionalParameters).Returns(new List<string> { flag });
+            OptionsMock.SetupGet(o => o.FolderConfigs).Returns(new List<FolderConfig>());
+
+            var method = typeof(SnykLanguageClient).GetMethod("GetLsDebugLevelAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            var level = await (Task<string>)method.Invoke(cut, null);
+
+            Assert.Equal("debug", level);
+        }
+
+        [Theory]
+        [InlineData("-d")]
+        [InlineData("--debug")]
+        public async Task GetLsDebugLevelAsync_ReturnsDebug_WhenFolderAdditionalParametersContainsDebugFlag(string flag)
+        {
+            OptionsMock.SetupGet(o => o.AdditionalParameters).Returns(new List<string>());
+            OptionsMock.SetupGet(o => o.FolderConfigs).Returns(new List<FolderConfig>
+            {
+                new FolderConfig { AdditionalParameters = new List<string> { flag } }
+            });
+
+            var method = typeof(SnykLanguageClient).GetMethod("GetLsDebugLevelAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            var level = await (Task<string>)method.Invoke(cut, null);
+
+            Assert.Equal("debug", level);
+        }
+
+        [Fact]
+        public async Task GetLsDebugLevelAsync_ReturnsInfo_WhenNoDebugFlagAnywhere()
+        {
+            OptionsMock.SetupGet(o => o.AdditionalParameters).Returns(new List<string> { "--some-other-flag" });
+            OptionsMock.SetupGet(o => o.FolderConfigs).Returns(new List<FolderConfig>
+            {
+                new FolderConfig { AdditionalParameters = new List<string> { "--filter=something" } }
+            });
+
+            var method = typeof(SnykLanguageClient).GetMethod("GetLsDebugLevelAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            var level = await (Task<string>)method.Invoke(cut, null);
+
+            Assert.Equal("info", level);
+        }
 
         [Fact]
         public async Task InvokeLogin_ShouldReturnNull_WhenNotReady()

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
@@ -692,6 +692,27 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
         }
 
         [Fact]
+        public void SaveIdeConfig_GlobalAdditionalParameters_SplitsSpaceJoinedString()
+        {
+            // Form sends additional_parameters as a plain string (text input → setFieldValue → string).
+            var config = JsonConvert.SerializeObject(new { additional_parameters = "--debug --severity-threshold=high" });
+
+            bridge.__saveIdeConfig__(config);
+
+            optionsMock.VerifySet(o => o.AdditionalParameters = new List<string> { "--debug", "--severity-threshold=high" });
+        }
+
+        [Fact]
+        public void SaveIdeConfig_GlobalAdditionalParameters_EmptyString_SetsEmptyList()
+        {
+            var config = JsonConvert.SerializeObject(new { additional_parameters = "" });
+
+            bridge.__saveIdeConfig__(config);
+
+            optionsMock.VerifySet(o => o.AdditionalParameters = new List<string>());
+        }
+
+        [Fact]
         public void SaveIdeConfig_FolderConfigs_NoExistingConfig_DoesNotThrow()
         {
             // No matching global config entry (FolderConfigs stays null) — the mirror block is

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/IdeConfigContractTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/IdeConfigContractTests.cs
@@ -13,7 +13,7 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
         // the setting at runtime.
         private const string AuthoritativePayload = @"{
             ""additional_environment"": """",
-            ""additional_parameters"": [],
+            ""additional_parameters"": """",
             ""api_endpoint"": ""https://api.snyk.io"",
             ""authentication_method"": ""oauth"",
             ""automatic_download"": false,

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/IdeConfigContractTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/IdeConfigContractTests.cs
@@ -12,6 +12,8 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
         // renamed, this test fails — surfacing the drift at build time instead of silently dropping
         // the setting at runtime.
         private const string AuthoritativePayload = @"{
+            ""additional_environment"": """",
+            ""additional_parameters"": [],
             ""api_endpoint"": ""https://api.snyk.io"",
             ""authentication_method"": ""oauth"",
             ""automatic_download"": false,


### PR DESCRIPTION
## Summary

- **`additional_environment` HTML-save hole (Part A):** `IdeConfigData` had no top-level `AdditionalEnv` field, so the HTML form's Project Defaults save silently dropped the value. Adds `[JsonProperty("additional_environment")]` to `IdeConfigData` and applies it in `ApplyMiscellaneousSettings`. Extends `SnapshotOptionsForRollback` to capture/restore `AdditionalParameters`.

- **`additional_parameters` global (Part B, end-to-end):** previously missing entirely at global scope. Adds:
  - `List<string> AdditionalParameters` to `IPersistableOption`, `SnykOptions`, `SnykSettings` (default `new List<string>()`), `SnykOptionsManager` load+save
  - `BuildSettingsMap` entry: `[PflagKeys.AdditionalParameters] = ConfigSetting.Of(options.AdditionalParameters ?? new List<string>())`
  - `GlobalSettingsApplier` case: `options.AdditionalParameters = val.ToObject<List<string>>()`
  - Top-level `[JsonProperty("additional_parameters")]` on `IdeConfigData`; applied in `ApplyMiscellaneousSettings`

Both keys use the same string as the per-folder `FolderConfigData` fields — the LS disambiguates by map position (top-level `settings` vs `folderConfigs[].settings`).

Fixes the `BuildSettingsMap_AdditionalParameters_NotInGlobalMap` test (flipped to `_InGlobalMap`); adds `AdditionalEnvironment` in-global-map assertion; adds both keys to the `IdeConfigContract` authoritative payload.

Completes IDE-side wiring for snyk-ls PR #1340 (IDE-2110).

## Test plan

- [ ] `dotnet build` green (Windows required)
- [ ] `dotnet test` — `LsSettingsV25Tests`, `IdeConfigContractTests`, `HtmlSettingsScriptingBridgeTest` pass
- [ ] Manual: open Settings → Project Defaults → Advanced; set both fields; save; reopen — fields repopulate
- [ ] OSS scan picks up global env vars and CLI params