### PR TITLE
feat: admit Visual Studio 2026 in VSIX install targets [IDE-1483]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
+++ b/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
@@ -13,10 +13,10 @@
         <Preview>false</Preview>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,19.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+        <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Community">
             <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
     </Installation>
@@ -24,7 +24,7 @@
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,19.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
### **User description**
## Summary
- Bump `InstallationTarget` (amd64 + arm64) and the CoreEditor `Prerequisite` version ranges from `[17.0,18.0)` to `[17.0,19.0)` so the extension installs on Visual Studio 2026 (18.x) in addition to VS 2022 (17.x).

## Why stacked / caveat
- Depends on PR-1: the settings-persistence fix is the precondition for VS 2026 (config + auth token must survive there first).
- ⚠️ Kept **separate and independently revertable** because the extension still compiles against the **VS 17.4 SDK** and has **not been smoke-tested on a VS 2026 host**. Validate on VS 2026 (or add an 18.x CI host) before release.

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR1["#510 PR-1\nsettings persistence + migration"]
    PR2["PR-2 ← YOU ARE HERE\nadmit VS 2026 in VSIX targets"]
    main --> PR1 --> PR2
    style PR2 fill:#ffd700,color:#000
```

**Depends on:** #510

## Test plan
- [ ] CI green
- [ ] Manual VS 2026 (18.x) install + scan smoke test before release


___

### **PR Type**
Enhancement


___

### **Description**
- Extend VSIX installation targets for VS 2026.

- Update version ranges in manifest files.

- Add compatibility for VS 18.x.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  main(["main"])
  PR1["#510 Settings persistence"]
  PR2["feat/IDE-1483 VS 2026 manifest update"]
  main --> PR1 --> PR2
  style PR2 fill:#ffd700,color:#000
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>source.extension.vsixmanifest</strong><dd><code>Update VSIX manifest for VS 2026 compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest

<ul><li>Updated <code>InstallationTarget</code> version ranges from <code>[17.0,18.0)</code> to <br><code>[17.0,19.0)</code> for both amd64 and arm64.<br> <li> Modified <code>CoreEditor</code> <code>Prerequisite</code> version to <code>[17.0,19.0)</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/511/changes#diff-fb4e6004c5a311874529791558902f0df92e84e96e89a1c3337264f871346022">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

