### PR TITLE
feat(settings): track user-overridden LSP config keys [IDE-2152]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,3 +280,4 @@ CLAUDE.md
 .snyk-code-output.json
 .snyk-code-output.err
 .verification-result.*
+.cache_ggshield

--- a/Snyk.VisualStudio.Extension.2022/BranchSelectorDialogWindow.xaml.cs
+++ b/Snyk.VisualStudio.Extension.2022/BranchSelectorDialogWindow.xaml.cs
@@ -58,7 +58,11 @@ namespace Snyk.VisualStudio.Extension
 
             var options = SnykVSPackage.ServiceProvider.Options;
             options.FolderConfigs = currentList;
-            SnykVSPackage.ServiceProvider.SnykOptionsManager.Save(options);
+            // editedKeys: empty — only folder config (per-folder) keys changed here; no global
+            // pflag keys were edited by the user, so the tracker should mark nothing.
+            SnykVSPackage.ServiceProvider.SnykOptionsManager.Save(
+                options,
+                editedKeys: new System.Collections.Generic.List<string>());
             if (SnykVSPackage.Instance.Options.AutoScan)
             {
                 ThreadHelper.JoinableTaskFactory.RunAsync(serviceProvider.TasksService.ScanAsync).FireAndForget();

--- a/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClient.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClient.cs
@@ -51,9 +51,32 @@ namespace Snyk.VisualStudio.Extension.Language
         public bool IsReady { get; set; }
         public object InitializationOptions => GetInitializationOptions();
 
+        // Serializes the peek→send→commit sequence of DidChangeConfigurationAsync (IDE-2152 fix #3).
+        // The config push is fire-and-forget from several call sites; without this, two overlapping
+        // sends would each peek the same queue and double-deliver, and their commits could race the
+        // tracker/persistence. Distinct from `semaphore` (which guards start/stop).
+        private readonly SemaphoreSlim configSendGate = new SemaphoreSlim(1, 1);
+
         public object GetInitializationOptions()
         {
             settingsV25 ??= new LsSettingsV25(SnykVSPackage.ServiceProvider);
+
+            // Init folds in the current pending resets (non-destructively) but does NOT commit them
+            // here (IDE-2152 fix #3): committing at init ran on a separate code path that could not be
+            // serialized with the DidChangeConfiguration commits. Instead the first successful
+            // DidChangeConfiguration commits, and persistence (fix #2) re-delivers across a restart if
+            // the handshake never confirms. Re-sending the same reset is idempotent for the LS.
+            //
+            // Deferred-commit invariant (IDE-2152 fix #3, made explicit): after a SUCCESSFUL init that
+            // carried the resets to the LS, those resets REMAIN queued in the tracker AND persisted in
+            // settings.json (PendingResetConfigKeys) — init never drains them. They are drained by the
+            // NEXT successful DidChangeConfigurationAsync, which peeks the same queue, sends, and only
+            // then commits (peek→send→commit, through the options manager so persistence stays in
+            // sync). This is safe precisely because a reset is idempotent for the LS: init delivering a
+            // reset and the first config-update re-delivering the same reset produce the same LS state,
+            // so double-delivery across the init→first-update boundary cannot corrupt anything. It also
+            // means a crash between a successful init and the first config-update loses nothing — the
+            // persisted queue re-delivers on the next session.
             return settingsV25.GetInitializationOptions();
         }
 
@@ -222,6 +245,12 @@ namespace Snyk.VisualStudio.Extension.Language
         public Task OnServerInitializedAsync()
         {
             IsReady = true;
+
+            // Note: pending resets are NOT committed here (IDE-2152 fix #3). The init options already
+            // carried them to the LS, but committing is deferred to the first successful
+            // DidChangeConfiguration (peek→send→commit), which is serialized and commits through the
+            // options manager so persistence stays in sync. If the handshake never confirms, the
+            // persisted pending-reset set (fix #2) re-delivers them after a restart.
             FireOnLanguageServerReadyAsyncEvent();
             SendPluginInstalledEvent();
             Rpc.Disconnected += Rpc_Disconnected;
@@ -525,17 +554,84 @@ namespace Snyk.VisualStudio.Extension.Language
 
         public async Task<object> DidChangeConfigurationAsync(CancellationToken cancellationToken)
         {
+            // Early-return BEFORE taking the gate: after a FAILED init, IsReady stays false so this
+            // returns without sending. Recovery from a failed init is NOT via a config update — it is
+            // the next successful (re-)initialization handshake, which flips IsReady back to true
+            // (IDE-2152 fix #6: correct the previous stale comment that claimed a config-update
+            // recovered a failed init).
             if (!IsReady) return default;
 
             settingsV25 ??= new LsSettingsV25(SnykVSPackage.ServiceProvider);
-            var config = settingsV25.GetLspConfigurationParam();
-            if (config == null)
+            var optionsManager = SnykVSPackage.ServiceProvider?.SnykOptionsManager;
+
+            // Serialize the whole peek→send→commit sequence (IDE-2152 fix #3): the config push is
+            // fire-and-forget from several call sites, so overlapping calls would otherwise each peek
+            // the same pending-reset queue and double-deliver, and their commits would race the tracker
+            // and its persistence. The gate makes exactly one push + its commit run at a time.
+            await configSendGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
             {
-                Logger.Warning("DidChangeConfigurationAsync: GetLspConfigurationParam returned null; skipping workspace/didChangeConfiguration notification.");
-                return default;
+                // Re-check readiness after acquiring the gate: a Rpc disconnect may have flipped IsReady
+                // to false while we were queued behind another send.
+                if (!IsReady) return default;
+
+                // Peek the pending resets ONCE, then thread this EXACT snapshot through the settings-map
+                // build AND the commit, so committed == sent by construction. Building the map with a
+                // second independent peek (as before) let a reset enqueued between the two reads be
+                // sent-but-not-committed (re-sent) or committed-but-not-sent (dropped).
+                var pendingResets = optionsManager?.OverrideTracker?.PeekPendingResets();
+
+                var config = settingsV25.GetLspConfigurationParam(pendingResets);
+                if (config == null)
+                {
+                    Logger.Warning("DidChangeConfigurationAsync: GetLspConfigurationParam returned null; skipping workspace/didChangeConfiguration notification.");
+                    return default;
+                }
+                var param = new LSP.DidChangeConfigurationParams { Settings = config };
+
+                // Do NOT route through InvokeWithParametersAsync here: that helper swallows every
+                // exception and returns default, which would hide a failed send and let the peeked
+                // resets be committed anyway. The config-update path must OBSERVE success/failure so it
+                // can decide whether to commit the resets. On failure we log and leave the queue intact.
+                try
+                {
+                    var result = await Rpc.InvokeWithParameterObjectAsync<object>(
+                        LsConstants.WorkspaceChangeConfiguration, param, cancellationToken).ConfigureAwait(false);
+
+                    // Confirmed successful send: commit EXACTLY the snapshot we sent, through the options
+                    // manager so the pending-reset persistence is updated too (IDE-2152 fix #2). Never a
+                    // blanket clear — a newer reset for a different key enqueued after this peek is not
+                    // in `pendingResets`, so it survives for the next update.
+                    //
+                    // Marshal to the UI thread BEFORE committing (IDE-2152 fix #7). CommitPendingResets
+                    // persists settings.json, and the whole settings-persistence subsystem was written
+                    // assuming UI-thread-only saves. Committing here (the RPC continuation runs on a
+                    // thread-pool thread after `ConfigureAwait(false)` above) would make this the first
+                    // background-thread settings writer, racing the pre-existing unlocked UI-thread
+                    // mutation sites (MigrateLegacySolutionSettings, LoadSettingsFromFile) and throwing
+                    // "collection was modified" mid-serialize. Switching to the main thread makes this
+                    // commit persist exactly like every other settings save — no background writer, so
+                    // the entire race class dissolves. Same pattern as HtmlSettingsControl /
+                    // AuthenticationFlowService. The switch happens only AFTER a confirmed send, still
+                    // inside the configSendGate region; holding that SemaphoreSlim (async, not a Monitor)
+                    // across the await is safe. On failure (catch below) we never switch and never commit.
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                    optionsManager?.CommitPendingResets(pendingResets);
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    // Transient failure: leave pendingResets in the queue (and in persistence) so the
+                    // next configuration update re-delivers them. Match the (silent-to-caller) contract
+                    // of the previous send helper.
+                    Logger.Error("{Ex}", ex);
+                    return default;
+                }
             }
-            var param = new LSP.DidChangeConfigurationParams { Settings = config };
-            return await InvokeWithParametersAsync<object>(LsConstants.WorkspaceChangeConfiguration, param, cancellationToken).ConfigureAwait(false);
+            finally
+            {
+                configSendGate.Release();
+            }
         }
 
         public async Task RestartServerAsync()

--- a/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClient.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClient.cs
@@ -619,6 +619,22 @@ namespace Snyk.VisualStudio.Extension.Language
                     optionsManager?.CommitPendingResets(pendingResets);
                     return result;
                 }
+                catch (OperationCanceledException)
+                {
+                    // Benign shutdown: the cancellationToken fired (IDE/LS shutting down) either DURING
+                    // the RPC send above — which also takes this token, so the LS may NOT have received
+                    // the notification — or AFTER a confirmed send, during the post-send main-thread
+                    // marshal. In BOTH sub-cases skipping the commit is safe: the reset stays pending and
+                    // re-delivers idempotently on the next configuration update (re-sending an already-
+                    // delivered reset is a harmless no-op). Do NOT log at Error — this is expected, not a
+                    // fault.
+                    //
+                    // Precondition: this benign treatment assumes callers pass a shutdown/DisposalToken
+                    // (all current callers do). A future per-operation or timeout token that could cancel
+                    // AFTER a confirmed send would cause the reset to re-deliver once more on the next
+                    // update; if such a token is introduced, revisit whether it belongs in this benign path.
+                    return default;
+                }
                 catch (Exception ex)
                 {
                     // Transient failure: leave pendingResets in the queue (and in persistence) so the

--- a/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClientCustomTarget.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClientCustomTarget.cs
@@ -231,8 +231,15 @@ namespace Snyk.VisualStudio.Extension.Language
 
             serviceProvider.Options.ApiToken = new AuthenticationToken(serviceProvider.Options.AuthenticationMethod, token);
 
-            // Persist without triggering SettingsChanged → DidChangeConfigurationAsync back to the LS.
-            serviceProvider.SnykOptionsManager.Save(serviceProvider.Options, false);
+            // LS-delivered auth result (OAuth flow completed by the LS): persist the token but
+            // do NOT trigger SettingsChanged (would send DidChangeConfigurationAsync back to the LS),
+            // and do NOT update the override tracker — recording an LS-delivered token as a user
+            // override would corrupt ChangedConfigKeys, especially during early-startup auth before
+            // Load() has seeded the tracker (snapshot would be empty → persisted set overwritten null).
+            serviceProvider.SnykOptionsManager.Save(
+                serviceProvider.Options,
+                triggerSettingsChangedEvent: false,
+                updateOverrideTracker: false);
 
             // Scan only when this is a new login (old token was blank).
             // Token refresh also has old token non-blank, so no scan.
@@ -262,7 +269,10 @@ namespace Snyk.VisualStudio.Extension.Language
             GlobalSettingsApplier.Apply(param.Settings, options);
             options.FolderConfigs = FolderConfigApplier.Apply(options.FolderConfigs, param.FolderConfigs);
             // Persist without re-triggering DidChangeConfigurationAsync (avoids feedback loop).
-            this.serviceProvider.SnykOptionsManager.Save(options, false);
+            // updateOverrideTracker:false — LS-pushed values (org, LDX flags) must NEVER be recorded
+            // as user overrides; doing so would defeat the purpose of IDE-2152 by re-sending them
+            // with changed:true and clobbering the very org defaults this feature preserves.
+            this.serviceProvider.SnykOptionsManager.Save(options, triggerSettingsChangedEvent: false, updateOverrideTracker: false);
             Logger.Debug("$/snyk.configuration applied: {KeyCount} global setting(s), {FolderCount} folder config(s) stored in-memory",
                 param.Settings?.Count ?? 0, param.FolderConfigs?.Count ?? 0);
 
@@ -293,7 +303,9 @@ namespace Snyk.VisualStudio.Extension.Language
             if (trustedFolders == null) return;
 
             serviceProvider.Options.TrustedFolders = new HashSet<string>(trustedFolders.TrustedFolders);
-            this.serviceProvider.SnykOptionsManager.Save(serviceProvider.Options, false);
+            // updateOverrideTracker:false — LS is pushing the resolved trusted-folder set back;
+            // this is not a user override action and must not pollute ChangedConfigKeys.
+            this.serviceProvider.SnykOptionsManager.Save(serviceProvider.Options, triggerSettingsChangedEvent: false, updateOverrideTracker: false);
             // Don't call DidChangeConfigurationAsync here as it creates an infinite loop
             // The Language Server already knows about the trusted folders changes
         }

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigDefaults.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigDefaults.cs
@@ -1,0 +1,94 @@
+// ABOUTME: Maps each global pflag key to its plugin default value, mirroring the SnykSettings field
+// ABOUTME: initializers. Used by UserOverrideTracker to seed the override set on first load (IDE-2152).
+using System.Collections.Generic;
+using Snyk.VisualStudio.Extension.Authentication;
+using Snyk.VisualStudio.Extension.Download;
+
+namespace Snyk.VisualStudio.Extension.Language
+{
+    // Default values for each global pflag key, derived from SnykSettings field initializers.
+    // Keys absent from this map are treated as "no default known" — IsDefault returns false.
+    internal static class ConfigDefaults
+    {
+        // Mirrors SnykSettings field initializers exactly so seed comparison is accurate.
+        // CLI string defaults use SnykCliDownloader constants (same source as SnykSettings initializers)
+        // so this map cannot silently drift from SnykSettings.
+        private static readonly Dictionary<string, object> Defaults = new Dictionary<string, object>
+        {
+            // Products
+            [PflagKeys.SnykOssEnabled]           = true,
+            [PflagKeys.SnykCodeEnabled]           = true,
+            [PflagKeys.SnykIacEnabled]            = true,
+            [PflagKeys.SnykSecretsEnabled]        = false,
+
+            // Scan
+            [PflagKeys.ScanAutomatic]             = true,
+            [PflagKeys.ScanNetNew]                = false,
+
+            // Severity filters
+            [PflagKeys.SeverityFilterCritical]    = true,
+            [PflagKeys.SeverityFilterHigh]        = true,
+            [PflagKeys.SeverityFilterMedium]      = true,
+            [PflagKeys.SeverityFilterLow]         = true,
+
+            // Issue view
+            [PflagKeys.IssueViewOpenIssues]       = true,
+            [PflagKeys.IssueViewIgnoredIssues]    = false,
+
+            // Connection / auth
+            [PflagKeys.ApiEndpoint]               = string.Empty,
+            [PflagKeys.Token]                     = string.Empty,
+            // AuthenticationMethod default is the zero value of the enum (OAuth).
+            // Matches SnykSettings.AuthenticationMethod which has no explicit initializer.
+            [PflagKeys.AuthenticationMethod]      = default(AuthenticationType).ToString().ToLowerInvariant(),
+            [PflagKeys.Organization]              = string.Empty,
+            [PflagKeys.ProxyInsecure]             = false,
+
+            // CLI / binary — reference canonical SnykCliDownloader constants so this map
+            // cannot drift from the SnykSettings field initializers that use the same constants.
+            [PflagKeys.AutomaticDownload]         = true,
+            [PflagKeys.CliPath]                   = string.Empty,
+            [PflagKeys.CliReleaseChannel]         = SnykCliDownloader.DefaultReleaseChannel,
+            [PflagKeys.BinaryBaseUrl]             = SnykCliDownloader.DefaultBaseDownloadUrl,
+
+            // Trust — TrustedFolders is not yielded by GetGlobalKeyValues (it is folder-scoped, not
+            // global). This entry is defensive: if IsDefault is ever called for this key it returns
+            // the correct answer rather than "unknown key → not default".
+            [PflagKeys.TrustedFolders]            = new System.Collections.Generic.HashSet<string>(),
+
+            // Env / params (global defaults are empty)
+            [PflagKeys.AdditionalEnvironment]     = string.Empty,
+            [PflagKeys.AdditionalParameters]      = string.Empty,
+
+            // Risk score: null means "not set" == default.
+            // Stored explicitly so IsDefault(key, null) works via the defaultValue==null branch.
+            [PflagKeys.RiskScoreThreshold]        = null,
+        };
+
+        /// <summary>
+        /// Returns true when <paramref name="value"/> equals the plugin default for
+        /// <paramref name="key"/>. Returns false for unknown keys (conservative: treat as overridden).
+        /// </summary>
+        public static bool IsDefault(string key, object value)
+        {
+            if (!Defaults.TryGetValue(key, out var defaultValue))
+                return false;
+
+            if (defaultValue == null)
+                return value == null;
+
+            // For collection types, two empty collections are considered equal to the default.
+            // This is correct only because all collection defaults in Defaults are currently empty;
+            // if a future key has a non-empty collection default this branch must be replaced with
+            // a proper set-equality comparison.
+            if (defaultValue is System.Collections.ICollection defaultCol)
+            {
+                if (value is System.Collections.ICollection valCol)
+                    return valCol.Count == 0 && defaultCol.Count == 0;
+                return false;
+            }
+
+            return defaultValue.Equals(value);
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigDefaults.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigDefaults.cs
@@ -11,8 +11,11 @@ namespace Snyk.VisualStudio.Extension.Language
     internal static class ConfigDefaults
     {
         // Mirrors SnykSettings field initializers exactly so seed comparison is accurate.
-        // CLI string defaults use SnykCliDownloader constants (same source as SnykSettings initializers)
-        // so this map cannot silently drift from SnykSettings.
+        // CLI string defaults reference SnykCliDownloader constants (same source as SnykSettings
+        // initializers) so they cannot silently drift. Boolean product/scan/severity/view defaults
+        // are set to the same literal values as SnykSettings field initializers; the test
+        // ConfigDefaults_BooleanValues_MatchSnykSettingsFieldInitializers (ConfigDefaultsTests.cs)
+        // acts as a drift guard by constructing new SnykSettings() and comparing via GetDefaultForTest.
         private static readonly Dictionary<string, object> Defaults = new Dictionary<string, object>
         {
             // Products
@@ -88,7 +91,25 @@ namespace Snyk.VisualStudio.Extension.Language
                 return false;
             }
 
+            // AdditionalParameters: the form sends a space-joined string from a text input.
+            // An empty or whitespace-only string ("   ") is semantically equivalent to the empty
+            // default (no parameters) — splitting on spaces produces an empty token list either way.
+            if (key == PflagKeys.AdditionalParameters && value is string paramStr)
+                return string.IsNullOrWhiteSpace(paramStr);
+
             return defaultValue.Equals(value);
+        }
+
+        /// <summary>
+        /// Test helper: returns the raw default value for <paramref name="key"/> from the
+        /// <see cref="Defaults"/> map, or null when the key is absent. Used by drift-guard tests
+        /// to compare ConfigDefaults entries against <see cref="Settings.SnykSettings"/> field
+        /// initializers without exposing the dictionary publicly.
+        /// </summary>
+        internal static object GetDefaultForTest(string key)
+        {
+            Defaults.TryGetValue(key, out var value);
+            return value;
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigSetting.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigSetting.cs
@@ -23,6 +23,19 @@ namespace Snyk.VisualStudio.Extension.Language
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool IsLocked { get; set; }
 
+        /// <summary>Creates a ConfigSetting that always sends <c>changed:true</c> (legacy behaviour).</summary>
         public static ConfigSetting Of(object value) => new ConfigSetting { Value = value, Changed = true };
+
+        /// <summary>
+        /// Creates a ConfigSetting with an explicit <paramref name="changed"/> flag.
+        /// Use this when the changed flag is driven by <see cref="IUserOverrideTracker"/> (IDE-2152).
+        /// </summary>
+        public static ConfigSetting Of(object value, bool changed) => new ConfigSetting { Value = value, Changed = changed };
+
+        /// <summary>
+        /// Creates a reset signal: <c>{value:null, changed:true}</c>. Sent when the user returns a
+        /// setting to its plugin default so the LS clears any org-level override (IDE-2152).
+        /// </summary>
+        public static ConfigSetting Reset() => new ConfigSetting { Value = null, Changed = true };
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/IUserOverrideTracker.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/IUserOverrideTracker.cs
@@ -1,0 +1,107 @@
+// ABOUTME: Interface for tracking which global LSP config keys the user has explicitly overridden
+// ABOUTME: from their plugin defaults. Used by BuildSettingsMap to set the `changed` flag (IDE-2152).
+using System.Collections.Generic;
+using Snyk.VisualStudio.Extension.Settings;
+
+namespace Snyk.VisualStudio.Extension.Language
+{
+    /// <summary>
+    /// Tracks which global pflag keys the user has explicitly set away from plugin defaults.
+    /// Keys for which <see cref="PflagKeys.IsAlwaysChanged"/> returns true are always treated as
+    /// changed regardless of user action.
+    /// Thread-safety: implementations are single-threaded (UI thread / settings thread); no
+    /// concurrent access guarantee is required.
+    /// </summary>
+    public interface IUserOverrideTracker
+    {
+        /// <summary>
+        /// Returns true once the tracker has been hydrated from persistence (via
+        /// <see cref="SeedFrom"/> or the explicit Mark-loop in
+        /// <see cref="ISnykOptionsManager.Load"/>). False on a freshly constructed instance.
+        /// <para>
+        /// <see cref="Language.V25.LsSettingsV25.BuildSettingsMap"/> gates on this: an unseeded
+        /// tracker falls back to <c>changed:true</c> for every key (the safe pre-IDE-2152
+        /// behaviour) so a startup-ordering race cannot silently downgrade user overrides.
+        /// </para>
+        /// <para>
+        /// Neither <see cref="ClearChanged"/> nor <see cref="Clear"/> resets this flag; once
+        /// seeded, the tracker remains seeded across reload cycles.
+        /// </para>
+        /// </summary>
+        bool IsSeeded { get; }
+
+        /// <summary>
+        /// Returns true when the key was explicitly overridden by the user, or
+        /// <see cref="PflagKeys.IsAlwaysChanged"/> returns true for it.
+        /// </summary>
+        bool IsChanged(string key);
+
+        /// <summary>
+        /// Marks <paramref name="key"/> as explicitly overridden.
+        /// </summary>
+        void Mark(string key);
+
+        /// <summary>
+        /// Unmarks <paramref name="key"/> and enqueues it in the pending-reset set so the next
+        /// <see cref="ILsSettingsV25.BuildSettingsMap"/> call can emit <c>{value:null, changed:true}</c>.
+        /// No-op when the key was not previously marked.
+        /// </summary>
+        void Unmark(string key);
+
+        /// <summary>
+        /// Returns and clears the set of keys that need a reset signal (<c>{value:null, changed:true}</c>)
+        /// on the next settings push. Idempotent: second call returns empty set.
+        /// </summary>
+        IReadOnlyCollection<string> ConsumePendingResets();
+
+        /// <summary>
+        /// Seeds the tracker from the persisted options on first load (upgrade path): marks any
+        /// key whose current value differs from the plugin default.
+        /// </summary>
+        void SeedFrom(IPersistableOptions options);
+
+        /// <summary>
+        /// Called from <see cref="ISnykOptionsManager.Save"/> on the user-edit path: marks each
+        /// key in <paramref name="editedKeys"/> whose <paramref name="options"/> value deviates
+        /// from the plugin default, and unmarks + enqueues a reset for each edited key whose value
+        /// equals the default. Keys NOT in <paramref name="editedKeys"/> are left completely
+        /// untouched — so org-pushed values that merely persist in Options are never recorded as
+        /// user overrides. Pass an empty set to mark nothing (safe default for callers that cannot
+        /// enumerate their edited keys).
+        /// </summary>
+        void ApplyUserEdits(IPersistableOptions options, System.Collections.Generic.IReadOnlyCollection<string> editedKeys);
+
+        /// <summary>
+        /// Returns a snapshot of the currently-marked keys (for persisting to
+        /// <see cref="SnykSettings.ChangedConfigKeys"/>). Returns a concrete HashSet so callers
+        /// that need to assign to a <c>HashSet&lt;string&gt;</c> field (e.g. SnykSettings) do not
+        /// require an explicit cast (ISet→HashSet has no implicit conversion in C#).
+        /// </summary>
+        System.Collections.Generic.HashSet<string> Snapshot();
+
+        /// <summary>
+        /// Marks the tracker as seeded. Called by <see cref="ISnykOptionsManager.Load"/> after
+        /// the explicit persisted-keys Mark-loop completes, so that
+        /// <see cref="Language.V25.LsSettingsV25.BuildSettingsMap"/>'s <c>IsSeeded</c> gate
+        /// becomes active. (The <see cref="SeedFrom"/> path sets the flag internally; this method
+        /// covers the persisted-keys branch in Load which calls Mark in a loop instead.)
+        /// </summary>
+        void MarkSeeded();
+
+        /// <summary>
+        /// Clears only the <c>changed</c> marks, preserving the pending-reset queue.
+        /// Call at the start of <see cref="ISnykOptionsManager.Load"/> hydration so that a second
+        /// Load on the same manager never unions stale marks, while any reset signals that were
+        /// enqueued (via <see cref="ApplyUserEdits"/> or <see cref="Unmark"/>) between saves are
+        /// not discarded before <see cref="ConsumePendingResets"/> picks them up in the next
+        /// BuildSettingsMap call.
+        /// </summary>
+        void ClearChanged();
+
+        /// <summary>
+        /// Clears all marks AND pending resets. Use only when a full reset of tracker state is
+        /// required (e.g. unit-test teardown or explicit full reinitialisation).
+        /// </summary>
+        void Clear();
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/IUserOverrideTracker.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/IUserOverrideTracker.cs
@@ -9,8 +9,11 @@ namespace Snyk.VisualStudio.Extension.Language
     /// Tracks which global pflag keys the user has explicitly set away from plugin defaults.
     /// Keys for which <see cref="PflagKeys.IsAlwaysChanged"/> returns true are always treated as
     /// changed regardless of user action.
-    /// Thread-safety: implementations are single-threaded (UI thread / settings thread); no
-    /// concurrent access guarantee is required.
+    /// Thread-safety: implementations MUST be safe for concurrent access. The tracker is mutated
+    /// from the UI thread (settings Save) and from thread-pool continuations (the fire-and-forget
+    /// config-send path commits resets after an awaited RPC), so every read and mutation must be
+    /// internally synchronised and <see cref="PeekPendingResets"/>/<see cref="Snapshot"/> must
+    /// return independent copies.
     /// </summary>
     public interface IUserOverrideTracker
     {
@@ -49,10 +52,44 @@ namespace Snyk.VisualStudio.Extension.Language
         void Unmark(string key);
 
         /// <summary>
-        /// Returns and clears the set of keys that need a reset signal (<c>{value:null, changed:true}</c>)
-        /// on the next settings push. Idempotent: second call returns empty set.
+        /// Returns the set of keys that need a reset signal (<c>{value:null, changed:true}</c>) on the
+        /// next settings push WITHOUT clearing them (IDE-2152 CP 2.2). Use this from
+        /// <see cref="Language.V25.LsSettingsV25.BuildSettingsMap"/> so a transient RPC failure does
+        /// not lose the reset intent — the queue is cleared only by <see cref="CommitPendingResets"/>
+        /// after a confirmed successful config-update send.
         /// </summary>
-        IReadOnlyCollection<string> ConsumePendingResets();
+        IReadOnlyCollection<string> PeekPendingResets();
+
+        /// <summary>
+        /// Removes only the named <paramref name="sentKeys"/> from the pending-reset queue, after they
+        /// were confirmed delivered to the LS (IDE-2152 CP 2.2). Never a blanket clear: a newer reset
+        /// for the same key enqueued between the peek and the commit is preserved. No-op on null/empty.
+        /// </summary>
+        void CommitPendingResets(IReadOnlyCollection<string> sentKeys);
+
+        /// <summary>
+        /// Applies an explicit user reset to each key in <paramref name="resetKeys"/> (IDE-2152): removes
+        /// the local override mark (so the key drops out of <see cref="Snapshot"/>) AND enqueues a
+        /// pending reset so the next <see cref="Language.V25.LsSettingsV25.BuildSettingsMap"/> emits
+        /// <c>{value:null, changed:true}</c>. Unlike <see cref="Unmark"/>, the reset signal is ALWAYS
+        /// enqueued — even when the key had no local mark — because a form reset must still tell the LS
+        /// to Unset any <c>user:global</c> override (e.g. an org-pushed value the user wants cleared);
+        /// the local un-mark is best-effort. No-op on null/empty. Reset and edit (<see cref="Mark"/>)
+        /// are disjoint per save: a key is either edited-to-a-value or reset, never both.
+        /// </summary>
+        void ApplyUserResets(IReadOnlyCollection<string> resetKeys);
+
+        /// <summary>
+        /// Re-queues persisted-but-unconfirmed reset keys on <see cref="ISnykOptionsManager.Load"/>
+        /// so a reset applied while the LS was not ready survives a restart and is re-delivered on the
+        /// next configuration update (IDE-2152 critical fix #2). Unlike <see cref="ApplyUserResets"/>,
+        /// this does NOT un-mark anything (Load hydrates <c>changed</c> separately) and skips any key
+        /// that is currently a live override mark — a persisted override means the user re-applied the
+        /// key after the reset was queued, so the override wins and no reset is re-emitted. No-op on
+        /// null/empty. Preserves the invariant that a key is never in both <c>changed</c> and the
+        /// pending-reset queue.
+        /// </summary>
+        void RehydratePendingResets(IReadOnlyCollection<string> resetKeys);
 
         /// <summary>
         /// Seeds the tracker from the persisted options on first load (upgrade path): marks any
@@ -98,9 +135,9 @@ namespace Snyk.VisualStudio.Extension.Language
         /// Clears only the <c>changed</c> marks, preserving the pending-reset queue.
         /// Call at the start of <see cref="ISnykOptionsManager.Load"/> hydration so that a second
         /// Load on the same manager never unions stale marks, while any reset signals that were
-        /// enqueued (via <see cref="ApplyUserEdits"/> or <see cref="Unmark"/>) between saves are
-        /// not discarded before <see cref="ConsumePendingResets"/> picks them up in the next
-        /// BuildSettingsMap call.
+        /// enqueued (via <see cref="ApplyUserResets"/> or <see cref="Unmark"/>) between saves are
+        /// not discarded before <see cref="PeekPendingResets"/> folds them into the next
+        /// BuildSettingsMap call (committed on confirmed send success).
         /// </summary>
         void ClearChanged();
 

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/IUserOverrideTracker.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/IUserOverrideTracker.cs
@@ -61,13 +61,19 @@ namespace Snyk.VisualStudio.Extension.Language
         void SeedFrom(IPersistableOptions options);
 
         /// <summary>
-        /// Called from <see cref="ISnykOptionsManager.Save"/> on the user-edit path: marks each
-        /// key in <paramref name="editedKeys"/> whose <paramref name="options"/> value deviates
-        /// from the plugin default, and unmarks + enqueues a reset for each edited key whose value
-        /// equals the default. Keys NOT in <paramref name="editedKeys"/> are left completely
-        /// untouched — so org-pushed values that merely persist in Options are never recorded as
-        /// user overrides. Pass an empty set to mark nothing (safe default for callers that cannot
-        /// enumerate their edited keys).
+        /// Called from <see cref="ISnykOptionsManager.Save"/> on the user-edit path: marks every
+        /// key in <paramref name="editedKeys"/> as an explicit user override, regardless of whether
+        /// its <paramref name="options"/> value equals the plugin default. Any key the settings form
+        /// posted is an explicit user choice, so setting a key to a value that happens to equal the
+        /// default (e.g. enabling Snyk Code, whose default is <c>true</c>) is still recorded as an
+        /// override — reset-to-default is never inferred here from value==default. Keys NOT in
+        /// <paramref name="editedKeys"/> are left completely untouched — so org-pushed values that
+        /// merely persist in Options are never recorded as user overrides. Pass an empty set to mark
+        /// nothing (safe default for callers that cannot enumerate their edited keys).
+        /// <para>
+        /// Reset-to-default is an explicit user action expressed via <see cref="Unmark"/>, not
+        /// derived by this method from the edited value equalling the plugin default.
+        /// </para>
         /// </summary>
         void ApplyUserEdits(IPersistableOptions options, System.Collections.Generic.IReadOnlyCollection<string> editedKeys);
 

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/LsSettingsV25.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/LsSettingsV25.cs
@@ -25,9 +25,11 @@ namespace Snyk.VisualStudio.Extension.Language
                 return null;
 
             var options = serviceProvider.Options;
-            // BuildSettingsMap consumes pending resets destructively (ConsumePendingResets clears the
-            // queue). The result MUST be sent to the LS immediately — do not call BuildSettingsMap
-            // for inspection only, as doing so would silently discard queued reset signals.
+            // Init path: BuildSettingsMap(options) with no explicit snapshot folds in the tracker's
+            // current pending resets non-destructively and does NOT commit them (IDE-2152 fix #3). The
+            // handshake sends them, but the first successful DidChangeConfiguration is what commits
+            // (peek→send→commit), and persistence (fix #2) re-delivers them if init/handshake never
+            // confirms. This removes the fragile init-time commit that ran on a separate code path.
             return new InitializationOptionsV25
             {
                 Settings = BuildSettingsMap(options),
@@ -50,7 +52,14 @@ namespace Snyk.VisualStudio.Extension.Language
         // settings map (Project Defaults tab) and per-folder in folderConfigs. The LS resolves
         // folder-over-global. Global values are wired via ISnykOptions.AdditionalParameters /
         // AdditionalEnv; per-folder values live in FolderConfig.
-        internal Dictionary<string, ConfigSetting> BuildSettingsMap(ISnykOptions options)
+        //
+        // pendingResets (IDE-2152 CP 2.2 / fix #3): when non-null, EXACTLY this snapshot of reset keys
+        // is folded into the map — the caller peeked it once and will commit exactly this same set on
+        // confirmed send, so committed == sent by construction (no second independent peek that could
+        // race). When null, the map is built with the tracker's current pending resets (peeked here) —
+        // used by the init path, which does not commit at build time.
+        internal Dictionary<string, ConfigSetting> BuildSettingsMap(ISnykOptions options,
+            IReadOnlyCollection<string> pendingResets = null)
         {
             // Obtain the tracker from the options manager. When null (e.g. in tests that do not wire
             // the manager), fall back to changed:true so every key is treated as user-overridden
@@ -123,17 +132,19 @@ namespace Snyk.VisualStudio.Extension.Language
             // Emit reset signals for keys that were just un-marked (returned to default).
             // These override the regular value entry for that key with {value:null, changed:true}.
             //
-            // ConsumePendingResets() is destructive (clears the set). This is safe because
-            // BuildSettingsMap is only ever called immediately before sending to the LS:
-            //   • GetInitializationOptions()   → passed directly to SnykLanguageClient.InitializationOptions
-            //   • GetLspConfigurationParam()   → passed directly to DidChangeConfigurationAsync
-            // There is no build-without-send path, so resets cannot be silently discarded.
+            // Single-snapshot discipline (IDE-2152 fix #3): when the caller passed an explicit
+            // pendingResets snapshot, fold in EXACTLY that set — the caller peeked it once and commits
+            // the same set on confirmed send, so sent == committed with no second racing peek. When
+            // null (init path), fall back to a fresh non-destructive peek; the init path sends but does
+            // not commit at build time (the first successful DidChangeConfiguration commits, or
+            // persistence re-delivers after a restart — IDE-2152 fix #2).
             //
             // Guard on trackerSeeded: an unseeded tracker has no meaningful pending resets
             // (it has never been hydrated from persistence, so nothing could have been un-marked).
-            if (trackerSeeded)
+            var resetsToFold = pendingResets ?? (trackerSeeded ? tracker.PeekPendingResets() : null);
+            if (trackerSeeded && resetsToFold != null)
             {
-                foreach (var resetKey in tracker.ConsumePendingResets())
+                foreach (var resetKey in resetsToFold)
                     map[resetKey] = ConfigSetting.Reset();
             }
 
@@ -167,18 +178,21 @@ namespace Snyk.VisualStudio.Extension.Language
             return result;
         }
 
-        public LspConfigurationParam GetLspConfigurationParam()
+        // pendingResets: the EXACT reset snapshot the caller peeked once (IDE-2152 fix #3). It is
+        // threaded through BuildSettingsMap so the settings map folds in precisely the set the caller
+        // will commit on confirmed send — sent == committed by construction. The caller
+        // (DidChangeConfigurationAsync) sends this param and commits that same snapshot on success
+        // (via ISnykOptionsManager.CommitPendingResets), so a transient RPC failure leaves the queue
+        // intact for re-delivery on the next configuration update (IDE-2152 CP 2.2).
+        public LspConfigurationParam GetLspConfigurationParam(IReadOnlyCollection<string> pendingResets = null)
         {
             if (serviceProvider == null)
                 return null;
 
             var options = serviceProvider.Options;
-            // BuildSettingsMap consumes pending resets destructively (ConsumePendingResets clears the
-            // queue). The result MUST be sent to the LS immediately — do not call BuildSettingsMap
-            // for inspection only, as doing so would silently discard queued reset signals.
             return new LspConfigurationParam
             {
-                Settings = BuildSettingsMap(options),
+                Settings = BuildSettingsMap(options, pendingResets),
                 FolderConfigs = BuildFolderConfigs(options.FolderConfigs),
             };
         }

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/LsSettingsV25.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/LsSettingsV25.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Snyk.VisualStudio.Extension.CLI;
+using Snyk.VisualStudio.Extension.Download;
 using Snyk.VisualStudio.Extension.Service;
 using Snyk.VisualStudio.Extension.Settings;
 
@@ -24,6 +25,9 @@ namespace Snyk.VisualStudio.Extension.Language
                 return null;
 
             var options = serviceProvider.Options;
+            // BuildSettingsMap consumes pending resets destructively (ConsumePendingResets clears the
+            // queue). The result MUST be sent to the LS immediately — do not call BuildSettingsMap
+            // for inspection only, as doing so would silently discard queued reset signals.
             return new InitializationOptionsV25
             {
                 Settings = BuildSettingsMap(options),
@@ -48,53 +52,90 @@ namespace Snyk.VisualStudio.Extension.Language
         // AdditionalEnv; per-folder values live in FolderConfig.
         internal Dictionary<string, ConfigSetting> BuildSettingsMap(ISnykOptions options)
         {
+            // Obtain the tracker from the options manager. When null (e.g. in tests that do not wire
+            // the manager), fall back to changed:true so every key is treated as user-overridden
+            // (safe: matches the pre-IDE-2152 behaviour).
+            var tracker = serviceProvider?.SnykOptionsManager?.OverrideTracker;
+
+            // Helper: sets the changed flag from the tracker for this key.
+            // Gate on IsSeeded: an unseeded tracker (Load() has not run yet) falls back to
+            // changed:true so a startup-ordering race cannot silently downgrade user overrides by
+            // sending changed:false before persistence has been read. Once seeded, the tracker
+            // distinguishes overridden keys (changed:true) from untouched ones (changed:false).
+            var trackerSeeded = tracker != null && tracker.IsSeeded;
+            ConfigSetting Cs(string key, object value) =>
+                ConfigSetting.Of(value, trackerSeeded ? tracker.IsChanged(key) : true);
+
             var map = new Dictionary<string, ConfigSetting>
             {
-                [PflagKeys.SnykOssEnabled] = ConfigSetting.Of(options.OssEnabled),
-                [PflagKeys.SnykCodeEnabled] = ConfigSetting.Of(options.SnykCodeSecurityEnabled),
-                [PflagKeys.SnykIacEnabled] = ConfigSetting.Of(options.IacEnabled),
-                [PflagKeys.SnykSecretsEnabled] = ConfigSetting.Of(options.SecretsEnabled),
+                [PflagKeys.SnykOssEnabled]          = Cs(PflagKeys.SnykOssEnabled,         options.OssEnabled),
+                [PflagKeys.SnykCodeEnabled]         = Cs(PflagKeys.SnykCodeEnabled,        options.SnykCodeSecurityEnabled),
+                [PflagKeys.SnykIacEnabled]          = Cs(PflagKeys.SnykIacEnabled,         options.IacEnabled),
+                [PflagKeys.SnykSecretsEnabled]      = Cs(PflagKeys.SnykSecretsEnabled,     options.SecretsEnabled),
 
                 // Send the persisted user preference (AutoScan), not the InternalAutoScan runtime
                 // gate. The gate only delays the *first* scan until the IDE is ready (handled by the
                 // scan-trigger logic in OnSnykConfiguration / OnHasAuthenticated) — it must not be the
                 // value we tell the LS to persist, or a manual-mode choice gets overwritten by the
                 // gate's post-first-scan `true` on the next config round-trip.
-                [PflagKeys.ScanAutomatic] = ConfigSetting.Of(options.AutoScan),
-                [PflagKeys.ScanNetNew] = ConfigSetting.Of(options.EnableDeltaFindings),
+                [PflagKeys.ScanAutomatic]           = Cs(PflagKeys.ScanAutomatic,          options.AutoScan),
+                [PflagKeys.ScanNetNew]              = Cs(PflagKeys.ScanNetNew,             options.EnableDeltaFindings),
 
-                [PflagKeys.SeverityFilterCritical] = ConfigSetting.Of(options.FilterCritical),
-                [PflagKeys.SeverityFilterHigh] = ConfigSetting.Of(options.FilterHigh),
-                [PflagKeys.SeverityFilterMedium] = ConfigSetting.Of(options.FilterMedium),
-                [PflagKeys.SeverityFilterLow] = ConfigSetting.Of(options.FilterLow),
+                [PflagKeys.SeverityFilterCritical]  = Cs(PflagKeys.SeverityFilterCritical, options.FilterCritical),
+                [PflagKeys.SeverityFilterHigh]      = Cs(PflagKeys.SeverityFilterHigh,     options.FilterHigh),
+                [PflagKeys.SeverityFilterMedium]    = Cs(PflagKeys.SeverityFilterMedium,   options.FilterMedium),
+                [PflagKeys.SeverityFilterLow]       = Cs(PflagKeys.SeverityFilterLow,      options.FilterLow),
 
-                [PflagKeys.IssueViewOpenIssues] = ConfigSetting.Of(options.OpenIssuesEnabled),
-                [PflagKeys.IssueViewIgnoredIssues] = ConfigSetting.Of(options.IgnoredIssuesEnabled),
+                [PflagKeys.IssueViewOpenIssues]     = Cs(PflagKeys.IssueViewOpenIssues,    options.OpenIssuesEnabled),
+                [PflagKeys.IssueViewIgnoredIssues]  = Cs(PflagKeys.IssueViewIgnoredIssues, options.IgnoredIssuesEnabled),
 
-                [PflagKeys.ApiEndpoint] = ConfigSetting.Of(options.CustomEndpoint ?? string.Empty),
-                [PflagKeys.Token] = ConfigSetting.Of(options.ApiToken?.ToString() ?? string.Empty),
-                [PflagKeys.Organization] = ConfigSetting.Of(options.Organization ?? string.Empty),
-                [PflagKeys.AuthenticationMethod] = ConfigSetting.Of(options.AuthenticationMethod.ToString().ToLowerInvariant()),
-                [PflagKeys.ProxyInsecure] = ConfigSetting.Of(options.IgnoreUnknownCA),
+                [PflagKeys.ApiEndpoint]             = Cs(PflagKeys.ApiEndpoint,            options.CustomEndpoint ?? string.Empty),
+                [PflagKeys.Token]                   = Cs(PflagKeys.Token,                  options.ApiToken?.ToString() ?? string.Empty),
+                [PflagKeys.Organization]            = Cs(PflagKeys.Organization,           options.Organization ?? string.Empty),
+                [PflagKeys.AuthenticationMethod]    = Cs(PflagKeys.AuthenticationMethod,   options.AuthenticationMethod.ToString().ToLowerInvariant()),
+                [PflagKeys.ProxyInsecure]           = Cs(PflagKeys.ProxyInsecure,          options.IgnoreUnknownCA),
 
-                [PflagKeys.AutomaticDownload] = ConfigSetting.Of(options.BinariesAutoUpdate),
-                [PflagKeys.CliPath] = ConfigSetting.Of(SnykCli.GetCliFilePath(options.CliCustomPath)),
-                [PflagKeys.BinaryBaseUrl] = ConfigSetting.Of(options.CliBaseDownloadURL ?? string.Empty),
-                [PflagKeys.CliReleaseChannel] = ConfigSetting.Of(options.CliReleaseChannel ?? string.Empty),
+                [PflagKeys.AutomaticDownload]       = Cs(PflagKeys.AutomaticDownload,      options.BinariesAutoUpdate),
+                [PflagKeys.CliPath]                 = Cs(PflagKeys.CliPath,                SnykCli.GetCliFilePath(options.CliCustomPath)),
+                [PflagKeys.BinaryBaseUrl]           = Cs(PflagKeys.BinaryBaseUrl,
+                                                         options.CliBaseDownloadURL ?? SnykCliDownloader.DefaultBaseDownloadUrl),
+                [PflagKeys.CliReleaseChannel]       = Cs(PflagKeys.CliReleaseChannel,
+                                                         options.CliReleaseChannel ?? SnykCliDownloader.DefaultReleaseChannel),
 
-                [PflagKeys.TrustedFolders] = ConfigSetting.Of(options.TrustedFolders?.ToList() ?? new List<string>()),
-                [PflagKeys.AdditionalEnvironment] = ConfigSetting.Of(options.AdditionalEnv ?? string.Empty),
+                // TrustedFolders is in AlwaysChanged so IsChanged returns true regardless.
+                [PflagKeys.TrustedFolders]          = Cs(PflagKeys.TrustedFolders,         options.TrustedFolders?.ToList() ?? new List<string>()),
+                [PflagKeys.AdditionalEnvironment]   = Cs(PflagKeys.AdditionalEnvironment,  options.AdditionalEnv ?? string.Empty),
                 // LS applyCliConfig reads additional_parameters via settingStr (string type-assert),
                 // so send as a space-joined string — same wire format LS uses on its outbound echo.
-                [PflagKeys.AdditionalParameters] = ConfigSetting.Of(
-                    string.Join(" ", options.AdditionalParameters ?? new List<string>())),
+                [PflagKeys.AdditionalParameters]    = Cs(PflagKeys.AdditionalParameters,
+                                                         string.Join(" ", options.AdditionalParameters ?? new List<string>())),
 
-                [PflagKeys.DeviceId] = ConfigSetting.Of(options.DeviceId ?? string.Empty),
-                [PflagKeys.ClientProtocolVersion] = ConfigSetting.Of("25"),
+                // DeviceId and ClientProtocolVersion are not user-settable; send as always-changed
+                // to preserve backward compatibility (LS needs them on every handshake).
+                [PflagKeys.DeviceId]                = ConfigSetting.Of(options.DeviceId ?? string.Empty),
+                [PflagKeys.ClientProtocolVersion]   = ConfigSetting.Of("25"),
             };
 
             if (options.RiskScoreThreshold.HasValue)
-                map[PflagKeys.RiskScoreThreshold] = ConfigSetting.Of(options.RiskScoreThreshold.Value);
+                map[PflagKeys.RiskScoreThreshold] = Cs(PflagKeys.RiskScoreThreshold,
+                    options.RiskScoreThreshold.Value);
+
+            // Emit reset signals for keys that were just un-marked (returned to default).
+            // These override the regular value entry for that key with {value:null, changed:true}.
+            //
+            // ConsumePendingResets() is destructive (clears the set). This is safe because
+            // BuildSettingsMap is only ever called immediately before sending to the LS:
+            //   • GetInitializationOptions()   → passed directly to SnykLanguageClient.InitializationOptions
+            //   • GetLspConfigurationParam()   → passed directly to DidChangeConfigurationAsync
+            // There is no build-without-send path, so resets cannot be silently discarded.
+            //
+            // Guard on trackerSeeded: an unseeded tracker has no meaningful pending resets
+            // (it has never been hydrated from persistence, so nothing could have been un-marked).
+            if (trackerSeeded)
+            {
+                foreach (var resetKey in tracker.ConsumePendingResets())
+                    map[resetKey] = ConfigSetting.Reset();
+            }
 
             return map;
         }
@@ -132,6 +173,9 @@ namespace Snyk.VisualStudio.Extension.Language
                 return null;
 
             var options = serviceProvider.Options;
+            // BuildSettingsMap consumes pending resets destructively (ConsumePendingResets clears the
+            // queue). The result MUST be sent to the LS immediately — do not call BuildSettingsMap
+            // for inspection only, as doing so would silently discard queued reset signals.
             return new LspConfigurationParam
             {
                 Settings = BuildSettingsMap(options),

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/PflagKeys.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/PflagKeys.cs
@@ -79,5 +79,35 @@ namespace Snyk.VisualStudio.Extension.Language
         /// regardless of whether the user has explicitly overridden it (requirement M4).
         /// </summary>
         public static bool IsAlwaysChanged(string key) => _alwaysChanged.Contains(key);
+
+        // Global (Project Defaults / org-scope) settings the user can reset to default via the
+        // "Reset overrides" button. Mirrors snyk-ls GlobalResettableSettings (IDE-2149): a form save
+        // that posts one of these keys as explicit JSON null is a reset — the plugin un-marks the
+        // local override and sends {value:null, changed:true} so the LS Unsets the user:global
+        // override and the org/LDX-sync default takes effect. Private; callers use IsGlobalResettable.
+        private static readonly HashSet<string> _globalResettable = new HashSet<string>
+        {
+            SnykOssEnabled,
+            SnykCodeEnabled,
+            SnykIacEnabled,
+            SnykSecretsEnabled,
+            ScanAutomatic,
+            ScanNetNew,
+            SeverityFilterCritical,
+            SeverityFilterHigh,
+            SeverityFilterMedium,
+            SeverityFilterLow,
+            IssueViewOpenIssues,
+            IssueViewIgnoredIssues,
+            RiskScoreThreshold,
+            Organization,
+        };
+
+        /// <summary>
+        /// Returns true when <paramref name="key"/> is a global (Project Defaults) setting that the
+        /// user can reset to default. A form save posting this key as explicit JSON null is a reset
+        /// (IDE-2152). Mirrors snyk-ls <c>GlobalResettableSettings</c>.
+        /// </summary>
+        public static bool IsGlobalResettable(string key) => _globalResettable.Contains(key);
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/PflagKeys.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/PflagKeys.cs
@@ -43,6 +43,10 @@ namespace Snyk.VisualStudio.Extension.Language
 
         // Trust
         public const string TrustedFolders = "trusted_folders";
+        // Keys for always-changed set per AC M4 (defined in LS spec; not currently in VS BuildSettingsMap
+        // but included so the AlwaysChanged set is complete for when they are added).
+        public const string TrustEnabled = "trust_enabled";
+        public const string AutomaticAuthentication = "automatic_authentication";
 
         // Folder-level
         public const string AdditionalParameters = "additional_parameters";
@@ -59,5 +63,21 @@ namespace Snyk.VisualStudio.Extension.Language
         // there, not from the Settings map — the Settings-map copies are harmless redundancy.
         public const string ClientProtocolVersion = "client_protocol_version";
         public const string DeviceId = "device_id";
+
+        // Keys that are always sent with changed:true regardless of user action (requirement M4).
+        // trusted_folders must always signal intent so the LS never silently inherits an org default.
+        // Private to prevent external mutation; callers use IsAlwaysChanged(key).
+        private static readonly HashSet<string> _alwaysChanged = new HashSet<string>
+        {
+            TrustedFolders,
+            TrustEnabled,
+            AutomaticAuthentication,
+        };
+
+        /// <summary>
+        /// Returns true when <paramref name="key"/> must always be sent with <c>changed:true</c>
+        /// regardless of whether the user has explicitly overridden it (requirement M4).
+        /// </summary>
+        public static bool IsAlwaysChanged(string key) => _alwaysChanged.Contains(key);
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/UserOverrideTracker.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/UserOverrideTracker.cs
@@ -1,6 +1,5 @@
 // ABOUTME: Tracks which global LSP pflag keys the user explicitly overrode from plugin defaults.
 // ABOUTME: Persists via SnykSettings.ChangedConfigKeys; seeds from options on first load (IDE-2152).
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Snyk.VisualStudio.Extension.Download;
@@ -190,52 +189,5 @@ namespace Snyk.VisualStudio.Extension.Language
 
         private static KeyValuePair<string, object> Pair(string key, object value)
             => new KeyValuePair<string, object>(key, value);
-
-        /// <summary>
-        /// Returns a snapshot of the global pflag key → current value pairs for
-        /// <paramref name="options"/>. The snapshot has the same set of keys that
-        /// <see cref="GetGlobalKeyValues"/> produces, using the same value normalisations.
-        /// <para>
-        /// Called by <see cref="HtmlSettingsScriptingBridge"/> to build a pre-apply snapshot,
-        /// then compared against the post-apply <see cref="ISnykOptions"/> to derive the
-        /// edit-delta for <see cref="ApplyUserEdits"/>.
-        /// </para>
-        /// </summary>
-        internal static Dictionary<string, object> SnapshotGlobalKeys(IPersistableOptions options)
-        {
-            if (options == null) return new Dictionary<string, object>();
-            var result = new Dictionary<string, object>();
-            foreach (var kv in GetGlobalKeyValues(options))
-                result[kv.Key] = kv.Value;
-            return result;
-        }
-
-        /// <summary>
-        /// Computes the set of pflag keys whose value in <paramref name="after"/> differs from
-        /// the corresponding value in <paramref name="before"/>. Used by
-        /// <see cref="HtmlSettingsScriptingBridge"/> to build the edit-delta passed to
-        /// <see cref="ApplyUserEdits"/>.
-        /// </summary>
-        internal static IReadOnlyCollection<string> DiffGlobalKeys(
-            Dictionary<string, object> before, IPersistableOptions after)
-        {
-            if (before == null || after == null) return new List<string>();
-            var edited = new List<string>();
-            var afterValues = SnapshotGlobalKeys(after);
-            foreach (var kv in afterValues)
-            {
-                if (!before.TryGetValue(kv.Key, out var prev))
-                {
-                    edited.Add(kv.Key); // new key — treat as edited
-                    continue;
-                }
-                // Compare by string representation to avoid boxing-equality issues with object.
-                var prevStr = prev == null ? string.Empty : prev.ToString();
-                var afterStr = kv.Value == null ? string.Empty : kv.Value.ToString();
-                if (!string.Equals(prevStr, afterStr, StringComparison.Ordinal))
-                    edited.Add(kv.Key);
-            }
-            return edited;
-        }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/UserOverrideTracker.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/UserOverrideTracker.cs
@@ -85,24 +85,20 @@ namespace Snyk.VisualStudio.Extension.Language
         /// <inheritdoc/>
         public void ApplyUserEdits(IPersistableOptions options, IReadOnlyCollection<string> editedKeys)
         {
-            if (options == null || editedKeys == null || editedKeys.Count == 0) return;
+            if (editedKeys == null || editedKeys.Count == 0) return;
 
-            // Build a lookup of the current key→value pairs for the global keys so we can check
-            // each edited key without iterating the full set repeatedly.
-            var currentValues = new Dictionary<string, object>();
-            foreach (var kv in GetGlobalKeyValues(options))
-                currentValues[kv.Key] = kv.Value;
-
+            // Every key the settings form posted (present in editedKeys) is an explicit user choice
+            // and is recorded as an override — regardless of whether its value happens to equal the
+            // plugin default. This fixes the "enabling Snyk Code doesn't persist" bug (PR #515):
+            // Snyk Code's default is `true`, so a user *enabling* it posts a value == the default;
+            // inferring a reset from value==default here turned the enable into a
+            // reset-to-org-default signal and let the org value silently win.
+            //
+            // Reset-to-default is henceforth an explicit user action only (via Unmark), never
+            // inferred from the value equalling the default. Mark() already no-ops on null/empty
+            // keys and on IsAlwaysChanged keys, and cancels any pending reset for the key.
             foreach (var key in editedKeys)
-            {
-                if (!currentValues.TryGetValue(key, out var value))
-                    continue; // key not in global map — ignore (safe: unknown key has no tracker state)
-
-                if (ConfigDefaults.IsDefault(key, value))
-                    Unmark(key);  // user reset this key to default → unmark + enqueue reset
-                else
-                    Mark(key);    // user set this key to a non-default value → mark as override
-            }
+                Mark(key);
         }
 
         /// <inheritdoc/>
@@ -181,8 +177,10 @@ namespace Snyk.VisualStudio.Extension.Language
                 string.Join(" ", options.AdditionalParameters ?? new List<string>()));
 
             // RiskScoreThreshold: always yield (null == default == not set).
-            // When HasValue is false we yield null so ApplyUserEdits can detect the transition
-            // back to default and enqueue the pending reset signal.
+            // When HasValue is false we yield null so SeedFrom compares "unset" against the
+            // default and does not mark the key as an override. GetGlobalKeyValues is consumed
+            // only by SeedFrom; ApplyUserEdits no longer reads it (it marks every edited key
+            // verbatim — reset-to-default is an explicit user action, never inferred here).
             yield return Pair(PflagKeys.RiskScoreThreshold,
                 options.RiskScoreThreshold.HasValue ? (object)options.RiskScoreThreshold.Value : null);
         }

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/UserOverrideTracker.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/UserOverrideTracker.cs
@@ -10,6 +10,17 @@ namespace Snyk.VisualStudio.Extension.Language
     /// <inheritdoc cref="IUserOverrideTracker"/>
     public class UserOverrideTracker : IUserOverrideTracker
     {
+        // Single lock guarding ALL access to `changed`, `pendingResets`, and `isSeeded`.
+        // The tracker is mutated from the UI thread (SnykOptionsManager.Save →
+        // ApplyUserEdits/ApplyUserResets) AND from thread-pool continuations (the fire-and-forget
+        // config-send path commits after `await ...ConfigureAwait(false)`), from multiple call
+        // sites. A non-thread-safe HashSet mutated concurrently can throw or corrupt state, so every
+        // public read and mutation takes this lock. Public methods must never call each other while
+        // holding the lock except through the *NoLock helpers below (C# locks are reentrant, but the
+        // explicit split keeps the atomic boundary obvious). Peek/Snapshot copy under the lock so the
+        // returned collection can never be observed mid-mutation.
+        private readonly object gate = new object();
+
         // Keys that the user has explicitly set away from plugin defaults.
         private readonly HashSet<string> changed = new HashSet<string>();
 
@@ -22,17 +33,29 @@ namespace Snyk.VisualStudio.Extension.Language
         private bool isSeeded;
 
         /// <inheritdoc/>
-        public bool IsSeeded => isSeeded;
+        public bool IsSeeded
+        {
+            get { lock (gate) return isSeeded; }
+        }
 
         /// <inheritdoc/>
         public bool IsChanged(string key)
         {
             if (string.IsNullOrEmpty(key)) return false;
-            return changed.Contains(key) || PflagKeys.IsAlwaysChanged(key);
+            // IsAlwaysChanged reads an immutable static set — safe outside the lock; but `changed`
+            // must be read under the lock.
+            if (PflagKeys.IsAlwaysChanged(key)) return true;
+            lock (gate) return changed.Contains(key);
         }
 
         /// <inheritdoc/>
         public void Mark(string key)
+        {
+            lock (gate) MarkNoLock(key);
+        }
+
+        // Core Mark logic; caller must hold `gate`.
+        private void MarkNoLock(string key)
         {
             if (string.IsNullOrEmpty(key)) return;
             // Always-changed keys are handled by IsAlwaysChanged(); adding them to the `changed`
@@ -50,36 +73,100 @@ namespace Snyk.VisualStudio.Extension.Language
         public void Unmark(string key)
         {
             if (string.IsNullOrEmpty(key)) return;
-            if (changed.Remove(key))
-                pendingResets.Add(key);
+            lock (gate)
+            {
+                if (changed.Remove(key))
+                    pendingResets.Add(key);
+            }
         }
 
         /// <inheritdoc/>
-        public IReadOnlyCollection<string> ConsumePendingResets()
+        public IReadOnlyCollection<string> PeekPendingResets()
         {
-            var result = pendingResets.ToList();
-            pendingResets.Clear();
-            return result;
+            // Non-destructive: return a copy TAKEN UNDER THE LOCK so the caller can iterate while the
+            // queue stays intact until CommitPendingResets confirms delivery (IDE-2152 CP 2.2). The
+            // copy also isolates the caller from concurrent mutation of the live set.
+            lock (gate) return pendingResets.ToList();
+        }
+
+        /// <inheritdoc/>
+        public void CommitPendingResets(IReadOnlyCollection<string> sentKeys)
+        {
+            if (sentKeys == null) return;
+            lock (gate)
+            {
+                // Remove only the keys that were actually delivered. Never a blanket Clear(): a reset
+                // for a DIFFERENT key enqueued between the peek (what was sent) and this commit was
+                // never in the confirmed message, so it must survive to be re-delivered on the next
+                // config update.
+                foreach (var key in sentKeys)
+                    pendingResets.Remove(key);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void ApplyUserResets(IReadOnlyCollection<string> resetKeys)
+        {
+            if (resetKeys == null || resetKeys.Count == 0) return;
+            lock (gate)
+            {
+                foreach (var key in resetKeys)
+                {
+                    if (string.IsNullOrEmpty(key)) continue;
+                    // Best-effort local un-mark: drop the override so the key leaves Snapshot() (and
+                    // thus the persisted ChangedConfigKeys set). Remove returns false when there was
+                    // no mark — that is fine, we still enqueue the LS reset signal below.
+                    changed.Remove(key);
+                    // Always enqueue the reset signal, even when there was no local mark: a form reset
+                    // must tell the LS to Unset any user:global override (e.g. an org-pushed value the
+                    // user wants cleared). This is the key difference from Unmark, which only enqueues
+                    // when the key was previously in the changed set.
+                    pendingResets.Add(key);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public void RehydratePendingResets(IReadOnlyCollection<string> resetKeys)
+        {
+            if (resetKeys == null || resetKeys.Count == 0) return;
+            lock (gate)
+            {
+                foreach (var key in resetKeys)
+                {
+                    if (string.IsNullOrEmpty(key)) continue;
+                    // Re-queue a persisted-but-unconfirmed reset on Load() so it is re-delivered after
+                    // a restart. Mirror the ApplyUserResets invariant: a rehydrated reset must never
+                    // coexist with a live override mark for the same key (a persisted override wins —
+                    // it means the user re-applied the key after the reset was queued).
+                    if (!changed.Contains(key))
+                        pendingResets.Add(key);
+                }
+            }
         }
 
         /// <inheritdoc/>
         public void SeedFrom(IPersistableOptions options)
         {
             if (options == null) return;
-            // Replace-semantics: clear BOTH changed and pendingResets before re-hydrating from
-            // options. SeedFrom is a from-scratch operation (first load / upgrade path); any
-            // pendingResets accumulated before seeding have no corresponding consumer and must
-            // not survive into the first BuildSettingsMap call, where they would emit spurious
-            // {value:null, changed:true} reset signals for keys the user never touched.
-            Clear();
-            foreach (var kv in GetGlobalKeyValues(options))
+            lock (gate)
             {
-                if (!ConfigDefaults.IsDefault(kv.Key, kv.Value))
-                    Mark(kv.Key);
+                // Replace-semantics: clear BOTH changed and pendingResets before re-hydrating from
+                // options. SeedFrom is a from-scratch operation (first load / upgrade path); any
+                // pendingResets accumulated before seeding have no corresponding consumer and must
+                // not survive into the first BuildSettingsMap call, where they would emit spurious
+                // {value:null, changed:true} reset signals for keys the user never touched.
+                changed.Clear();
+                pendingResets.Clear();
+                foreach (var kv in GetGlobalKeyValues(options))
+                {
+                    if (!ConfigDefaults.IsDefault(kv.Key, kv.Value))
+                        MarkNoLock(kv.Key);
+                }
+                // Mark seeded after the loop so BuildSettingsMap's IsSeeded gate becomes active
+                // once the tracker genuinely has data from persistence.
+                isSeeded = true;
             }
-            // Mark seeded after the loop so BuildSettingsMap's IsSeeded gate becomes active
-            // once the tracker genuinely has data from persistence.
-            isSeeded = true;
         }
 
         /// <inheritdoc/>
@@ -97,26 +184,29 @@ namespace Snyk.VisualStudio.Extension.Language
             // Reset-to-default is henceforth an explicit user action only (via Unmark), never
             // inferred from the value equalling the default. Mark() already no-ops on null/empty
             // keys and on IsAlwaysChanged keys, and cancels any pending reset for the key.
-            foreach (var key in editedKeys)
-                Mark(key);
+            lock (gate)
+            {
+                foreach (var key in editedKeys)
+                    MarkNoLock(key);
+            }
         }
 
         /// <inheritdoc/>
         public HashSet<string> Snapshot()
         {
-            return new HashSet<string>(changed);
+            lock (gate) return new HashSet<string>(changed);
         }
 
         /// <inheritdoc/>
         public void MarkSeeded()
         {
-            isSeeded = true;
+            lock (gate) isSeeded = true;
         }
 
         /// <inheritdoc/>
         public void ClearChanged()
         {
-            changed.Clear();
+            lock (gate) changed.Clear();
             // pendingResets is intentionally preserved: resets enqueued by ApplyUserEdits / Unmark
             // between saves must survive into the next BuildSettingsMap call to emit
             // {value:null, changed:true} reset signals.
@@ -126,8 +216,11 @@ namespace Snyk.VisualStudio.Extension.Language
         /// <inheritdoc/>
         public void Clear()
         {
-            changed.Clear();
-            pendingResets.Clear();
+            lock (gate)
+            {
+                changed.Clear();
+                pendingResets.Clear();
+            }
             // isSeeded is intentionally NOT reset — once seeded, always seeded.
         }
 

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/UserOverrideTracker.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/UserOverrideTracker.cs
@@ -1,0 +1,241 @@
+// ABOUTME: Tracks which global LSP pflag keys the user explicitly overrode from plugin defaults.
+// ABOUTME: Persists via SnykSettings.ChangedConfigKeys; seeds from options on first load (IDE-2152).
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Snyk.VisualStudio.Extension.Download;
+using Snyk.VisualStudio.Extension.Settings;
+
+namespace Snyk.VisualStudio.Extension.Language
+{
+    /// <inheritdoc cref="IUserOverrideTracker"/>
+    public class UserOverrideTracker : IUserOverrideTracker
+    {
+        // Keys that the user has explicitly set away from plugin defaults.
+        private readonly HashSet<string> changed = new HashSet<string>();
+
+        // Keys that were just un-marked and need a {value:null, changed:true} reset signal.
+        private readonly HashSet<string> pendingResets = new HashSet<string>();
+
+        // Set to true once hydrated from persistence (SeedFrom or the explicit Mark-loop in Load()).
+        // Never reset by ClearChanged()/Clear() — once seeded, always seeded.
+        // BuildSettingsMap gates on this to avoid sending changed:false before Load() has run.
+        private bool isSeeded;
+
+        /// <inheritdoc/>
+        public bool IsSeeded => isSeeded;
+
+        /// <inheritdoc/>
+        public bool IsChanged(string key)
+        {
+            if (string.IsNullOrEmpty(key)) return false;
+            return changed.Contains(key) || PflagKeys.IsAlwaysChanged(key);
+        }
+
+        /// <inheritdoc/>
+        public void Mark(string key)
+        {
+            if (string.IsNullOrEmpty(key)) return;
+            // Always-changed keys are handled by IsAlwaysChanged(); adding them to the `changed`
+            // set would cause them to appear in Snapshot() and get persisted unnecessarily.
+            if (PflagKeys.IsAlwaysChanged(key)) return;
+            changed.Add(key);
+            // Cancel any pending reset for this key: the user has re-applied an override after
+            // having previously reset to default. Without this, BuildSettingsMap would overwrite
+            // the live {value:false, changed:true} entry with a Reset() signal (value:null).
+            // Invariant: a key is never simultaneously in both `changed` and `pendingResets`.
+            pendingResets.Remove(key);
+        }
+
+        /// <inheritdoc/>
+        public void Unmark(string key)
+        {
+            if (string.IsNullOrEmpty(key)) return;
+            if (changed.Remove(key))
+                pendingResets.Add(key);
+        }
+
+        /// <inheritdoc/>
+        public IReadOnlyCollection<string> ConsumePendingResets()
+        {
+            var result = pendingResets.ToList();
+            pendingResets.Clear();
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public void SeedFrom(IPersistableOptions options)
+        {
+            if (options == null) return;
+            // Replace-semantics: clear BOTH changed and pendingResets before re-hydrating from
+            // options. SeedFrom is a from-scratch operation (first load / upgrade path); any
+            // pendingResets accumulated before seeding have no corresponding consumer and must
+            // not survive into the first BuildSettingsMap call, where they would emit spurious
+            // {value:null, changed:true} reset signals for keys the user never touched.
+            Clear();
+            foreach (var kv in GetGlobalKeyValues(options))
+            {
+                if (!ConfigDefaults.IsDefault(kv.Key, kv.Value))
+                    Mark(kv.Key);
+            }
+            // Mark seeded after the loop so BuildSettingsMap's IsSeeded gate becomes active
+            // once the tracker genuinely has data from persistence.
+            isSeeded = true;
+        }
+
+        /// <inheritdoc/>
+        public void ApplyUserEdits(IPersistableOptions options, IReadOnlyCollection<string> editedKeys)
+        {
+            if (options == null || editedKeys == null || editedKeys.Count == 0) return;
+
+            // Build a lookup of the current key→value pairs for the global keys so we can check
+            // each edited key without iterating the full set repeatedly.
+            var currentValues = new Dictionary<string, object>();
+            foreach (var kv in GetGlobalKeyValues(options))
+                currentValues[kv.Key] = kv.Value;
+
+            foreach (var key in editedKeys)
+            {
+                if (!currentValues.TryGetValue(key, out var value))
+                    continue; // key not in global map — ignore (safe: unknown key has no tracker state)
+
+                if (ConfigDefaults.IsDefault(key, value))
+                    Unmark(key);  // user reset this key to default → unmark + enqueue reset
+                else
+                    Mark(key);    // user set this key to a non-default value → mark as override
+            }
+        }
+
+        /// <inheritdoc/>
+        public HashSet<string> Snapshot()
+        {
+            return new HashSet<string>(changed);
+        }
+
+        /// <inheritdoc/>
+        public void MarkSeeded()
+        {
+            isSeeded = true;
+        }
+
+        /// <inheritdoc/>
+        public void ClearChanged()
+        {
+            changed.Clear();
+            // pendingResets is intentionally preserved: resets enqueued by ApplyUserEdits / Unmark
+            // between saves must survive into the next BuildSettingsMap call to emit
+            // {value:null, changed:true} reset signals.
+            // isSeeded is intentionally NOT reset — once seeded, always seeded.
+        }
+
+        /// <inheritdoc/>
+        public void Clear()
+        {
+            changed.Clear();
+            pendingResets.Clear();
+            // isSeeded is intentionally NOT reset — once seeded, always seeded.
+        }
+
+        // Returns the global (non-folder) pflag key → current value pairs from options.
+        // This must mirror exactly the keys emitted by LsSettingsV25.BuildSettingsMap for global settings.
+        private static IEnumerable<KeyValuePair<string, object>> GetGlobalKeyValues(IPersistableOptions options)
+        {
+            yield return Pair(PflagKeys.SnykOssEnabled, options.OssEnabled);
+            yield return Pair(PflagKeys.SnykCodeEnabled, options.SnykCodeSecurityEnabled);
+            yield return Pair(PflagKeys.SnykIacEnabled, options.IacEnabled);
+            yield return Pair(PflagKeys.SnykSecretsEnabled, options.SecretsEnabled);
+
+            // ScanAutomatic tracks the user's AutoScan preference. BuildSettingsMap sends
+            // InternalAutoScan (which gates on additional runtime conditions), but the tracker
+            // compares AutoScan (user intent) — intentional asymmetry.
+            yield return Pair(PflagKeys.ScanAutomatic, options.AutoScan);
+            yield return Pair(PflagKeys.ScanNetNew, options.EnableDeltaFindings);
+
+            yield return Pair(PflagKeys.SeverityFilterCritical, options.FilterCritical);
+            yield return Pair(PflagKeys.SeverityFilterHigh, options.FilterHigh);
+            yield return Pair(PflagKeys.SeverityFilterMedium, options.FilterMedium);
+            yield return Pair(PflagKeys.SeverityFilterLow, options.FilterLow);
+
+            yield return Pair(PflagKeys.IssueViewOpenIssues, options.OpenIssuesEnabled);
+            yield return Pair(PflagKeys.IssueViewIgnoredIssues, options.IgnoredIssuesEnabled);
+
+            yield return Pair(PflagKeys.ApiEndpoint, options.CustomEndpoint ?? string.Empty);
+            // Token and AuthenticationMethod must be tracked so the LS receives changed:true when
+            // the user has set a non-default credential or auth mode.
+            yield return Pair(PflagKeys.Token, options.ApiToken?.ToString() ?? string.Empty);
+            yield return Pair(PflagKeys.AuthenticationMethod,
+                options.AuthenticationMethod.ToString().ToLowerInvariant());
+            yield return Pair(PflagKeys.Organization, options.Organization ?? string.Empty);
+            yield return Pair(PflagKeys.ProxyInsecure, options.IgnoreUnknownCA);
+
+            yield return Pair(PflagKeys.AutomaticDownload, options.BinariesAutoUpdate);
+            // CliPath: tracker compares the raw options.CliCustomPath (user-configured path).
+            // BuildSettingsMap sends the RESOLVED SnykCli.GetCliFilePath(...) — intentional.
+            yield return Pair(PflagKeys.CliPath, options.CliCustomPath ?? string.Empty);
+            yield return Pair(PflagKeys.CliReleaseChannel,
+                options.CliReleaseChannel ?? SnykCliDownloader.DefaultReleaseChannel);
+            yield return Pair(PflagKeys.BinaryBaseUrl,
+                options.CliBaseDownloadURL ?? SnykCliDownloader.DefaultBaseDownloadUrl);
+
+            yield return Pair(PflagKeys.AdditionalEnvironment, options.AdditionalEnv ?? string.Empty);
+            yield return Pair(PflagKeys.AdditionalParameters,
+                string.Join(" ", options.AdditionalParameters ?? new List<string>()));
+
+            // RiskScoreThreshold: always yield (null == default == not set).
+            // When HasValue is false we yield null so ApplyUserEdits can detect the transition
+            // back to default and enqueue the pending reset signal.
+            yield return Pair(PflagKeys.RiskScoreThreshold,
+                options.RiskScoreThreshold.HasValue ? (object)options.RiskScoreThreshold.Value : null);
+        }
+
+        private static KeyValuePair<string, object> Pair(string key, object value)
+            => new KeyValuePair<string, object>(key, value);
+
+        /// <summary>
+        /// Returns a snapshot of the global pflag key → current value pairs for
+        /// <paramref name="options"/>. The snapshot has the same set of keys that
+        /// <see cref="GetGlobalKeyValues"/> produces, using the same value normalisations.
+        /// <para>
+        /// Called by <see cref="HtmlSettingsScriptingBridge"/> to build a pre-apply snapshot,
+        /// then compared against the post-apply <see cref="ISnykOptions"/> to derive the
+        /// edit-delta for <see cref="ApplyUserEdits"/>.
+        /// </para>
+        /// </summary>
+        internal static Dictionary<string, object> SnapshotGlobalKeys(IPersistableOptions options)
+        {
+            if (options == null) return new Dictionary<string, object>();
+            var result = new Dictionary<string, object>();
+            foreach (var kv in GetGlobalKeyValues(options))
+                result[kv.Key] = kv.Value;
+            return result;
+        }
+
+        /// <summary>
+        /// Computes the set of pflag keys whose value in <paramref name="after"/> differs from
+        /// the corresponding value in <paramref name="before"/>. Used by
+        /// <see cref="HtmlSettingsScriptingBridge"/> to build the edit-delta passed to
+        /// <see cref="ApplyUserEdits"/>.
+        /// </summary>
+        internal static IReadOnlyCollection<string> DiffGlobalKeys(
+            Dictionary<string, object> before, IPersistableOptions after)
+        {
+            if (before == null || after == null) return new List<string>();
+            var edited = new List<string>();
+            var afterValues = SnapshotGlobalKeys(after);
+            foreach (var kv in afterValues)
+            {
+                if (!before.TryGetValue(kv.Key, out var prev))
+                {
+                    edited.Add(kv.Key); // new key — treat as edited
+                    continue;
+                }
+                // Compare by string representation to avoid boxing-equality issues with object.
+                var prevStr = prev == null ? string.Empty : prev.ToString();
+                var afterStr = kv.Value == null ? string.Empty : kv.Value.ToString();
+                if (!string.Equals(prevStr, afterStr, StringComparison.Ordinal))
+                    edited.Add(kv.Key);
+            }
+            return edited;
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/Service/SnykTasksService.cs
+++ b/Snyk.VisualStudio.Extension.2022/Service/SnykTasksService.cs
@@ -769,7 +769,13 @@ namespace Snyk.VisualStudio.Extension.Service
                 downloadFinishedCallbacks.Add(() =>
                 {
                     this.serviceProvider.Options.CurrentCliVersion = cliDownloader.GetLatestReleaseInfo().Name;
-                    this.serviceProvider.SnykOptionsManager.Save(this.serviceProvider.Options);
+                    // System-driven update: suppress both the SettingsChanged event (would re-send
+                    // DidChangeConfigurationAsync for a CLI-version bump) and tracker mutation (recording
+                    // the new CurrentCliVersion as a user override would create a phantom ChangedConfigKeys entry).
+                    this.serviceProvider.SnykOptionsManager.Save(
+                        this.serviceProvider.Options,
+                        triggerSettingsChangedEvent: false,
+                        updateOverrideTracker: false);
                     DisposeCancellationTokenSource(this.downloadCliTokenSource);
                 });
 

--- a/Snyk.VisualStudio.Extension.2022/Service/WorkspaceTrustService.cs
+++ b/Snyk.VisualStudio.Extension.2022/Service/WorkspaceTrustService.cs
@@ -33,7 +33,7 @@ namespace Snyk.VisualStudio.Extension.Service
                 var trustedFolders = this.serviceProvider.Options.TrustedFolders;
                 trustedFolders.Add(absoluteFolderPath);
                 this.serviceProvider.Options.TrustedFolders = trustedFolders;
-                this.serviceProvider.SnykOptionsManager.Save(this.serviceProvider.Options, false);
+                this.serviceProvider.SnykOptionsManager.Save(this.serviceProvider.Options, triggerSettingsChangedEvent: false, updateOverrideTracker: false);
             }
             catch (Exception e)
             {

--- a/Snyk.VisualStudio.Extension.2022/Settings/IPersistableOption.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/IPersistableOption.cs
@@ -88,4 +88,11 @@ public interface IPersistableOptions
     string AdditionalEnv { get; set; }
     List<string> AdditionalParameters { get; set; }
     int? RiskScoreThreshold { get; set; }
+
+    /// <summary>
+    /// Set of pflag keys that the user explicitly overrode from the plugin default.
+    /// Persisted to settings.json so the override set survives IDE restarts (IDE-2152).
+    /// Null when absent from disk (first load / upgrade path) — treated as empty by the tracker.
+    /// </summary>
+    ISet<string> ChangedConfigKeys { get; set; }
 }

--- a/Snyk.VisualStudio.Extension.2022/Settings/ISnykOptionsManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/ISnykOptionsManager.cs
@@ -19,15 +19,32 @@ namespace Snyk.VisualStudio.Extension.Settings
     /// default: org-pushed values already in Options are never accidentally frozen). Only consulted
     /// when <paramref name="updateOverrideTracker"/> is true.
     /// </param>
+    /// <param name="resetKeys">
+    /// The set of global pflag keys the user reset to default in this save action (posted as explicit
+    /// JSON null by the "Reset overrides" button). For each, the tracker un-marks the local override
+    /// and enqueues a <c>{value:null, changed:true}</c> reset signal for the LS (IDE-2152). Disjoint
+    /// from <paramref name="editedKeys"/>: a key is either edited-to-a-value or reset, never both.
+    /// Null or empty → no resets. Only consulted when <paramref name="updateOverrideTracker"/> is true.
+    /// </param>
     void Save(IPersistableOptions options, bool triggerSettingsChangedEvent = true,
               bool updateOverrideTracker = true,
-              System.Collections.Generic.IReadOnlyCollection<string> editedKeys = null);
+              System.Collections.Generic.IReadOnlyCollection<string> editedKeys = null,
+              System.Collections.Generic.IReadOnlyCollection<string> resetKeys = null);
 
     /// <summary>
     /// The user-override tracker singleton owned by this manager. Used by
     /// <see cref="LsSettingsV25"/> to set the <c>changed</c> flag on each ConfigSetting (IDE-2152).
     /// </summary>
     IUserOverrideTracker OverrideTracker { get; }
+
+    /// <summary>
+    /// Commit reset keys confirmed-delivered to the Language Server (IDE-2152 fix #2): removes exactly
+    /// the given keys from the tracker's pending-reset queue AND re-persists the shrunken set to disk,
+    /// so a delivered reset is not re-sent after a restart. The single commit entry point — the
+    /// config-send path calls this rather than the tracker directly, keeping persistence and the
+    /// in-memory queue in sync. No-op on null/empty.
+    /// </summary>
+    void CommitPendingResets(System.Collections.Generic.IReadOnlyCollection<string> sentKeys);
 
     /// <summary>
     /// Migrate the legacy per-solution settings entry for the given solution folder (if any) into the

--- a/Snyk.VisualStudio.Extension.2022/Settings/ISnykOptionsManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/ISnykOptionsManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Snyk.VisualStudio.Extension.Language;
 
 namespace Snyk.VisualStudio.Extension.Settings
 {
@@ -7,7 +8,26 @@ namespace Snyk.VisualStudio.Extension.Settings
     void LoadSettingsFromFile();
     void SaveSettingsToFile();
     ISnykOptions Load();
-    void Save(IPersistableOptions options, bool triggerSettingsChangedEvent = true);
+    /// <param name="updateOverrideTracker">
+    /// When true (default, user-initiated saves): calls ApplyUserEdits and persists ChangedConfigKeys.
+    /// When false (LS-originated / system saves): skips tracker mutation so LS-pushed values are
+    /// never recorded as user overrides, and leaves ChangedConfigKeys on disk exactly as it was.
+    /// </param>
+    /// <param name="editedKeys">
+    /// The set of pflag keys the user actually changed in this save action. Only these keys are
+    /// marked / unmarked in the tracker (edit-delta). Null or empty → no keys are marked (safe
+    /// default: org-pushed values already in Options are never accidentally frozen). Only consulted
+    /// when <paramref name="updateOverrideTracker"/> is true.
+    /// </param>
+    void Save(IPersistableOptions options, bool triggerSettingsChangedEvent = true,
+              bool updateOverrideTracker = true,
+              System.Collections.Generic.IReadOnlyCollection<string> editedKeys = null);
+
+    /// <summary>
+    /// The user-override tracker singleton owned by this manager. Used by
+    /// <see cref="LsSettingsV25"/> to set the <c>changed</c> flag on each ConfigSetting (IDE-2152).
+    /// </summary>
+    IUserOverrideTracker OverrideTracker { get; }
 
     /// <summary>
     /// Migrate the legacy per-solution settings entry for the given solution folder (if any) into the

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykOptions.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykOptions.cs
@@ -52,6 +52,7 @@ namespace Snyk.VisualStudio.Extension.Settings
         public string AdditionalEnv { get; set; }
         public List<string> AdditionalParameters { get; set; }
         public int? RiskScoreThreshold { get; set; }
+        public ISet<string> ChangedConfigKeys { get; set; } = new HashSet<string>();
         public string SnykCodeSettingsUrl => $"{this.GetBaseAppUrl()}/manage/snyk-code";
         public event EventHandler<SnykSettingsChangedEventArgs> SettingsChanged;
 

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
@@ -17,6 +17,16 @@ namespace Snyk.VisualStudio.Extension.Settings
         private readonly SnykSettingsLoader settingsLoader;
         private SnykSettings snykSettings;
 
+        // Singleton tracker that lives alongside this manager (composed in the same root).
+        // Exposed for injection into LsSettingsV25 via ISnykOptionsManager.OverrideTracker.
+        private readonly UserOverrideTracker overrideTracker = new UserOverrideTracker();
+
+        /// <summary>
+        /// The user-override tracker owned by this manager. LsSettingsV25 uses this to set
+        /// the <c>changed</c> flag on each ConfigSetting (IDE-2152).
+        /// </summary>
+        public IUserOverrideTracker OverrideTracker => overrideTracker;
+
         public SnykOptionsManager(string settingsFilePath, ISnykServiceProvider serviceProvider)
         {
             this.serviceProvider = serviceProvider;
@@ -76,7 +86,9 @@ namespace Snyk.VisualStudio.Extension.Settings
                 // event: the caller is about to (re)start the LS, which receives these via the
                 // initialization options, and Save leaves SolutionSettingsDict untouched so the shrink
                 // is what gets written.
-                Save(options, triggerSettingsChangedEvent: false);
+                // updateOverrideTracker:false — migration is system-driven, not a user override action;
+                // calling ApplyUserEdits over migrated values would create phantom overrides.
+                Save(options, triggerSettingsChangedEvent: false, updateOverrideTracker: false);
 
                 Logger.Information(
                     "Migrated legacy per-solution settings for '{Folder}' into a folder config.",
@@ -92,7 +104,10 @@ namespace Snyk.VisualStudio.Extension.Settings
 
         public ISnykOptions Load()
         {
-            return new SnykOptions
+            // Copy the persisted override set into options, or null when not present on disk.
+            var persistedKeys = snykSettings.ChangedConfigKeys;
+
+            var options = new SnykOptions
             {
                 DeviceId = snykSettings.DeviceId,
                 TrustedFolders = snykSettings.TrustedFolders,
@@ -134,9 +149,37 @@ namespace Snyk.VisualStudio.Extension.Settings
                 AdditionalParameters = snykSettings.AdditionalParameters,
                 RiskScoreThreshold = snykSettings.RiskScoreThreshold,
             };
+
+            // Clear only the changed marks so a second Load() on the same manager instance never
+            // unions stale marks from a previous load cycle. pendingResets is preserved: any reset
+            // signals enqueued by ApplyUserEdits between saves must survive into the next BuildSettingsMap call.
+            overrideTracker.ClearChanged();
+
+            // Hydrate the in-memory tracker from the persisted set.
+            // If the persisted set is null/empty (first load / upgrade path), seed by comparing
+            // each value against its plugin default so pre-existing non-default values are picked up.
+            // SeedFrom sets IsSeeded = true internally.
+            if (persistedKeys == null || persistedKeys.Count == 0)
+            {
+                overrideTracker.SeedFrom(options);
+            }
+            else
+            {
+                foreach (var key in persistedKeys)
+                    overrideTracker.Mark(key);
+                // Mark seeded after the explicit Mark-loop so BuildSettingsMap's IsSeeded gate
+                // becomes active once the tracker has been hydrated from persisted keys.
+                overrideTracker.MarkSeeded();
+            }
+
+            // Write the seeded set back so it is available on the returned options object.
+            options.ChangedConfigKeys = overrideTracker.Snapshot();
+            return options;
         }
 
-        public void Save(IPersistableOptions options, bool triggerSettingsChangedEvent = true)
+        public void Save(IPersistableOptions options, bool triggerSettingsChangedEvent = true,
+                         bool updateOverrideTracker = true,
+                         IReadOnlyCollection<string> editedKeys = null)
         {
             snykSettings.DeviceId = options.DeviceId;
             snykSettings.TrustedFolders = options.TrustedFolders;
@@ -177,6 +220,23 @@ namespace Snyk.VisualStudio.Extension.Settings
             snykSettings.AdditionalEnv = options.AdditionalEnv;
             snykSettings.AdditionalParameters = options.AdditionalParameters;
             snykSettings.RiskScoreThreshold = options.RiskScoreThreshold;
+
+            if (updateOverrideTracker)
+            {
+                // User-initiated save: apply only the edit-delta (the keys the user actually
+                // changed in this action) so org-pushed values sitting in Options are never
+                // recorded as user overrides. editedKeys==null/empty → mark nothing (safe default).
+                // Snapshot() returns a fresh copy; no need to wrap in another HashSet.
+                overrideTracker.ApplyUserEdits(options, editedKeys ?? new List<string>());
+                var snapshot = overrideTracker.Snapshot();
+                snykSettings.ChangedConfigKeys = snapshot.Count > 0
+                    ? snapshot
+                    : null; // keep out of settings.json when empty (NullValueHandling.Ignore)
+            }
+            // When updateOverrideTracker is false (LS/system-originated save): skip tracker
+            // mutation so LS-pushed values (org, LDX flags, etc.) are never recorded as user
+            // overrides. snykSettings.ChangedConfigKeys is intentionally left unchanged — the
+            // user's persisted override set must survive every LS-push round-trip.
 
             this.SaveSettingsToFile();
             if(triggerSettingsChangedEvent)

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
@@ -155,20 +155,56 @@ namespace Snyk.VisualStudio.Extension.Settings
             // signals enqueued by ApplyUserEdits between saves must survive into the next BuildSettingsMap call.
             overrideTracker.ClearChanged();
 
-            // Hydrate the in-memory tracker from the persisted set.
-            // If the persisted set is null/empty (first load / upgrade path), seed by comparing
-            // each value against its plugin default so pre-existing non-default values are picked up.
-            // SeedFrom sets IsSeeded = true internally.
-            if (persistedKeys == null || persistedKeys.Count == 0)
+            // Seeded-marker lifecycle (IDE-2152 refinement S) — three branches:
+            //
+            // Branch A — marker ABSENT + keys null/empty (true first run / fresh install):
+            //   Seed once from value-vs-default (SeedFrom), then IMMEDIATELY persist both the
+            //   resulting ChangedConfigKeys and the marker so the seed is authoritative even if
+            //   the IDE crashes before a user-edit save. SeedFrom sets IsSeeded = true.
+            //
+            // Branch B — marker ABSENT + keys non-empty (migration: prior version wrote a set
+            //   without the marker — treat as already-seeded, do NOT re-derive):
+            //   Hydrate verbatim (Mark each key + MarkSeeded), then persist the marker so the
+            //   next load follows Branch C and never re-derives.
+            //
+            // Branch C — marker PRESENT (steady state):
+            //   The persisted set is the durable source of truth. Hydrate verbatim including an
+            //   empty set, which means "seeded, zero user overrides." Never re-derive.
+            if (!snykSettings.ChangedConfigKeysSeeded && (persistedKeys == null || persistedKeys.Count == 0))
             {
+                // Branch A: true first run — seed from value-vs-default.
+                // SeedFrom() performs a full Clear() (changed + pendingResets) before deriving marks,
+                // so any pendingResets accumulated before this load are intentionally discarded here
+                // (there is no prior user session to have enqueued them). The "pendingResets preserved
+                // by ClearChanged()" note above applies to Branches B and C only.
                 overrideTracker.SeedFrom(options);
+                var seeded = overrideTracker.Snapshot();
+                // ChangedConfigKeys is omitted from settings.json when null (NullValueHandling.Ignore
+                // on the HashSet property), which happens when seeding finds zero non-default values.
+                // ChangedConfigKeysSeeded (the bool marker) is omitted when false
+                // (DefaultValueHandling.Ignore on the bool property) — it is now set to true so it
+                // will be written, marking this file as seeded for all future loads (Branch C).
+                snykSettings.ChangedConfigKeys = seeded.Count > 0 ? seeded : null;
+                snykSettings.ChangedConfigKeysSeeded = true;
+                SaveSettingsToFile();
+            }
+            else if (!snykSettings.ChangedConfigKeysSeeded)
+            {
+                // Branch B: marker absent but keys non-empty — prior-version migration.
+                // Hydrate verbatim; persist the marker so next load uses Branch C.
+                foreach (var key in persistedKeys)
+                    overrideTracker.Mark(key);
+                overrideTracker.MarkSeeded();
+                snykSettings.ChangedConfigKeysSeeded = true;
+                SaveSettingsToFile();
             }
             else
             {
-                foreach (var key in persistedKeys)
+                // Branch C: marker present — hydrate verbatim (may be null/empty; that is correct).
+                foreach (var key in persistedKeys ?? System.Linq.Enumerable.Empty<string>())
                     overrideTracker.Mark(key);
-                // Mark seeded after the explicit Mark-loop so BuildSettingsMap's IsSeeded gate
-                // becomes active once the tracker has been hydrated from persisted keys.
+                // MarkSeeded activates BuildSettingsMap's IsSeeded gate so it consults the
+                // tracker rather than falling back to changed:true for every key.
                 overrideTracker.MarkSeeded();
             }
 

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
@@ -17,6 +17,24 @@ namespace Snyk.VisualStudio.Extension.Settings
         private readonly SnykSettingsLoader settingsLoader;
         private SnykSettings snykSettings;
 
+        // Serializes ALL settings-file persistence (IDE-2152 fix #4). Persisting callers still run on
+        // different threads even after the DidChangeConfiguration reset-commit was marshaled to the UI
+        // thread (IDE-2152 fix #7): the LS-push handlers in SnykLanguageClientCustomTarget
+        // (OnSnykConfiguration, OnHasAuthenticated, OnAddTrustedFolders) call Save(updateOverrideTracker:
+        // false) directly on StreamJsonRpc's BACKGROUND dispatch threads, concurrently with a UI-thread
+        // user Save (clicks Apply). Both MUTATE the shared `snykSettings` object (its ChangedConfigKeys /
+        // PendingResetConfigKeys HashSets — the UI-thread user Save does; the LS-push saves leave the sets
+        // untouched but still write the object's other fields) and then SERIALIZE + WriteAllText the same
+        // file. Guarding only the File.WriteAllText is not enough: one thread mutating a HashSet on
+        // `snykSettings` while another serializes it throws "collection was modified", and two concurrent
+        // writers tear the file. So the critical section is the whole mutate-snykSettings → serialize →
+        // write region, taken by every persisting path. The lock is held only across synchronous work
+        // (no `await` inside), so it can never deadlock a continuation. The UserOverrideTracker keeps its
+        // own lock for its in-memory sets; this lock additionally makes the tracker-snapshot →
+        // copy-into-snykSettings → write sequence atomic. This gate remains load-bearing (not merely
+        // defense-in-depth) precisely because those LS-push background writers persist unchanged.
+        private readonly object persistGate = new object();
+
         // Singleton tracker that lives alongside this manager (composed in the same root).
         // Exposed for injection into LsSettingsV25 via ISnykOptionsManager.OverrideTracker.
         private readonly UserOverrideTracker overrideTracker = new UserOverrideTracker();
@@ -46,7 +64,14 @@ namespace Snyk.VisualStudio.Extension.Settings
 
         public void SaveSettingsToFile()
         {
-            this.settingsLoader.Save(snykSettings);
+            // Serialize + write under persistGate so two persisting threads never write the file
+            // concurrently and never serialize `snykSettings` while another thread mutates its
+            // HashSets (IDE-2152 fix #4). Reentrant: callers that already hold persistGate (Save,
+            // CommitPendingResets) re-enter here safely, keeping their mutate+serialize+write atomic.
+            lock (persistGate)
+            {
+                this.settingsLoader.Save(snykSettings);
+            }
         }
 
         /// <summary>
@@ -184,9 +209,14 @@ namespace Snyk.VisualStudio.Extension.Settings
                 // ChangedConfigKeysSeeded (the bool marker) is omitted when false
                 // (DefaultValueHandling.Ignore on the bool property) — it is now set to true so it
                 // will be written, marking this file as seeded for all future loads (Branch C).
-                snykSettings.ChangedConfigKeys = seeded.Count > 0 ? seeded : null;
-                snykSettings.ChangedConfigKeysSeeded = true;
-                SaveSettingsToFile();
+                // Mutate snykSettings + write under persistGate (IDE-2152 fix #4) so this load-time
+                // seed-write is atomic with respect to any concurrent Save/CommitPendingResets.
+                lock (persistGate)
+                {
+                    snykSettings.ChangedConfigKeys = seeded.Count > 0 ? seeded : null;
+                    snykSettings.ChangedConfigKeysSeeded = true;
+                    SaveSettingsToFile();
+                }
             }
             else if (!snykSettings.ChangedConfigKeysSeeded)
             {
@@ -195,8 +225,13 @@ namespace Snyk.VisualStudio.Extension.Settings
                 foreach (var key in persistedKeys)
                     overrideTracker.Mark(key);
                 overrideTracker.MarkSeeded();
-                snykSettings.ChangedConfigKeysSeeded = true;
-                SaveSettingsToFile();
+                // Mutate snykSettings + write under persistGate (IDE-2152 fix #4), same rationale as
+                // Branch A: keep the marker-write atomic against concurrent persisters.
+                lock (persistGate)
+                {
+                    snykSettings.ChangedConfigKeysSeeded = true;
+                    SaveSettingsToFile();
+                }
             }
             else
             {
@@ -208,6 +243,14 @@ namespace Snyk.VisualStudio.Extension.Settings
                 overrideTracker.MarkSeeded();
             }
 
+            // Rehydrate persisted-but-unconfirmed pending resets (IDE-2152 fix #2) AFTER the changed
+            // set has been hydrated by the branch above, so RehydratePendingResets can skip any key
+            // that is now a live override mark (a persisted override means the user re-applied the key
+            // after the reset was queued, so the override wins). Branch A (SeedFrom) clears the queue,
+            // which is why this runs last. Skipped when the tracker was NOT hydrated from persistence
+            // (Branch A on a genuinely fresh install writes no pending set; the disk field is null).
+            overrideTracker.RehydratePendingResets(snykSettings.PendingResetConfigKeys);
+
             // Write the seeded set back so it is available on the returned options object.
             options.ChangedConfigKeys = overrideTracker.Snapshot();
             return options;
@@ -215,8 +258,17 @@ namespace Snyk.VisualStudio.Extension.Settings
 
         public void Save(IPersistableOptions options, bool triggerSettingsChangedEvent = true,
                          bool updateOverrideTracker = true,
-                         IReadOnlyCollection<string> editedKeys = null)
+                         IReadOnlyCollection<string> editedKeys = null,
+                         IReadOnlyCollection<string> resetKeys = null)
         {
+            // Hold persistGate across the ENTIRE mutate-snykSettings → tracker-apply → serialize →
+            // write region (IDE-2152 fix #4) so a concurrent LS-push Save on a StreamJsonRpc background
+            // dispatch thread (SnykLanguageClientCustomTarget.OnSnykConfiguration/OnHasAuthenticated/
+            // OnAddTrustedFolders) can neither tear the file nor serialize `snykSettings` while this
+            // thread mutates its HashSets. All work inside is synchronous — no `await` — so the lock is
+            // safe to hold. The settings-changed event is fired AFTER the lock is released (below).
+            lock (persistGate)
+            {
             snykSettings.DeviceId = options.DeviceId;
             snykSettings.TrustedFolders = options.TrustedFolders;
             snykSettings.AnalyticsPluginInstalledSent = options.AnalyticsPluginInstalledSent;
@@ -264,10 +316,22 @@ namespace Snyk.VisualStudio.Extension.Settings
                 // recorded as user overrides. editedKeys==null/empty → mark nothing (safe default).
                 // Snapshot() returns a fresh copy; no need to wrap in another HashSet.
                 overrideTracker.ApplyUserEdits(options, editedKeys ?? new List<string>());
+                // Apply explicit resets (keys posted as JSON null by "Reset overrides"): un-mark the
+                // local override AND enqueue the LS reset signal. Runs after ApplyUserEdits so the two
+                // disjoint channels compose deterministically; the resulting Snapshot() below drops the
+                // un-marked keys out of the persisted ChangedConfigKeys set (AC: "no longer marked as
+                // changed"), which survives restart.
+                overrideTracker.ApplyUserResets(resetKeys);
                 var snapshot = overrideTracker.Snapshot();
                 snykSettings.ChangedConfigKeys = snapshot.Count > 0
                     ? snapshot
                     : null; // keep out of settings.json when empty (NullValueHandling.Ignore)
+
+                // Persist the pending-reset queue alongside ChangedConfigKeys (IDE-2152 fix #2): a
+                // reset applied while the LS is not ready must survive a restart. Written even when
+                // updateOverrideTracker is true only — the tracker is authoritative here. Mirrors the
+                // ChangedConfigKeys null-when-empty convention (NullValueHandling.Ignore).
+                PersistPendingResetsNoSave();
             }
             // When updateOverrideTracker is false (LS/system-originated save): skip tracker
             // mutation so LS-pushed values (org, LDX flags, etc.) are never recorded as user
@@ -275,8 +339,52 @@ namespace Snyk.VisualStudio.Extension.Settings
             // user's persisted override set must survive every LS-push round-trip.
 
             this.SaveSettingsToFile();
+            } // release persistGate before firing the settings-changed event
+
+            // Fired OUTSIDE persistGate: it is not persistence, and its handlers can run arbitrary
+            // code (including paths that re-enter Save) — keeping it out of the lock avoids holding
+            // the write lock across foreign callbacks.
             if(triggerSettingsChangedEvent)
                 serviceProvider.Options.InvokeSettingsChangedEvent();
+        }
+
+        /// <summary>
+        /// Commit reset keys that have been confirmed-delivered to the Language Server (IDE-2152 fix
+        /// #2). Delegates to the tracker to remove exactly the sent keys from the in-memory queue, then
+        /// re-persists the shrunken pending-reset set to disk so a delivered reset is not re-sent after
+        /// a restart. This is the single commit entry point: the config-send path calls it (not the
+        /// tracker directly) so persistence and the in-memory queue never diverge. No-op on null/empty.
+        /// </summary>
+        public void CommitPendingResets(IReadOnlyCollection<string> sentKeys)
+        {
+            if (sentKeys == null || sentKeys.Count == 0) return;
+            overrideTracker.CommitPendingResets(sentKeys);
+            // Hold persistGate across copy-into-snykSettings → write (IDE-2152 fix #4). The config-send
+            // caller (DidChangeConfigurationAsync) now marshals to the UI thread before calling this
+            // (IDE-2152 fix #7), so this no longer runs on the RPC continuation — but the gate is still
+            // required: an LS-push Save on a StreamJsonRpc background dispatch thread
+            // (SnykLanguageClientCustomTarget) may serialize the same `snykSettings` concurrently.
+            // PersistPendingResetsNoSave mutates PendingResetConfigKeys and SaveSettingsToFile
+            // serializes+writes — both must be inside the same critical section as Save's region. No
+            // `await` inside; the tracker commit above already took (and released) the tracker's own
+            // lock, so there is no lock-ordering hazard here.
+            lock (persistGate)
+            {
+                PersistPendingResetsNoSave();
+                this.SaveSettingsToFile();
+            }
+        }
+
+        // Copies the tracker's current pending-reset queue into snykSettings.PendingResetConfigKeys,
+        // using the null-when-empty convention (NullValueHandling.Ignore keeps the key out of
+        // settings.json when nothing is pending). Does NOT write to disk — callers decide when to
+        // flush (Save writes at its end; CommitPendingResets flushes explicitly).
+        private void PersistPendingResetsNoSave()
+        {
+            var pending = overrideTracker.PeekPendingResets();
+            snykSettings.PendingResetConfigKeys = pending.Count > 0
+                ? new System.Collections.Generic.HashSet<string>(pending)
+                : null;
         }
 
         /// <summary>
@@ -295,8 +403,13 @@ namespace Snyk.VisualStudio.Extension.Settings
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task SaveOrganizationAsync(string organization)
         {
-            snykSettings.Organization = organization;
-            this.SaveSettingsToFile();
+            // Mutate snykSettings + write under persistGate (IDE-2152 fix #4) so this writer is
+            // mutually exclusive with Save/CommitPendingResets.
+            lock (persistGate)
+            {
+                snykSettings.Organization = organization;
+                this.SaveSettingsToFile();
+            }
             serviceProvider.Options.Organization = organization;
             return Task.CompletedTask;
         }

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
@@ -240,6 +240,26 @@ namespace Snyk.VisualStudio.Extension.Settings
 
         public ISnykOptions Load()
         {
+            // Hold persistGate across the ENTIRE read-and-seed region below (PR #515 review, IDE-2152).
+            // The concurrent persisting writers that mutate the very fields this read consumes take
+            // persistGate around their mutate+serialize+write region: Save (including the LS-push
+            // Save(updateOverrideTracker:false) calls from SnykLanguageClientCustomTarget on StreamJsonRpc
+            // background dispatch threads), CommitPendingResets, SaveOrganizationAsync, and SaveSettingsToFile.
+            // If such a writer mutated these fields while the `new SnykOptions { ... }` initializer read
+            // them, Load() could return an options object mixing pre- and post-Save values (a torn read).
+            // Taking the same gate once over the whole read region makes the read atomic w.r.t. those
+            // writers. (MigrateLegacySolutionSettings mutates SolutionSettingsDict outside the gate before
+            // its own Save(), but Load() does not read SolutionSettingsDict, so it is not part of this
+            // invariant.) The lock is reentrant and there is no `await` inside Load(), so the seeding
+            // branches below re-enter safely and this cannot deadlock a continuation. Taken once (rather
+            // than per-branch) to avoid nested-lock churn.
+            lock (persistGate)
+            {
+            // Testable-interleave seam: fires at the very top of the guarded read region so a
+            // concurrent-Save thread-safety test can prove the writer is blocked here. No-op in
+            // production (mirrors the CopyFile seam).
+            OnLoadReadRegionEntered();
+
             // Copy the persisted override set into options, or null when not present on disk.
             var persistedKeys = snykSettings.ChangedConfigKeys;
 
@@ -328,8 +348,9 @@ namespace Snyk.VisualStudio.Extension.Settings
                 // Set the marker/keys ON snykSettings IN MEMORY only (no SaveSettingsToFile — see
                 // DEFERRED-PERSIST above). A same-manager second Load() then observes the in-memory
                 // marker and takes Branch C (no re-seed, no stale-mark unioning). Persistence is
-                // deferred to the next real Save. Mutate under persistGate so a concurrent
-                // Save/CommitPendingResets never reads a half-updated snykSettings.
+                // deferred to the next real Save. This mutation runs under the method-level
+                // persistGate (taken at the top of Load()) so a concurrent Save/CommitPendingResets
+                // never reads a half-updated snykSettings.
                 //
                 // settingsFileWasUnreadable guard: after a present-but-corrupt read, snykSettings is a
                 // fresh blank-defaults object that only LOOKS like a fresh install. Do NOT stamp the
@@ -337,13 +358,12 @@ namespace Snyk.VisualStudio.Extension.Settings
                 // from ever being mistaken for an authoritative seeded snapshot, so the recoverable
                 // file is re-read and re-seeded fresh on the next process start. The tracker is still
                 // seeded in memory (above) so this session behaves correctly.
+                // (Already inside the method-level lock (persistGate) taken at the top of Load(), so this
+                // mutation of snykSettings is serialized against every concurrent Save.)
                 if (!settingsFileWasUnreadable)
                 {
-                    lock (persistGate)
-                    {
-                        snykSettings.ChangedConfigKeys = seeded.Count > 0 ? seeded : null;
-                        snykSettings.ChangedConfigKeysSeeded = true;
-                    }
+                    snykSettings.ChangedConfigKeys = seeded.Count > 0 ? seeded : null;
+                    snykSettings.ChangedConfigKeysSeeded = true;
                 }
             }
             else if (!snykSettings.ChangedConfigKeysSeeded)
@@ -355,10 +375,8 @@ namespace Snyk.VisualStudio.Extension.Settings
                 foreach (var key in persistedKeys)
                     overrideTracker.Mark(key);
                 overrideTracker.MarkSeeded();
-                lock (persistGate)
-                {
-                    snykSettings.ChangedConfigKeysSeeded = true;
-                }
+                // Already inside the method-level lock (persistGate) taken at the top of Load().
+                snykSettings.ChangedConfigKeysSeeded = true;
             }
             else
             {
@@ -381,6 +399,25 @@ namespace Snyk.VisualStudio.Extension.Settings
             // Write the seeded set back so it is available on the returned options object.
             options.ChangedConfigKeys = overrideTracker.Snapshot();
             return options;
+            } // release persistGate (returning from inside the lock releases it)
+        }
+
+        // Testable seam over the top of Load()'s guarded read region (mirrors the CopyFile seam). A
+        // no-op in production; a test subclass overrides it to drive a concurrent Save() and prove that
+        // Load() holds persistGate across its read (so the writer is blocked mid-read). Called while
+        // holding persistGate.
+        protected virtual void OnLoadReadRegionEntered()
+        {
+        }
+
+        // Testable seam over the TOP of Save()'s persistGate critical section (mirrors the CopyFile /
+        // OnLoadReadRegionEntered seams). A no-op in production; a test subclass overrides it to signal
+        // that a concurrent Save() has acquired persistGate and entered its critical section — the
+        // deterministic positive handshake used to prove Load() holds the gate across its read (the
+        // writer must NOT reach this point while Load()'s read region is executing). Called while
+        // holding persistGate.
+        protected virtual void OnSaveCriticalSectionEntered()
+        {
         }
 
         public void Save(IPersistableOptions options, bool triggerSettingsChangedEvent = true,
@@ -396,6 +433,13 @@ namespace Snyk.VisualStudio.Extension.Settings
             // safe to hold. The settings-changed event is fired AFTER the lock is released (below).
             lock (persistGate)
             {
+            // Testable-interleave seam: fires once the writer has acquired persistGate and entered
+            // Save's critical section. A no-op in production (mirrors the CopyFile /
+            // OnLoadReadRegionEntered seams); a thread-safety test overrides it to signal that a
+            // concurrent Save() got into the gate, so the Load()-holds-the-gate invariant can be
+            // asserted deterministically rather than inferred from a wall-clock poll.
+            OnSaveCriticalSectionEntered();
+
             snykSettings.DeviceId = options.DeviceId;
             snykSettings.TrustedFolders = options.TrustedFolders;
             snykSettings.AnalyticsPluginInstalledSent = options.AnalyticsPluginInstalledSent;

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
@@ -104,5 +104,24 @@ namespace Snyk.VisualStudio.Extension.Settings
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public HashSet<string> ChangedConfigKeys { get; set; }
+
+        /// <summary>
+        /// Persisted seeded-marker for the load-time seeding lifecycle (IDE-2152).
+        /// Absent (false) on pre-feature / fresh-install settings files. <see cref="SnykOptionsManager.Load"/>
+        /// checks this flag to determine whether the override set has ever been seeded:
+        /// <list type="bullet">
+        ///   <item>Absent/false + <see cref="ChangedConfigKeys"/> null/empty → seed once from value-vs-default,
+        ///   then persist both the resulting set and this marker to disk.</item>
+        ///   <item>Absent/false + <see cref="ChangedConfigKeys"/> non-empty → keys were written by a prior
+        ///   version without the marker; hydrate verbatim and persist the marker.</item>
+        ///   <item>True → the persisted set is the authoritative source of truth; hydrate verbatim
+        ///   (including an empty set = "seeded, zero user overrides").</item>
+        /// </list>
+        /// <see cref="DefaultValueHandling.Ignore"/> keeps the key out of settings.json when false
+        /// (matching "absent on pre-feature files"). IDE-only: never added to
+        /// <see cref="ChangedConfigKeys"/> and never sent over the language-server wire.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool ChangedConfigKeysSeeded { get; set; }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
@@ -106,6 +106,19 @@ namespace Snyk.VisualStudio.Extension.Settings
         public HashSet<string> ChangedConfigKeys { get; set; }
 
         /// <summary>
+        /// Set of global pflag keys with a pending reset-to-default that has NOT yet been
+        /// confirmed-delivered to the Language Server (IDE-2152 critical fix #2). A reset applied
+        /// while the LS is not ready lives here so it survives a restart and is re-delivered on the
+        /// next configuration update; a reset is removed once its config send is confirmed
+        /// (<see cref="SnykOptionsManager.CommitPendingResets"/>). Null when absent from disk /
+        /// nothing pending. NullValueHandling.Ignore keeps the key out of settings.json until at
+        /// least one reset is pending, matching <see cref="ChangedConfigKeys"/>. IDE-only: never sent
+        /// over the language-server wire as-is (it drives which keys emit a reset signal, not a value).
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public HashSet<string> PendingResetConfigKeys { get; set; }
+
+        /// <summary>
         /// Persisted seeded-marker for the load-time seeding lifecycle (IDE-2152).
         /// Absent (false) on pre-feature / fresh-install settings files. <see cref="SnykOptionsManager.Load"/>
         /// checks this flag to determine whether the override set has ever been seeded:

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
@@ -94,5 +94,15 @@ namespace Snyk.VisualStudio.Extension.Settings
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public Dictionary<int, LegacySolutionSettings> SolutionSettingsDict { get; set; }
+
+        /// <summary>
+        /// Set of pflag keys the user explicitly overrode from plugin defaults (IDE-2152).
+        /// Null when absent from disk (first load / pre-upgrade file) — treated as empty by
+        /// <see cref="SnykOptionsManager.Load"/>, which seeds from values in that case.
+        /// NullValueHandling.Ignore keeps the key out of settings.json until at least one key
+        /// is tracked, matching the behaviour of <see cref="SolutionSettingsDict"/>.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public HashSet<string> ChangedConfigKeys { get; set; }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -96,6 +96,9 @@
     <Compile Include="Language\LsConstants.cs" />
     <Compile Include="Language\V25\PflagKeys.cs" />
     <Compile Include="Language\V25\ConfigSetting.cs" />
+    <Compile Include="Language\V25\ConfigDefaults.cs" />
+    <Compile Include="Language\V25\IUserOverrideTracker.cs" />
+    <Compile Include="Language\V25\UserOverrideTracker.cs" />
     <Compile Include="Language\V25\LspFolderConfig.cs" />
     <Compile Include="Language\V25\LspConfigurationParam.cs" />
     <Compile Include="Language\V25\InitializationOptionsV25.cs" />

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
@@ -104,12 +104,16 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                     // the tracker marks/unmarks only genuinely user-edited keys — org-pushed values
                     // that were never touched by the user are absent from the payload and therefore
                     // never marked as user overrides.
-                    var editedKeys = await ParseAndSaveConfigAsync(jsonString);
+                    var applyResult = await ParseAndSaveConfigAsync(jsonString);
 
                     // Persist all settings to storage at the end.
                     // This triggers SettingsChanged event which notifies Language Server.
+                    // resetKeys carries the "Reset overrides" nulls (disjoint from editedKeys) so the
+                    // tracker un-marks them and the LS receives {value:null, changed:true} (IDE-2152).
                     OptionsManager.Save(Options, triggerSettingsChangedEvent: true,
-                                        updateOverrideTracker: true, editedKeys: editedKeys);
+                                        updateOverrideTracker: true,
+                                        editedKeys: applyResult.EditedKeys,
+                                        resetKeys: applyResult.ResetKeys);
 
                     tcs.TrySetResult(true);
                 }
@@ -244,11 +248,30 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             }
         }
 
+        // Result of parsing + applying a save payload: the form-driven edit-delta (keys applied to a
+        // value) and the disjoint reset-delta (reset-eligible global keys posted as explicit JSON
+        // null by "Reset overrides"). The two channels never overlap for a single save.
+        private readonly struct ApplyResult
+        {
+            public ApplyResult(IReadOnlyCollection<string> editedKeys, IReadOnlyCollection<string> resetKeys)
+            {
+                EditedKeys = editedKeys;
+                ResetKeys = resetKeys;
+            }
+
+            public IReadOnlyCollection<string> EditedKeys { get; }
+            public IReadOnlyCollection<string> ResetKeys { get; }
+        }
+
         // Returns the form-driven edit-delta: the global pflag keys that each Apply* method
         // actually applied in this save action. Because detection is co-located with the
         // mutation, keys with extra gating (e.g. ApplyConnectionSettings rejects malformed URLs)
         // are recorded only when the value is genuinely applied — one source of truth per key.
-        private async Task<IReadOnlyCollection<string>> ParseAndSaveConfigAsync(string jsonString)
+        // Also returns the reset-delta: top-level reset-eligible global keys posted as explicit JSON
+        // null (the "Reset overrides" action), detected from the raw JSON so present-null stays
+        // distinct from absent (a distinction the nullable typed model cannot carry) — mirroring the
+        // raw-JSON handling already used by ApplyFolderConfigsAsync for folder resets.
+        private async Task<ApplyResult> ParseAndSaveConfigAsync(string jsonString)
         {
             // LS HTML JavaScript handles all validation - we just parse and save.
             // Throw on a null result (malformed/empty JSON that maps to nothing) rather than
@@ -296,6 +319,13 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                     string.Join(", ", contract.UnmappedKeys));
             }
 
+            // Parse the raw JSON to a JObject ONCE here, then pass it to both the global-reset detector
+            // and the folder-config applier (IDE-2152 cleanup #5). Previously each parsed the string
+            // independently with copy-pasted try/catch. A parse failure is non-fatal for these raw-JSON
+            // passes (the typed model already applied successfully), so a null root means "no raw-JSON
+            // work to do" — the typed apply still stands.
+            var root = TryParseJObject(jsonString);
+
             var isCliOnly = config.IsFallbackForm ?? false;
             Logger.Information("Saving workspace configuration (CLI only: {IsCliOnly})", isCliOnly);
 
@@ -334,7 +364,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                     ApplyTrustedFolders(config, editedKeys);
                     ApplyFilterSettings(config, editedKeys);
                     ApplyMiscellaneousSettings(config, editedKeys);
-                    await ApplyFolderConfigsAsync(jsonString);
+                    await ApplyFolderConfigsAsync(root);
                 }
             }
             catch
@@ -343,7 +373,53 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                 throw;
             }
 
-            return editedKeys;
+            // Detect top-level reset-eligible global keys posted as explicit JSON null (the "Reset
+            // overrides" action). Read from the parsed root so present-null stays distinct from absent —
+            // the nullable typed model collapses both to C# null, so a reset would otherwise be
+            // silently dropped by the .HasValue/!= null guards in the Apply* helpers above. A reset
+            // key is never a value-apply, so this channel is disjoint from editedKeys by construction.
+            var resetKeys = DetectGlobalResetKeys(root);
+
+            return new ApplyResult(editedKeys, resetKeys);
+        }
+
+        // Parses the raw settings-save JSON to a JObject a SINGLE time (IDE-2152 cleanup #5). The
+        // result is shared by DetectGlobalResetKeys and ApplyFolderConfigsAsync. Returns null on
+        // empty/whitespace or a parse failure — both raw-JSON passes treat null as "nothing to do",
+        // which is non-fatal because the typed model has already applied successfully.
+        private static JObject TryParseJObject(string rawJson)
+        {
+            if (string.IsNullOrWhiteSpace(rawJson))
+                return null;
+
+            try
+            {
+                return JObject.Parse(rawJson);
+            }
+            catch (JsonException ex)
+            {
+                Logger.Warning(ex, "Could not parse settings-save JSON for raw-JSON passes (reset detection / folder configs)");
+                return null;
+            }
+        }
+
+        // Inspects the parsed root for top-level properties present with a JSON null value whose key is
+        // a reset-eligible global setting (PflagKeys.IsGlobalResettable). These are the "Reset
+        // overrides" nulls. Folder-scoped resets live under folderConfigs[] and are handled separately
+        // by ApplyFolderConfigsAsync — this only considers top-level keys.
+        private static IReadOnlyCollection<string> DetectGlobalResetKeys(JObject root)
+        {
+            var resetKeys = new List<string>();
+            if (root == null)
+                return resetKeys;
+
+            foreach (var property in root.Properties())
+            {
+                if (property.Value.Type == JTokenType.Null && PflagKeys.IsGlobalResettable(property.Name))
+                    resetKeys.Add(property.Name);
+            }
+
+            return resetKeys;
         }
 
         // Captures the current Options state and returns an action that restores it, so a partially-
@@ -681,21 +757,10 @@ namespace Snyk.VisualStudio.Extension.UI.Html
         // we Set the key to null so BuildFolderConfigs emits {value:null, changed:true} and the LS
         // Unsets the user:folder: override. Going through the raw JSON keeps null-vs-absent distinct,
         // which a nullable typed model can't — so no ResetKeys side-channel is needed.
-        private Task ApplyFolderConfigsAsync(string rawJson)
+        private Task ApplyFolderConfigsAsync(JObject root)
         {
-            if (string.IsNullOrWhiteSpace(rawJson))
+            if (root == null)
                 return Task.CompletedTask;
-
-            JObject root;
-            try
-            {
-                root = JObject.Parse(rawJson);
-            }
-            catch (JsonException ex)
-            {
-                Logger.Warning(ex, "Could not parse JSON for folder configs");
-                return Task.CompletedTask;
-            }
 
             if (!(root["folderConfigs"] is JArray folderConfigsJson) || folderConfigsJson.Count == 0)
                 return Task.CompletedTask;

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
@@ -98,11 +98,17 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             {
                 try
                 {
-                    await ParseAndSaveConfigAsync(jsonString);
+                    // ParseAndSaveConfigAsync applies the form values to Options and returns the
+                    // edit-delta (the set of global pflag keys whose value actually changed from
+                    // the pre-apply snapshot). Only these keys are passed to Save so the tracker
+                    // marks only genuinely user-edited keys — not org-pushed values that merely
+                    // sit in Options unchanged.
+                    var editedKeys = await ParseAndSaveConfigAsync(jsonString);
 
                     // Persist all settings to storage at the end.
                     // This triggers SettingsChanged event which notifies Language Server.
-                    OptionsManager.Save(Options, triggerSettingsChangedEvent: true);
+                    OptionsManager.Save(Options, triggerSettingsChangedEvent: true,
+                                        updateOverrideTracker: true, editedKeys: editedKeys);
 
                     tcs.TrySetResult(true);
                 }
@@ -237,7 +243,10 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             }
         }
 
-        private async Task ParseAndSaveConfigAsync(string jsonString)
+        // Returns the set of global pflag keys whose value changed during this save action
+        // (the edit-delta). The caller passes this to OptionsManager.Save so only genuinely
+        // user-edited keys are marked as user overrides in the tracker.
+        private async Task<IReadOnlyCollection<string>> ParseAndSaveConfigAsync(string jsonString)
         {
             // LS HTML JavaScript handles all validation - we just parse and save.
             // Throw on a null result (malformed/empty JSON that maps to nothing) rather than
@@ -288,6 +297,12 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             var isCliOnly = config.IsFallbackForm ?? false;
             Logger.Information("Saving workspace configuration (CLI only: {IsCliOnly})", isCliOnly);
 
+            // Capture the global pflag key→value snapshot BEFORE applying the form values.
+            // After apply we diff this against the post-apply Options to produce the edit-delta:
+            // only keys whose value actually changed are passed to the tracker, so org-pushed
+            // values that the user didn't touch are never recorded as user overrides.
+            var preApplySnapshot = UserOverrideTracker.SnapshotGlobalKeys(Options);
+
             // Apply directly to the live Options, but capture a rollback first. Apply* mutate Options
             // in place (folder-config entries included) and OptionsManager.Save only runs after this
             // method returns — so a mid-apply failure would otherwise leave Options half-applied in
@@ -324,6 +339,11 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                 rollback();
                 throw;
             }
+
+            // Derive the edit-delta: keys whose value differs between the pre-apply snapshot and
+            // the post-apply Options state. This is what the user actually changed in this save
+            // action. The tracker will mark/unmark only these keys.
+            return UserOverrideTracker.DiffGlobalKeys(preApplySnapshot, Options);
         }
 
         // Captures the current Options state and returns an action that restores it, so a partially-

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlSettingsScriptingBridge.cs
@@ -99,10 +99,11 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                 try
                 {
                     // ParseAndSaveConfigAsync applies the form values to Options and returns the
-                    // edit-delta (the set of global pflag keys whose value actually changed from
-                    // the pre-apply snapshot). Only these keys are passed to Save so the tracker
-                    // marks only genuinely user-edited keys — not org-pushed values that merely
-                    // sit in Options unchanged.
+                    // form-driven edit-delta (the global pflag keys the form actually sent — i.e.
+                    // the keys the user touched in the UI). Only these keys are passed to Save so
+                    // the tracker marks/unmarks only genuinely user-edited keys — org-pushed values
+                    // that were never touched by the user are absent from the payload and therefore
+                    // never marked as user overrides.
                     var editedKeys = await ParseAndSaveConfigAsync(jsonString);
 
                     // Persist all settings to storage at the end.
@@ -243,9 +244,10 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             }
         }
 
-        // Returns the set of global pflag keys whose value changed during this save action
-        // (the edit-delta). The caller passes this to OptionsManager.Save so only genuinely
-        // user-edited keys are marked as user overrides in the tracker.
+        // Returns the form-driven edit-delta: the global pflag keys that each Apply* method
+        // actually applied in this save action. Because detection is co-located with the
+        // mutation, keys with extra gating (e.g. ApplyConnectionSettings rejects malformed URLs)
+        // are recorded only when the value is genuinely applied — one source of truth per key.
         private async Task<IReadOnlyCollection<string>> ParseAndSaveConfigAsync(string jsonString)
         {
             // LS HTML JavaScript handles all validation - we just parse and save.
@@ -297,11 +299,12 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             var isCliOnly = config.IsFallbackForm ?? false;
             Logger.Information("Saving workspace configuration (CLI only: {IsCliOnly})", isCliOnly);
 
-            // Capture the global pflag key→value snapshot BEFORE applying the form values.
-            // After apply we diff this against the post-apply Options to produce the edit-delta:
-            // only keys whose value actually changed are passed to the tracker, so org-pushed
-            // values that the user didn't touch are never recorded as user overrides.
-            var preApplySnapshot = UserOverrideTracker.SnapshotGlobalKeys(Options);
+            // Each Apply* method appends the pflag key it applies to this list (form-driven
+            // edit-delta). Detection is co-located with the mutation so extra gating in Apply*
+            // (e.g. URL validation in ApplyConnectionSettings) is reflected correctly. The
+            // isCliOnly split falls out naturally: Apply* methods not called in CLI-only mode
+            // contribute nothing.
+            var editedKeys = new List<string>();
 
             // Apply directly to the live Options, but capture a rollback first. Apply* mutate Options
             // in place (folder-config entries included) and OptionsManager.Save only runs after this
@@ -311,26 +314,26 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             try
             {
                 // Always apply CLI settings and Insecure setting
-                ApplyCliSettings(config);
-                ApplyInsecureSetting(config);
+                ApplyCliSettings(config, editedKeys);
+                ApplyInsecureSetting(config, editedKeys);
 
                 // Only apply full settings when not in CLI-only mode
                 if (!isCliOnly)
                 {
-                    ApplyScanSettings(config);
-                    ApplyIssueViewSettings(config);
+                    ApplyScanSettings(config, editedKeys);
+                    ApplyIssueViewSettings(config, editedKeys);
                     var previousAuthMethod = Options.AuthenticationMethod;
-                    ApplyAuthenticationSettings(config);
+                    ApplyAuthenticationSettings(config, editedKeys);
                     // Clear stored token when auth method changes: a token from one method is not valid for another.
                     if (config.AuthenticationMethod != null && Options.AuthenticationMethod != previousAuthMethod)
                     {
                         Options.ApiToken = new AuthenticationToken(Options.AuthenticationMethod, string.Empty);
                     }
 
-                    ApplyConnectionSettings(config);
-                    ApplyTrustedFolders(config);
-                    ApplyFilterSettings(config);
-                    ApplyMiscellaneousSettings(config);
+                    ApplyConnectionSettings(config, editedKeys);
+                    ApplyTrustedFolders(config, editedKeys);
+                    ApplyFilterSettings(config, editedKeys);
+                    ApplyMiscellaneousSettings(config, editedKeys);
                     await ApplyFolderConfigsAsync(jsonString);
                 }
             }
@@ -340,10 +343,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                 throw;
             }
 
-            // Derive the edit-delta: keys whose value differs between the pre-apply snapshot and
-            // the post-apply Options state. This is what the user actually changed in this save
-            // action. The tracker will mark/unmark only these keys.
-            return UserOverrideTracker.DiffGlobalKeys(preApplySnapshot, Options);
+            return editedKeys;
         }
 
         // Captures the current Options state and returns an action that restores it, so a partially-
@@ -429,57 +429,65 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             return JsonConvert.DeserializeObject<List<FolderConfig>>(JsonConvert.SerializeObject(source));
         }
 
-        private void ApplyScanSettings(IdeConfigData config)
+        private void ApplyScanSettings(IdeConfigData config, ICollection<string> editedKeys)
         {
             // Product enablement (snyk_oss_enabled, snyk_code_enabled, snyk_iac_enabled, snyk_secrets_enabled)
             if (config.SnykOssEnabled.HasValue)
             {
                 Options.OssEnabled = config.SnykOssEnabled.Value;
+                editedKeys.Add(PflagKeys.SnykOssEnabled);
             }
 
             if (config.SnykCodeEnabled.HasValue)
             {
                 Options.SnykCodeSecurityEnabled = config.SnykCodeEnabled.Value;
+                editedKeys.Add(PflagKeys.SnykCodeEnabled);
             }
 
             if (config.SnykIacEnabled.HasValue)
             {
                 Options.IacEnabled = config.SnykIacEnabled.Value;
+                editedKeys.Add(PflagKeys.SnykIacEnabled);
             }
 
             if (config.SnykSecretsEnabled.HasValue)
             {
                 Options.SecretsEnabled = config.SnykSecretsEnabled.Value;
+                editedKeys.Add(PflagKeys.SnykSecretsEnabled);
             }
 
             // Apply automatic-scan toggle (scan_automatic)
             if (config.ScanAutomatic.HasValue)
             {
                 Options.AutoScan = config.ScanAutomatic.Value;
+                editedKeys.Add(PflagKeys.ScanAutomatic);
             }
         }
 
-        private void ApplyIssueViewSettings(IdeConfigData config)
+        private void ApplyIssueViewSettings(IdeConfigData config, ICollection<string> editedKeys)
         {
             // Apply issue view options (issue_view_open_issues, issue_view_ignored_issues)
             if (config.IssueViewOpenIssues.HasValue)
             {
                 Options.OpenIssuesEnabled = config.IssueViewOpenIssues.Value;
+                editedKeys.Add(PflagKeys.IssueViewOpenIssues);
             }
 
             if (config.IssueViewIgnoredIssues.HasValue)
             {
                 Options.IgnoredIssuesEnabled = config.IssueViewIgnoredIssues.Value;
+                editedKeys.Add(PflagKeys.IssueViewIgnoredIssues);
             }
 
             // Apply net-new / delta findings (scan_net_new)
             if (config.ScanNetNew.HasValue)
             {
                 Options.EnableDeltaFindings = config.ScanNetNew.Value;
+                editedKeys.Add(PflagKeys.ScanNetNew);
             }
         }
 
-        private void ApplyAuthenticationSettings(IdeConfigData config)
+        private void ApplyAuthenticationSettings(IdeConfigData config, ICollection<string> editedKeys)
         {
             // Apply authentication method (authenticationMethod: "oauth"/"token"/"pat")
             if (config.AuthenticationMethod != null)
@@ -501,19 +509,21 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                         Options.AuthenticationMethod = AuthenticationType.OAuth;
                         break;
                 }
+                editedKeys.Add(PflagKeys.AuthenticationMethod);
             }
         }
 
-        private void ApplyInsecureSetting(IdeConfigData config)
+        private void ApplyInsecureSetting(IdeConfigData config, ICollection<string> editedKeys)
         {
             // Apply Insecure (SSL) setting - available in both CLI-only and full mode
             if (config.Insecure.HasValue)
             {
                 Options.IgnoreUnknownCA = config.Insecure.Value;
+                editedKeys.Add(PflagKeys.ProxyInsecure);
             }
         }
 
-        private void ApplyConnectionSettings(IdeConfigData config)
+        private void ApplyConnectionSettings(IdeConfigData config, ICollection<string> editedKeys)
         {
             // Allow an empty value to reset to the default endpoint, but otherwise only accept an
             // absolute http/https URL — same guard as the snyk.login bridge path and the
@@ -524,6 +534,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                 if (string.IsNullOrEmpty(config.ApiEndpoint) || UriExtensions.IsValidWebUrl(config.ApiEndpoint))
                 {
                     Options.CustomEndpoint = config.ApiEndpoint;
+                    editedKeys.Add(PflagKeys.ApiEndpoint);
                 }
                 else
                 {
@@ -545,16 +556,18 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                     // Store the trimmed value (what we compared) so stray form whitespace doesn't get
                     // baked into the token store and silently fail downstream IsValid() parsing.
                     Options.ApiToken = new AuthenticationToken(Options.AuthenticationMethod, normalizedNewToken);
+                    editedKeys.Add(PflagKeys.Token);
                 }
             }
 
             if (config.Organization != null)
             {
                 Options.Organization = config.Organization;
+                editedKeys.Add(PflagKeys.Organization);
             }
         }
 
-        private void ApplyTrustedFolders(IdeConfigData config)
+        private void ApplyTrustedFolders(IdeConfigData config, ICollection<string> editedKeys)
         {
             // Allow empty list to clear trusted folders
             if (config.TrustedFolders == null)
@@ -571,76 +584,91 @@ namespace Snyk.VisualStudio.Extension.UI.Html
 
             // Set even if empty to allow clearing
             Options.TrustedFolders = trustedFolders;
+            // TrustedFolders: always-changed (AlwaysChanged set in PflagKeys); included so
+            // ApplyUserEdits is notified (IsAlwaysChanged gates Mark, so it's a no-op for the
+            // tracker set, but correct and future-proof to record).
+            editedKeys.Add(PflagKeys.TrustedFolders);
         }
 
-        private void ApplyCliSettings(IdeConfigData config)
+        private void ApplyCliSettings(IdeConfigData config, ICollection<string> editedKeys)
         {
             // Allow empty values to reset settings
             if (config.CliPath != null)
             {
                 Options.CliCustomPath = config.CliPath;
+                editedKeys.Add(PflagKeys.CliPath);
             }
 
             if (config.ManageBinariesAutomatically.HasValue)
             {
                 Options.BinariesAutoUpdate = config.ManageBinariesAutomatically.Value;
+                editedKeys.Add(PflagKeys.AutomaticDownload);
             }
 
             if (config.CliBaseDownloadURL != null)
             {
                 Options.CliBaseDownloadURL = config.CliBaseDownloadURL;
+                editedKeys.Add(PflagKeys.BinaryBaseUrl);
             }
 
             if (config.CliReleaseChannel != null)
             {
                 Options.CliReleaseChannel = config.CliReleaseChannel;
+                editedKeys.Add(PflagKeys.CliReleaseChannel);
             }
         }
 
-        private void ApplyFilterSettings(IdeConfigData config)
+        private void ApplyFilterSettings(IdeConfigData config, ICollection<string> editedKeys)
         {
             // Severity filters arrive as individual flat keys (severity_filter_*). The form
             // only sends the ones that changed, so each is applied independently.
             if (config.SeverityFilterCritical.HasValue)
             {
                 Options.FilterCritical = config.SeverityFilterCritical.Value;
+                editedKeys.Add(PflagKeys.SeverityFilterCritical);
             }
 
             if (config.SeverityFilterHigh.HasValue)
             {
                 Options.FilterHigh = config.SeverityFilterHigh.Value;
+                editedKeys.Add(PflagKeys.SeverityFilterHigh);
             }
 
             if (config.SeverityFilterMedium.HasValue)
             {
                 Options.FilterMedium = config.SeverityFilterMedium.Value;
+                editedKeys.Add(PflagKeys.SeverityFilterMedium);
             }
 
             if (config.SeverityFilterLow.HasValue)
             {
                 Options.FilterLow = config.SeverityFilterLow.Value;
+                editedKeys.Add(PflagKeys.SeverityFilterLow);
             }
         }
 
-        private void ApplyMiscellaneousSettings(IdeConfigData config)
+        private void ApplyMiscellaneousSettings(IdeConfigData config, ICollection<string> editedKeys)
         {
             // Apply risk score threshold only when present — the form sends a changed-only
             // payload, so an absent value must not clobber the stored threshold with null.
             if (config.RiskScoreThreshold.HasValue)
             {
                 Options.RiskScoreThreshold = config.RiskScoreThreshold;
+                editedKeys.Add(PflagKeys.RiskScoreThreshold);
             }
 
             // Global (Project Defaults) advanced settings — absent (null) means no change.
             if (config.AdditionalEnv != null)
             {
                 Options.AdditionalEnv = config.AdditionalEnv;
+                editedKeys.Add(PflagKeys.AdditionalEnvironment);
             }
             if (config.AdditionalParameters != null)
             {
                 Options.AdditionalParameters = config.AdditionalParameters
                     .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
                     .ToList();
+                editedKeys.Add(PflagKeys.AdditionalParameters);
             }
         }
 

--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SnykScriptManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/SnykScriptManager.cs
@@ -64,8 +64,19 @@ namespace Snyk.VisualStudio.Extension.UI.Toolwindow
         {
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
+                // Capture previous value before mutating so we can detect a real change.
+                var previous = this.serviceProvider.Options.EnableDeltaFindings;
                 this.serviceProvider.Options.EnableDeltaFindings = isEnabled;
-                this.serviceProvider.SnykOptionsManager.Save(this.serviceProvider.Options);
+
+                // Only declare ScanNetNew as edited when the value actually changed.
+                // An idempotent call (isEnabled == previous) must not enqueue a spurious reset signal.
+                var edited = isEnabled != previous
+                    ? new System.Collections.Generic.List<string> { Language.PflagKeys.ScanNetNew }
+                    : new System.Collections.Generic.List<string>();
+
+                this.serviceProvider.SnykOptionsManager.Save(
+                    this.serviceProvider.Options,
+                    editedKeys: edited);
                 await LanguageClientHelper.LanguageClientManager().DidChangeConfigurationAsync(SnykVSPackage.Instance.DisposalToken);
 
             }).FireAndForget();

--- a/Snyk.VisualStudio.Extension.Tests/Language/ConfigDefaultsTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/ConfigDefaultsTests.cs
@@ -103,5 +103,85 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
                 AuthenticationType.OAuth.ToString().ToLowerInvariant(),
                 default(AuthenticationType).ToString().ToLowerInvariant());
         }
+
+        // PR-REV-2b-1: IsDefault for AdditionalParameters with an empty string must return true.
+        // The form sends AdditionalParameters as a space-joined text string (from a text input),
+        // not as a collection. An empty string is the form's representation of "no parameters",
+        // which must equal the default (empty list → space-joined → empty string).
+        [Fact]
+        public void IsDefault_AdditionalParameters_EmptyStringIsDefault()
+        {
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.AdditionalParameters, string.Empty),
+                "An empty string for AdditionalParameters must be the default — " +
+                "the form sends a space-joined string; empty string == empty list (the SnykSettings default)");
+        }
+
+        // PR-REV-2b-2: IsDefault for AdditionalParameters with a whitespace-only string must also
+        // return true. A form field with only spaces should also be treated as "no parameters set".
+        [Fact]
+        public void IsDefault_AdditionalParameters_WhitespaceOnlyStringIsDefault()
+        {
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.AdditionalParameters, "   "),
+                "A whitespace-only string for AdditionalParameters must be the default — " +
+                "it is semantically equivalent to the empty list (splits to no tokens)");
+        }
+
+        // PR-REV-2b-3: IsDefault for AdditionalParameters with a non-empty string must return false.
+        [Fact]
+        public void IsDefault_AdditionalParameters_NonEmptyStringIsNotDefault()
+        {
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.AdditionalParameters, "--debug"),
+                "A non-empty AdditionalParameters string must NOT be the default");
+        }
+
+        // PR-REV-3-1: ConfigDefaults boolean values for product-enablement must match
+        // the canonical SnykSettings field initializers. This acts as a drift guard:
+        // if SnykSettings changes a default, the test (which reads the SnykSettings field
+        // via new SnykSettings()) will catch the mismatch.
+        // Note: SnykSettings uses inline field initializers (not named constants), so we compare
+        // by constructing a default instance and reading each field.
+        [Fact]
+        public void ConfigDefaults_BooleanValues_MatchSnykSettingsFieldInitializers()
+        {
+            var defaults = new Snyk.VisualStudio.Extension.Settings.SnykSettings();
+
+            // Product enablement
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SnykOssEnabled) == defaults.OssEnabled,
+                "SnykOssEnabled default must match SnykSettings.OssEnabled initializer");
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SnykCodeEnabled) == defaults.SnykCodeSecurityEnabled,
+                "SnykCodeEnabled default must match SnykSettings.SnykCodeSecurityEnabled initializer");
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SnykIacEnabled) == defaults.IacEnabled,
+                "SnykIacEnabled default must match SnykSettings.IacEnabled initializer");
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SnykSecretsEnabled) == defaults.SecretsEnabled,
+                "SnykSecretsEnabled default must match SnykSettings.SecretsEnabled initializer");
+
+            // Scan
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.ScanAutomatic) == defaults.AutoScan,
+                "ScanAutomatic default must match SnykSettings.AutoScan initializer");
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.ScanNetNew) == defaults.EnableDeltaFindings,
+                "ScanNetNew default must match SnykSettings.EnableDeltaFindings initializer");
+
+            // Severity filters
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SeverityFilterCritical) == defaults.FilterCritical,
+                "SeverityFilterCritical default must match SnykSettings.FilterCritical initializer");
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SeverityFilterHigh) == defaults.FilterHigh,
+                "SeverityFilterHigh default must match SnykSettings.FilterHigh initializer");
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SeverityFilterMedium) == defaults.FilterMedium,
+                "SeverityFilterMedium default must match SnykSettings.FilterMedium initializer");
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SeverityFilterLow) == defaults.FilterLow,
+                "SeverityFilterLow default must match SnykSettings.FilterLow initializer");
+
+            // Issue view
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.IssueViewOpenIssues) == defaults.OpenIssuesEnabled,
+                "IssueViewOpenIssues default must match SnykSettings.OpenIssuesEnabled initializer");
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.IssueViewIgnoredIssues) == defaults.IgnoredIssuesEnabled,
+                "IssueViewIgnoredIssues default must match SnykSettings.IgnoredIssuesEnabled initializer");
+
+            // CLI / binary booleans
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.AutomaticDownload) == defaults.BinariesAutoUpdateEnabled,
+                "AutomaticDownload default must match SnykSettings.BinariesAutoUpdateEnabled initializer");
+            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.ProxyInsecure) == defaults.IgnoreUnknownCa,
+                "ProxyInsecure default must match SnykSettings.IgnoreUnknownCa initializer");
+        }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/Language/ConfigDefaultsTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/ConfigDefaultsTests.cs
@@ -1,4 +1,5 @@
 // ABOUTME: Unit tests for ConfigDefaults covering UNIT-007, UNIT-012 from the IDE-2152 test plan.
+using Snyk.VisualStudio.Extension.Authentication;
 using Snyk.VisualStudio.Extension.Download;
 using Snyk.VisualStudio.Extension.Language;
 using Xunit;
@@ -71,7 +72,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
         [Fact]
         public void IsDefault_AuthenticationMethod_MatchesEnumDefault()
         {
-            var defaultValue = default(Authentication.AuthenticationType).ToString().ToLowerInvariant();
+            var defaultValue = default(AuthenticationType).ToString().ToLowerInvariant();
 
             Assert.True(ConfigDefaults.IsDefault(PflagKeys.AuthenticationMethod, defaultValue),
                 $"IsDefault should return true for default auth method '{defaultValue}'");
@@ -99,10 +100,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
         {
             // OAuth must be the zero value so default(AuthenticationType) == OAuth.
             Assert.Equal(
-                Authentication.AuthenticationType.OAuth.ToString().ToLowerInvariant(),
-                default(Authentication.AuthenticationType).ToString().ToLowerInvariant(),
-                "AuthenticationType.OAuth must be the enum zero value. If this fails, ConfigDefaults " +
-                "authentication_method default is wrong and must be corrected to match the new zero value.");
+                AuthenticationType.OAuth.ToString().ToLowerInvariant(),
+                default(AuthenticationType).ToString().ToLowerInvariant());
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/Language/ConfigDefaultsTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/ConfigDefaultsTests.cs
@@ -1,0 +1,108 @@
+// ABOUTME: Unit tests for ConfigDefaults covering UNIT-007, UNIT-012 from the IDE-2152 test plan.
+using Snyk.VisualStudio.Extension.Download;
+using Snyk.VisualStudio.Extension.Language;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.Language
+{
+    public class ConfigDefaultsTests
+    {
+        // UNIT-007: ConfigDefaults.IsDefault returns true for each global pflag key at its SnykSettings
+        // default value, and false for a non-default value.
+        [Fact]
+        public void IsDefault_MatchesSnykSettingsDefaults()
+        {
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.SnykOssEnabled, true));
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.SnykOssEnabled, false));
+
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.SnykCodeEnabled, true));
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.SnykCodeEnabled, false));
+
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.SnykIacEnabled, true));
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.SnykIacEnabled, false));
+
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.SnykSecretsEnabled, false));
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.SnykSecretsEnabled, true));
+
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.ScanAutomatic, true));
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.ScanAutomatic, false));
+
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.ScanNetNew, false));
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.ScanNetNew, true));
+
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.SeverityFilterCritical, true));
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.SeverityFilterHigh, true));
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.SeverityFilterMedium, true));
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.SeverityFilterLow, true));
+
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.IssueViewOpenIssues, true));
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.IssueViewOpenIssues, false));
+
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.IssueViewIgnoredIssues, false));
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.IssueViewIgnoredIssues, true));
+
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.AutomaticDownload, true));
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.AutomaticDownload, false));
+
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.CliReleaseChannel, SnykCliDownloader.DefaultReleaseChannel));
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.CliReleaseChannel, "rc-preview"));
+
+            // Unknown key: treat as "no default known" → not-default regardless of value.
+            Assert.False(ConfigDefaults.IsDefault("unknown_key", "anything"));
+        }
+
+        // UNIT-012 (finding 2): BinaryBaseUrl default must match SnykCliDownloader.DefaultBaseDownloadUrl
+        // ("https://downloads.snyk.io", no /cli suffix). A user who never changed this URL must NOT be
+        // marked as overriding it.
+        [Fact]
+        public void IsDefault_BinaryBaseUrl_MatchesCanonicalDownloaderConstant()
+        {
+            // The canonical constant — must match exactly (no trailing /cli).
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.BinaryBaseUrl, SnykCliDownloader.DefaultBaseDownloadUrl),
+                $"IsDefault should return true for '{SnykCliDownloader.DefaultBaseDownloadUrl}' (SnykCliDownloader.DefaultBaseDownloadUrl)");
+
+            // A non-default value must return false.
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.BinaryBaseUrl, "https://example.com"),
+                "IsDefault should return false for a non-default URL");
+        }
+
+        // UNIT-013 (finding 1): AuthenticationMethod default is default(AuthenticationType).ToString().ToLowerInvariant().
+        // A user who never changed auth method must NOT be marked as overriding it.
+        [Fact]
+        public void IsDefault_AuthenticationMethod_MatchesEnumDefault()
+        {
+            var defaultValue = default(Authentication.AuthenticationType).ToString().ToLowerInvariant();
+
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.AuthenticationMethod, defaultValue),
+                $"IsDefault should return true for default auth method '{defaultValue}'");
+
+            // A non-default auth method.
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.AuthenticationMethod, "pat"),
+                "IsDefault should return false for a non-default auth method");
+        }
+
+        // UNIT-014 (finding 3): RiskScoreThreshold null == default.
+        [Fact]
+        public void IsDefault_RiskScoreThreshold_NullIsDefault()
+        {
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.RiskScoreThreshold, null),
+                "null RiskScoreThreshold should be the default");
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.RiskScoreThreshold, 70),
+                "Non-null RiskScoreThreshold should not be the default");
+        }
+
+        // R3-4: Pin the enum-default assumption. ConfigDefaults bakes the authentication_method
+        // default from default(AuthenticationType).ToString().ToLowerInvariant(). If the enum is
+        // ever reordered so OAuth is no longer the zero value, this test fails immediately.
+        [Fact]
+        public void AuthenticationType_OAuthIsZeroValue_MatchesDefaultEnumAssumption()
+        {
+            // OAuth must be the zero value so default(AuthenticationType) == OAuth.
+            Assert.Equal(
+                Authentication.AuthenticationType.OAuth.ToString().ToLowerInvariant(),
+                default(Authentication.AuthenticationType).ToString().ToLowerInvariant(),
+                "AuthenticationType.OAuth must be the enum zero value. If this fails, ConfigDefaults " +
+                "authentication_method default is wrong and must be corrected to match the new zero value.");
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
@@ -262,7 +262,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             var trackerMock = new Mock<IUserOverrideTracker>();
             trackerMock.Setup(t => t.IsSeeded).Returns(true); // seeded so the gate is active
             trackerMock.Setup(t => t.IsChanged(It.IsAny<string>())).Returns(false);
-            trackerMock.Setup(t => t.ConsumePendingResets()).Returns(new List<string>());
+            trackerMock.Setup(t => t.PeekPendingResets()).Returns(new List<string>());
             optionsManagerMock.Setup(m => m.OverrideTracker).Returns(trackerMock.Object);
 
             var map = cut.BuildSettingsMap(optionsMock.Object);
@@ -280,7 +280,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             trackerMock.Setup(t => t.IsSeeded).Returns(true); // seeded so the gate is active
             trackerMock.Setup(t => t.IsChanged(PflagKeys.SnykOssEnabled)).Returns(true);
             trackerMock.Setup(t => t.IsChanged(It.Is<string>(k => k != PflagKeys.SnykOssEnabled))).Returns(false);
-            trackerMock.Setup(t => t.ConsumePendingResets()).Returns(new List<string>());
+            trackerMock.Setup(t => t.PeekPendingResets()).Returns(new List<string>());
             optionsManagerMock.Setup(m => m.OverrideTracker).Returns(trackerMock.Object);
 
             var map = cut.BuildSettingsMap(optionsMock.Object);
@@ -309,16 +309,18 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
                 "because PflagKeys.IsAlwaysChanged must return true for it");
         }
 
-        // ACC-004: A key that was reset emits {value:null, changed:true} and is not re-emitted.
+        // ACC-004: A peeked pending reset is folded into the map as {value:null, changed:true}.
+        // BuildSettingsMap peeks non-destructively (IDE-2152 CP 2.2); the caller commits on send success.
         [Fact]
-        public void BuildSettingsMap_ResetKey_EmitsNullChangedTrue_AndUnmarks()
+        public void BuildSettingsMap_ResetKey_EmitsNullChangedTrue()
         {
             SetupDefaults();
             var trackerMock = new Mock<IUserOverrideTracker>();
             trackerMock.Setup(t => t.IsSeeded).Returns(true); // seeded so pending-reset loop runs
             trackerMock.Setup(t => t.IsChanged(It.IsAny<string>())).Returns(false);
-            // ConsumePendingResets returns SnykOssEnabled as a key to reset.
-            trackerMock.Setup(t => t.ConsumePendingResets())
+            // PeekPendingResets returns SnykOssEnabled as a key to reset (non-destructive; the send path
+            // commits only on confirmed success — IDE-2152 CP 2.2).
+            trackerMock.Setup(t => t.PeekPendingResets())
                        .Returns(new List<string> { PflagKeys.SnykOssEnabled });
             optionsManagerMock.Setup(m => m.OverrideTracker).Returns(trackerMock.Object);
 
@@ -342,7 +344,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             trackerMock.Setup(t => t.IsChanged(It.IsAny<string>()))
                        .Callback<string>(_ => trackerCalled = true)
                        .Returns(false);
-            trackerMock.Setup(t => t.ConsumePendingResets()).Returns(new List<string>());
+            trackerMock.Setup(t => t.PeekPendingResets()).Returns(new List<string>());
             optionsManagerMock.Setup(m => m.OverrideTracker).Returns(trackerMock.Object);
 
             cut.BuildSettingsMap(optionsMock.Object);

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
@@ -5,6 +5,7 @@ using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Snyk.VisualStudio.Extension.Authentication;
+using Snyk.VisualStudio.Extension.Download;
 using Snyk.VisualStudio.Extension.Language;
 using Snyk.VisualStudio.Extension.Service;
 using Snyk.VisualStudio.Extension.Settings;
@@ -30,6 +31,40 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             cut = new LsSettingsV25(serviceProviderMock.Object);
         }
 
+        // Builds a minimal IPersistableOptions at all-plugin-defaults for use with SeedFrom.
+        // Used by tests that need a seeded real UserOverrideTracker with no keys marked changed.
+        private static ISnykOptions BuildDefaultOptionsForSeed()
+        {
+            var o = new Mock<ISnykOptions>();
+            o.SetupGet(x => x.OssEnabled).Returns(true);
+            o.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true);
+            o.SetupGet(x => x.IacEnabled).Returns(true);
+            o.SetupGet(x => x.SecretsEnabled).Returns(false);
+            o.SetupGet(x => x.AutoScan).Returns(true);
+            o.SetupGet(x => x.EnableDeltaFindings).Returns(false);
+            o.SetupGet(x => x.FilterCritical).Returns(true);
+            o.SetupGet(x => x.FilterHigh).Returns(true);
+            o.SetupGet(x => x.FilterMedium).Returns(true);
+            o.SetupGet(x => x.FilterLow).Returns(true);
+            o.SetupGet(x => x.OpenIssuesEnabled).Returns(true);
+            o.SetupGet(x => x.IgnoredIssuesEnabled).Returns(false);
+            o.SetupGet(x => x.CustomEndpoint).Returns((string)null);
+            o.SetupGet(x => x.Organization).Returns((string)null);
+            o.SetupGet(x => x.IgnoreUnknownCA).Returns(false);
+            o.SetupGet(x => x.BinariesAutoUpdate).Returns(true);
+            o.SetupGet(x => x.CliCustomPath).Returns(string.Empty);
+            o.SetupGet(x => x.CliReleaseChannel).Returns(SnykCliDownloader.DefaultReleaseChannel);
+            o.SetupGet(x => x.CliBaseDownloadURL).Returns(SnykCliDownloader.DefaultBaseDownloadUrl);
+            o.SetupGet(x => x.AdditionalEnv).Returns(string.Empty);
+            o.SetupGet(x => x.AdditionalParameters).Returns(new List<string>());
+            o.SetupGet(x => x.RiskScoreThreshold).Returns((int?)null);
+            o.SetupGet(x => x.TrustedFolders).Returns(new System.Collections.Generic.HashSet<string>());
+            o.SetupGet(x => x.ApiToken).Returns(
+                new AuthenticationToken(AuthenticationType.OAuth, string.Empty));
+            o.SetupGet(x => x.AuthenticationMethod).Returns(default(AuthenticationType));
+            return o.Object;
+        }
+
         private void SetupDefaults()
         {
             TestUtils.SetupOptionsMock(optionsMock);
@@ -40,8 +75,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             optionsMock.SetupGet(o => o.FilterLow).Returns(false);
             optionsMock.SetupGet(o => o.OpenIssuesEnabled).Returns(true);
             optionsMock.SetupGet(o => o.IgnoredIssuesEnabled).Returns(false);
-            optionsMock.SetupGet(o => o.CliReleaseChannel).Returns("stable");
-            optionsMock.SetupGet(o => o.CliBaseDownloadURL).Returns("https://downloads.snyk.io");
+            optionsMock.SetupGet(o => o.CliReleaseChannel).Returns(SnykCliDownloader.DefaultReleaseChannel);
+            optionsMock.SetupGet(o => o.CliBaseDownloadURL).Returns(SnykCliDownloader.DefaultBaseDownloadUrl);
             optionsMock.SetupGet(o => o.AdditionalEnv).Returns(string.Empty);
             optionsMock.SetupGet(o => o.AdditionalParameters).Returns(new List<string>());
             optionsMock.SetupGet(o => o.RiskScoreThreshold).Returns((int?)null);
@@ -217,14 +252,141 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.Equal(false, map[PflagKeys.SeverityFilterLow].Value);
         }
 
+        // ACC-001: A key the user has NOT overridden is sent with changed:false.
         [Fact]
-        public void BuildSettingsMap_AllEntriesHaveChangedTrue()
+        public void BuildSettingsMap_UntouchedKey_NotMarkedChanged()
         {
             SetupDefaults();
+            // Tracker returns false for SnykOssEnabled (user never changed it).
+            var trackerMock = new Mock<IUserOverrideTracker>();
+            trackerMock.Setup(t => t.IsSeeded).Returns(true); // seeded so the gate is active
+            trackerMock.Setup(t => t.IsChanged(It.IsAny<string>())).Returns(false);
+            trackerMock.Setup(t => t.ConsumePendingResets()).Returns(new List<string>());
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(trackerMock.Object);
+
             var map = cut.BuildSettingsMap(optionsMock.Object);
 
-            foreach (var kv in map)
-                Assert.True(kv.Value.Changed, $"Expected Changed=true for key '{kv.Key}'");
+            Assert.False(map[PflagKeys.SnykOssEnabled].Changed,
+                "An untouched key must be sent with changed:false so org defaults are not clobbered");
+        }
+
+        // ACC-002: A key the user HAS overridden is sent with changed:true.
+        [Fact]
+        public void BuildSettingsMap_UserChangedKey_MarkedChanged()
+        {
+            SetupDefaults();
+            var trackerMock = new Mock<IUserOverrideTracker>();
+            trackerMock.Setup(t => t.IsSeeded).Returns(true); // seeded so the gate is active
+            trackerMock.Setup(t => t.IsChanged(PflagKeys.SnykOssEnabled)).Returns(true);
+            trackerMock.Setup(t => t.IsChanged(It.Is<string>(k => k != PflagKeys.SnykOssEnabled))).Returns(false);
+            trackerMock.Setup(t => t.ConsumePendingResets()).Returns(new List<string>());
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(trackerMock.Object);
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            Assert.True(map[PflagKeys.SnykOssEnabled].Changed,
+                "A user-overridden key must be sent with changed:true");
+        }
+
+        // ACC-005: trusted_folders is always marked changed regardless of tracker.
+        // Uses a REAL seeded UserOverrideTracker (empty changed set) so the assertion exercises the
+        // real PflagKeys.IsAlwaysChanged path — a mock that stubs IsChanged=true cannot detect
+        // an AlwaysChanged regression (it would pass even if IsAlwaysChanged were removed).
+        [Fact]
+        public void BuildSettingsMap_AlwaysChangedKeys_AlwaysMarked()
+        {
+            SetupDefaults();
+            // Real tracker seeded with all-defaults (empty changed set) — no key has been explicitly marked.
+            var realTracker = new UserOverrideTracker();
+            realTracker.SeedFrom(BuildDefaultOptionsForSeed());
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(realTracker);
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            Assert.True(map[PflagKeys.TrustedFolders].Changed,
+                "trusted_folders must always be sent with changed:true even when the tracker has no marks, " +
+                "because PflagKeys.IsAlwaysChanged must return true for it");
+        }
+
+        // ACC-004: A key that was reset emits {value:null, changed:true} and is not re-emitted.
+        [Fact]
+        public void BuildSettingsMap_ResetKey_EmitsNullChangedTrue_AndUnmarks()
+        {
+            SetupDefaults();
+            var trackerMock = new Mock<IUserOverrideTracker>();
+            trackerMock.Setup(t => t.IsSeeded).Returns(true); // seeded so pending-reset loop runs
+            trackerMock.Setup(t => t.IsChanged(It.IsAny<string>())).Returns(false);
+            // ConsumePendingResets returns SnykOssEnabled as a key to reset.
+            trackerMock.Setup(t => t.ConsumePendingResets())
+                       .Returns(new List<string> { PflagKeys.SnykOssEnabled });
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(trackerMock.Object);
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            Assert.True(map.ContainsKey(PflagKeys.SnykOssEnabled));
+            Assert.Null(map[PflagKeys.SnykOssEnabled].Value);
+            Assert.True(map[PflagKeys.SnykOssEnabled].Changed,
+                "A reset key must be sent with value:null, changed:true");
+        }
+
+        // INT-003: Composition-root wiring — BuildSettingsMap uses the tracker injected via
+        // ISnykOptionsManager.OverrideTracker; this test fails if the wiring is removed.
+        [Fact]
+        public void BuildSettingsMap_UsesInjectedTracker()
+        {
+            SetupDefaults();
+            var trackerMock = new Mock<IUserOverrideTracker>();
+            trackerMock.Setup(t => t.IsSeeded).Returns(true); // seeded so IsChanged is actually consulted
+            var trackerCalled = false;
+            trackerMock.Setup(t => t.IsChanged(It.IsAny<string>()))
+                       .Callback<string>(_ => trackerCalled = true)
+                       .Returns(false);
+            trackerMock.Setup(t => t.ConsumePendingResets()).Returns(new List<string>());
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(trackerMock.Object);
+
+            cut.BuildSettingsMap(optionsMock.Object);
+
+            Assert.True(trackerCalled,
+                "BuildSettingsMap must consult the tracker from ISnykOptionsManager.OverrideTracker. " +
+                "This test fails if the wiring is removed from the production path.");
+        }
+
+        // R5-1e: An UNSEEDED real tracker causes Cs() to fall back to changed:true (safe pre-IDE-2152 behavior).
+        // This proves that a startup race (BuildSettingsMap before Load()) cannot silently downgrade overrides.
+        [Fact]
+        public void BuildSettingsMap_UnseededTracker_FallsBackToChangedTrue()
+        {
+            SetupDefaults();
+            // Real tracker with no SeedFrom call — IsSeeded is false.
+            var unseededTracker = new UserOverrideTracker();
+            Assert.False(unseededTracker.IsSeeded); // precondition
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(unseededTracker);
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            Assert.True(map[PflagKeys.SnykOssEnabled].Changed,
+                "An unseeded tracker must fall back to changed:true — " +
+                "BuildSettingsMap may run before Load() at startup; silently sending changed:false " +
+                "would let org defaults override the user's persisted settings");
+        }
+
+        // R5-1f: A SEEDED tracker with an empty changed set emits changed:false for normal (non-always-changed) keys.
+        // Proves the seeded path still distinguishes between overridden and untouched keys.
+        [Fact]
+        public void BuildSettingsMap_SeededEmptyTracker_EmitsChangedFalseForNormalKeys()
+        {
+            SetupDefaults();
+            // Real tracker seeded with all-default options — no key is marked changed.
+            var seededTracker = new UserOverrideTracker();
+            seededTracker.SeedFrom(BuildDefaultOptionsForSeed());
+            Assert.True(seededTracker.IsSeeded); // precondition
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(seededTracker);
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            Assert.False(map[PflagKeys.SnykOssEnabled].Changed,
+                "A seeded tracker with an empty changed set must emit changed:false for normal keys — " +
+                "the seeded path must distinguish overridden from untouched keys");
         }
 
         [Fact]
@@ -235,6 +397,28 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             Assert.True(map.ContainsKey(PflagKeys.ClientProtocolVersion));
             Assert.Equal("25", map[PflagKeys.ClientProtocolVersion].Value);
+        }
+
+        // R3-3: DeviceId and ClientProtocolVersion are emitted via ConfigSetting.Of (always changed:true),
+        // NOT via the tracker-gated Cs(). Assert changed:true directly so a regression switching them
+        // to Cs() (which would make them changed:false for new users) is caught.
+        [Fact]
+        public void BuildSettingsMap_DeviceIdAndClientProtocolVersion_AlwaysChangedTrue()
+        {
+            SetupDefaults();
+            // Wire a real seeded tracker with empty changed set — neither DeviceId nor ClientProtocolVersion
+            // should be in AlwaysChanged, so they must be true via ConfigSetting.Of, not the tracker.
+            // Seeding is required so the IsSeeded gate is active (unseeded fallback would trivially pass).
+            var realTracker = new UserOverrideTracker();
+            realTracker.SeedFrom(BuildDefaultOptionsForSeed());
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(realTracker);
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            Assert.True(map[PflagKeys.DeviceId].Changed,
+                "device_id must always be sent with changed:true (ConfigSetting.Of, not tracker-gated)");
+            Assert.True(map[PflagKeys.ClientProtocolVersion].Changed,
+                "client_protocol_version must always be sent with changed:true (ConfigSetting.Of, not tracker-gated)");
         }
 
         [Fact]
@@ -477,6 +661,193 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             Assert.NotNull(result.FolderConfigs);
             Assert.Empty(result.FolderConfigs);
+        }
+
+        // RACC-001 (Acceptance / RED gate): Org pushes a non-default value, user saves WITHOUT
+        // editing that key → the key must NOT be marked as a user override, so subsequent org
+        // changes keep propagating. The correct path is ApplyUserEdits with empty editedKeys,
+        // which leaves org-pushed values untouched in the tracker.
+        [Fact]
+        public void OrgPushedValue_UserSavesWithoutEditingIt_StillSentUnmarked_SoOrgChangesKeepPropagating()
+        {
+            SetupDefaults();
+            // The org pushed OssEnabled=false (non-default) into Options.
+            // The user opens settings and saves without changing OssEnabled (editedKeys is empty).
+            // The tracker must NOT mark OssEnabled as a user override.
+
+            // Use a real seeded tracker + real UserOverrideTracker after an ApplyUserEdits({}) call.
+            var realTracker = new UserOverrideTracker();
+            realTracker.SeedFrom(BuildDefaultOptionsForSeed()); // seeded, clean slate
+
+            // Simulate: org pushed OssEnabled=false into Options (non-default).
+            // Then the user saves with an empty edited-key set (didn't touch anything).
+            var optionsWithOrgPush = new Mock<ISnykOptions>();
+            optionsWithOrgPush.SetupGet(x => x.OssEnabled).Returns(false); // org-pushed non-default
+            // (other keys are not queried by ApplyUserEdits when editedKeys is empty)
+
+            realTracker.ApplyUserEdits(optionsWithOrgPush.Object, new List<string>()); // no edits
+
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(realTracker);
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            Assert.False(map[PflagKeys.SnykOssEnabled].Changed,
+                "An org-pushed value that the user did NOT edit must remain sent with changed:false. " +
+                "Using ApplyUserEdits with empty editedKeys correctly leaves the key unmarked so " +
+                "subsequent org changes keep propagating (the LS does not treat it as user-frozen).");
+        }
+
+        // RACC-002 (Acceptance): HTML bridge marks only edited keys, not untouched org values.
+        // This tests the bridge-level edit-delta derivation: a key whose value was the same
+        // before and after the apply step must NOT appear in the editedKeys passed to Save.
+        [Fact]
+        public void SaveIdeConfig_MarksOnlyEditedKeys_NotUntouchedOrgValues()
+        {
+            SetupDefaults();
+            // Org pushed OssEnabled=false. User only edited IacEnabled (set to false).
+            // Expected: IacEnabled marked (edited), OssEnabled NOT marked (untouched).
+
+            // Real tracker, seeded clean.
+            var realTracker = new UserOverrideTracker();
+            realTracker.SeedFrom(BuildDefaultOptionsForSeed());
+
+            // Simulate the pre-apply snapshot: OssEnabled=false (org-pushed), IacEnabled=true (default).
+            // After apply: user changed IacEnabled to false; OssEnabled still false (untouched).
+            // editedKeys derived by bridge: {IacEnabled} only.
+            realTracker.ApplyUserEdits(
+                // options after apply — OssEnabled=false (org), IacEnabled=false (user-edited)
+                new Func<ISnykOptions>(() =>
+                {
+                    var o = new Mock<ISnykOptions>();
+                    o.SetupGet(x => x.OssEnabled).Returns(false);  // org-pushed, not edited
+                    o.SetupGet(x => x.IacEnabled).Returns(false);  // user-edited
+                    o.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true);
+                    o.SetupGet(x => x.SecretsEnabled).Returns(false);
+                    o.SetupGet(x => x.AutoScan).Returns(true);
+                    o.SetupGet(x => x.EnableDeltaFindings).Returns(false);
+                    o.SetupGet(x => x.FilterCritical).Returns(true);
+                    o.SetupGet(x => x.FilterHigh).Returns(true);
+                    o.SetupGet(x => x.FilterMedium).Returns(true);
+                    o.SetupGet(x => x.FilterLow).Returns(true);
+                    o.SetupGet(x => x.OpenIssuesEnabled).Returns(true);
+                    o.SetupGet(x => x.IgnoredIssuesEnabled).Returns(false);
+                    o.SetupGet(x => x.CustomEndpoint).Returns((string)null);
+                    o.SetupGet(x => x.Organization).Returns((string)null);
+                    o.SetupGet(x => x.IgnoreUnknownCA).Returns(false);
+                    o.SetupGet(x => x.BinariesAutoUpdate).Returns(true);
+                    o.SetupGet(x => x.CliCustomPath).Returns(string.Empty);
+                    o.SetupGet(x => x.CliReleaseChannel).Returns(Download.SnykCliDownloader.DefaultReleaseChannel);
+                    o.SetupGet(x => x.CliBaseDownloadURL).Returns(Download.SnykCliDownloader.DefaultBaseDownloadUrl);
+                    o.SetupGet(x => x.AdditionalEnv).Returns(string.Empty);
+                    o.SetupGet(x => x.AdditionalParameters).Returns(new List<string>());
+                    o.SetupGet(x => x.RiskScoreThreshold).Returns((int?)null);
+                    o.SetupGet(x => x.TrustedFolders).Returns(new System.Collections.Generic.HashSet<string>());
+                    o.SetupGet(x => x.ApiToken).Returns(
+                        new Authentication.AuthenticationToken(Authentication.AuthenticationType.OAuth, string.Empty));
+                    o.SetupGet(x => x.AuthenticationMethod).Returns(default(Authentication.AuthenticationType));
+                    return o.Object;
+                })(),
+                // editedKeys: only IacEnabled (the bridge derives this from the pre/post snapshot diff)
+                new List<string> { PflagKeys.SnykIacEnabled });
+
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(realTracker);
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            Assert.True(map[PflagKeys.SnykIacEnabled].Changed,
+                "IacEnabled was in the edit delta (user changed it) → must be marked changed");
+            Assert.False(map[PflagKeys.SnykOssEnabled].Changed,
+                "OssEnabled was NOT in the edit delta (org-pushed, user didn't touch it) → must remain unmarked");
+        }
+
+        // RACC-003 (Acceptance): User edits a key back to its default → that key emits a reset and
+        // is unmarked. Untouched keys that happen to be at their defaults do NOT emit resets.
+        [Fact]
+        public void UserEditsKeyToDefault_EmitsResetAndUnmarks_ButUntouchedDefaultsNeverEmitReset()
+        {
+            SetupDefaults();
+            // Start: OssEnabled was previously overridden (false). User edits it back to true (default).
+            // IacEnabled is at its default (true) and was NOT edited.
+            // Expected: OssEnabled reset emitted, IacEnabled not reset.
+
+            var realTracker = new UserOverrideTracker();
+            // Simulate previously-overridden OssEnabled.
+            realTracker.Mark(PflagKeys.SnykOssEnabled);
+            realTracker.MarkSeeded(); // mark seeded so BuildSettingsMap's IsSeeded gate is active
+
+            // User's edit: OssEnabled→true (default). IacEnabled not touched (not in editedKeys).
+            var options = new Mock<ISnykOptions>();
+            options.SetupGet(x => x.OssEnabled).Returns(true); // back to default
+            options.SetupGet(x => x.IacEnabled).Returns(true);
+            options.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true);
+            options.SetupGet(x => x.SecretsEnabled).Returns(false);
+            options.SetupGet(x => x.AutoScan).Returns(true);
+            options.SetupGet(x => x.EnableDeltaFindings).Returns(false);
+            options.SetupGet(x => x.FilterCritical).Returns(true);
+            options.SetupGet(x => x.FilterHigh).Returns(true);
+            options.SetupGet(x => x.FilterMedium).Returns(true);
+            options.SetupGet(x => x.FilterLow).Returns(true);
+            options.SetupGet(x => x.OpenIssuesEnabled).Returns(true);
+            options.SetupGet(x => x.IgnoredIssuesEnabled).Returns(false);
+            options.SetupGet(x => x.CustomEndpoint).Returns((string)null);
+            options.SetupGet(x => x.Organization).Returns((string)null);
+            options.SetupGet(x => x.IgnoreUnknownCA).Returns(false);
+            options.SetupGet(x => x.BinariesAutoUpdate).Returns(true);
+            options.SetupGet(x => x.CliCustomPath).Returns(string.Empty);
+            options.SetupGet(x => x.CliReleaseChannel).Returns(Download.SnykCliDownloader.DefaultReleaseChannel);
+            options.SetupGet(x => x.CliBaseDownloadURL).Returns(Download.SnykCliDownloader.DefaultBaseDownloadUrl);
+            options.SetupGet(x => x.AdditionalEnv).Returns(string.Empty);
+            options.SetupGet(x => x.AdditionalParameters).Returns(new List<string>());
+            options.SetupGet(x => x.RiskScoreThreshold).Returns((int?)null);
+            options.SetupGet(x => x.TrustedFolders).Returns(new System.Collections.Generic.HashSet<string>());
+            options.SetupGet(x => x.ApiToken).Returns(
+                new Authentication.AuthenticationToken(Authentication.AuthenticationType.OAuth, string.Empty));
+            options.SetupGet(x => x.AuthenticationMethod).Returns(default(Authentication.AuthenticationType));
+
+            realTracker.ApplyUserEdits(options.Object, new List<string> { PflagKeys.SnykOssEnabled });
+
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(realTracker);
+            optionsMock.SetupGet(o => o.RiskScoreThreshold).Returns((int?)null);
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            // OssEnabled was in editedKeys and reset to default → reset signal emitted.
+            Assert.True(map.ContainsKey(PflagKeys.SnykOssEnabled),
+                "OssEnabled must be in the map (as a reset entry)");
+            Assert.Null(map[PflagKeys.SnykOssEnabled].Value,
+                "OssEnabled reset must emit value:null");
+            Assert.True(map[PflagKeys.SnykOssEnabled].Changed,
+                "OssEnabled reset must emit changed:true");
+
+            // IacEnabled was NOT in editedKeys → no reset emitted (its normal value entry is present).
+            // If IacEnabled emitted a reset spuriously, its Value would be null — assert it is not.
+            Assert.NotNull(map[PflagKeys.SnykIacEnabled].Value,
+                "IacEnabled was NOT edited → must NOT emit a reset; its value entry must be present");
+        }
+
+        // UNIT-008: ConfigSetting.Of(value, changed) overload sets Changed correctly;
+        // ConfigSetting.Reset() sets value=null, changed=true.
+        [Fact]
+        public void ConfigSetting_Factories_SetChangedCorrectly()
+        {
+            // Of(value) — existing factory, always changed:true.
+            var withChanged = ConfigSetting.Of("v");
+            Assert.True(withChanged.Changed);
+            Assert.Equal("v", withChanged.Value);
+
+            // Of(value, changed:false) — new overload, not changed:
+            var notChanged = ConfigSetting.Of("v", changed: false);
+            Assert.False(notChanged.Changed);
+            Assert.Equal("v", notChanged.Value);
+
+            // Of(value, changed:true) — new overload, explicit true:
+            var explicitChanged = ConfigSetting.Of("v", changed: true);
+            Assert.True(explicitChanged.Changed);
+
+            // Reset() — value=null, changed=true (used for un-marking a setting):
+            var reset = ConfigSetting.Reset();
+            Assert.Null(reset.Value);
+            Assert.True(reset.Changed);
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
@@ -761,24 +761,24 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
                 "OssEnabled was NOT in the edit delta (org-pushed, user didn't touch it) → must remain unmarked");
         }
 
-        // RACC-003 (Acceptance): User edits a key back to its default → that key emits a reset and
-        // is unmarked. Untouched keys that happen to be at their defaults do NOT emit resets.
+        // RACC-003 (corrected semantics, PR #515): A key the user edits to its default value via the
+        // form goes out as an explicit user-owned value ({value, changed:true}), NOT a reset — the
+        // edit is an explicit choice. Untouched keys at their defaults never emit a reset either.
+        // (Reset-to-default is no longer inferred inside ApplyUserEdits from value==default.)
         [Fact]
-        public void UserEditsKeyToDefault_EmitsResetAndUnmarks_ButUntouchedDefaultsNeverEmitReset()
+        public void UserEditsKeyToDefault_SendsExplicitValueChangedTrue_ButUntouchedDefaultsNeverEmitReset()
         {
             SetupDefaults();
-            // Start: OssEnabled was previously overridden (false). User edits it back to true (default).
+            // User edits OssEnabled through the form, landing on the default value true.
             // IacEnabled is at its default (true) and was NOT edited.
-            // Expected: OssEnabled reset emitted, IacEnabled not reset.
+            // Expected: OssEnabled sent {value:true, changed:true} (no reset); IacEnabled not reset.
 
             var realTracker = new UserOverrideTracker();
-            // Simulate previously-overridden OssEnabled.
-            realTracker.Mark(PflagKeys.SnykOssEnabled);
             realTracker.MarkSeeded(); // mark seeded so BuildSettingsMap's IsSeeded gate is active
 
-            // User's edit: OssEnabled→true (default). IacEnabled not touched (not in editedKeys).
+            // User's edit: OssEnabled→true (its default). IacEnabled not touched (not in editedKeys).
             var options = new Mock<ISnykOptions>();
-            options.SetupGet(x => x.OssEnabled).Returns(true); // back to default
+            options.SetupGet(x => x.OssEnabled).Returns(true); // user-applied value == default
             options.SetupGet(x => x.IacEnabled).Returns(true);
             options.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true);
             options.SetupGet(x => x.SecretsEnabled).Returns(false);
@@ -812,16 +812,56 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             var map = cut.BuildSettingsMap(optionsMock.Object);
 
-            // OssEnabled was in editedKeys and reset to default → reset signal emitted.
+            // OssEnabled was in editedKeys → sent as an explicit user-owned value, NOT a reset.
             Assert.True(map.ContainsKey(PflagKeys.SnykOssEnabled),
-                "OssEnabled must be in the map (as a reset entry)");
-            Assert.Null(map[PflagKeys.SnykOssEnabled].Value);    // reset must emit value:null
+                "OssEnabled must be in the map");
+            Assert.NotNull(map[PflagKeys.SnykOssEnabled].Value); // explicit value, NOT a reset (value:null)
             Assert.True(map[PflagKeys.SnykOssEnabled].Changed,
-                "OssEnabled reset must emit changed:true");
+                "An edited key must emit changed:true so the org default cannot override it");
 
             // IacEnabled was NOT in editedKeys → no reset emitted (its normal value entry is present).
-            // If IacEnabled emitted a reset spuriously, its Value would be null — assert it is not.
             Assert.NotNull(map[PflagKeys.SnykIacEnabled].Value); // not edited → must not emit a reset
+        }
+
+        // RACC-004 (Acceptance / PR #515 regression): Enabling the global Snyk Code toggle must
+        // persist as an explicit user-owned value, not be turned into a reset-to-default signal.
+        //
+        // Snyk Code's plugin default is `true` (ConfigDefaults). Under the OLD (buggy) semantics
+        // ApplyUserEdits classified an edited key by value==plugin-default, so a user *enabling*
+        // Code (posting true) hit the Unmark branch → BuildSettingsMap emitted a Reset
+        // ({value:null, changed:true}) → the org/server default won → the enable appeared not to
+        // persist. The fix: any key the form posted (present in editedKeys) is an explicit user
+        // choice and must be Mark'd (changed:true) carrying the user's value, never a reset.
+        [Fact]
+        public void EnablingSnykCode_SendsExplicitEnabledValueChangedTrue_NotReset()
+        {
+            SetupDefaults(); // SnykCodeSecurityEnabled == true (the plugin default the user just enabled)
+
+            var realTracker = new UserOverrideTracker();
+            realTracker.SeedFrom(BuildDefaultOptionsForSeed()); // clean seeded slate, Code unmarked
+
+            // The user enables Snyk Code in the settings form and applies. The form posts
+            // snyk_code_enabled=true and includes it in the edit delta. Even though true equals the
+            // plugin default, the user made an explicit choice — it must be recorded as an override.
+            var optionsAfterSave = new Mock<ISnykOptions>();
+            optionsAfterSave.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true); // user-enabled == plugin default
+
+            realTracker.ApplyUserEdits(
+                optionsAfterSave.Object,
+                new List<string> { PflagKeys.SnykCodeEnabled });
+
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(realTracker);
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            // The user's explicit enable must go out as {value:true, changed:true} — NOT a reset.
+            Assert.True(map.ContainsKey(PflagKeys.SnykCodeEnabled),
+                "snyk_code_enabled must be present in the settings map");
+            Assert.NotNull(map[PflagKeys.SnykCodeEnabled].Value); // must NOT be a reset (value:null)
+            Assert.Equal(true, map[PflagKeys.SnykCodeEnabled].Value); // carries the user's enabled value
+            Assert.True(map[PflagKeys.SnykCodeEnabled].Changed,
+                "An explicitly enabled Snyk Code toggle must be marked changed so the org default " +
+                "cannot silently override the user's choice");
         }
 
         // UNIT-008: ConfigSetting.Of(value, changed) overload sets Changed correctly;

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Sdk.TestFramework;
@@ -743,8 +744,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
                     o.SetupGet(x => x.RiskScoreThreshold).Returns((int?)null);
                     o.SetupGet(x => x.TrustedFolders).Returns(new System.Collections.Generic.HashSet<string>());
                     o.SetupGet(x => x.ApiToken).Returns(
-                        new Authentication.AuthenticationToken(Authentication.AuthenticationType.OAuth, string.Empty));
-                    o.SetupGet(x => x.AuthenticationMethod).Returns(default(Authentication.AuthenticationType));
+                        new AuthenticationToken(AuthenticationType.OAuth, string.Empty));
+                    o.SetupGet(x => x.AuthenticationMethod).Returns(default(AuthenticationType));
                     return o.Object;
                 })(),
                 // editedKeys: only IacEnabled (the bridge derives this from the pre/post snapshot diff)
@@ -801,8 +802,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             options.SetupGet(x => x.RiskScoreThreshold).Returns((int?)null);
             options.SetupGet(x => x.TrustedFolders).Returns(new System.Collections.Generic.HashSet<string>());
             options.SetupGet(x => x.ApiToken).Returns(
-                new Authentication.AuthenticationToken(Authentication.AuthenticationType.OAuth, string.Empty));
-            options.SetupGet(x => x.AuthenticationMethod).Returns(default(Authentication.AuthenticationType));
+                new AuthenticationToken(AuthenticationType.OAuth, string.Empty));
+            options.SetupGet(x => x.AuthenticationMethod).Returns(default(AuthenticationType));
 
             realTracker.ApplyUserEdits(options.Object, new List<string> { PflagKeys.SnykOssEnabled });
 
@@ -814,15 +815,13 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             // OssEnabled was in editedKeys and reset to default → reset signal emitted.
             Assert.True(map.ContainsKey(PflagKeys.SnykOssEnabled),
                 "OssEnabled must be in the map (as a reset entry)");
-            Assert.Null(map[PflagKeys.SnykOssEnabled].Value,
-                "OssEnabled reset must emit value:null");
+            Assert.Null(map[PflagKeys.SnykOssEnabled].Value);    // reset must emit value:null
             Assert.True(map[PflagKeys.SnykOssEnabled].Changed,
                 "OssEnabled reset must emit changed:true");
 
             // IacEnabled was NOT in editedKeys → no reset emitted (its normal value entry is present).
             // If IacEnabled emitted a reset spuriously, its Value would be null — assert it is not.
-            Assert.NotNull(map[PflagKeys.SnykIacEnabled].Value,
-                "IacEnabled was NOT edited → must NOT emit a reset; its value entry must be present");
+            Assert.NotNull(map[PflagKeys.SnykIacEnabled].Value); // not edited → must not emit a reset
         }
 
         // UNIT-008: ConfigSetting.Of(value, changed) overload sets Changed correctly;

--- a/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
@@ -344,9 +344,10 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             await cut.OnHasAuthenticated(arg);
 
             // Assert — token and endpoint stored, saved without triggering didChangeConfiguration loop
+            // and without updating the override tracker (LS-delivered auth result, not a user settings-edit).
             optionsMock.VerifySet(o => o.CustomEndpoint = "https://api.snyk.io");
             optionsMock.VerifySet(o => o.ApiToken = It.Is<AuthenticationToken>(t => t.Type == AuthenticationType.OAuth && t.ToString() == "test-token"));
-            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false), Times.Once);
+            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false, false, null), Times.Once);
             authenticationFlowServiceMock.Verify(o => o.HandleAuthenticationSuccessAsync("test-token", "https://api.snyk.io"), Times.Once);
         }
 
@@ -362,8 +363,9 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             // Act
             await cut.OnHasAuthenticated(arg);
 
-            // Assert — Save must be called with triggerSettingsChangedEvent=false to avoid the loop
-            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false), Times.Once);
+            // Assert — Save must be called with triggerSettingsChangedEvent=false (avoid loop) and
+            // updateOverrideTracker=false (LS-delivered auth, not a user settings-edit).
+            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false, false, null), Times.Once);
             // HandleAuthenticationSuccessAsync must NOT be called — not a new login
             authenticationFlowServiceMock.Verify(o => o.HandleAuthenticationSuccessAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             // No scan on refresh — old token was non-blank
@@ -401,7 +403,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.Equal(2, optionsMock.Object.TrustedFolders.Count);
             Assert.Contains("/folder1", optionsMock.Object.TrustedFolders);
             Assert.Contains("/folder2", optionsMock.Object.TrustedFolders);
-            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false), Times.Once);
+            // updateOverrideTracker:false — LS is pushing trusted-folder set back; must not record as user override.
+            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false, false), Times.Once);
             // Note: DidChangeConfigurationAsync is intentionally not called to avoid infinite loop
             languageClientManagerMock.Verify(s => s.DidChangeConfigurationAsync(It.IsAny<CancellationToken>()), Times.Never);
         }
@@ -702,7 +705,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             // Assert — the setting was applied to Options...
             Assert.True(optionsMock.Object.OssEnabled);
             // ...and persisted without re-triggering DidChangeConfigurationAsync (triggerSettingsChangedEvent=false)
-            snykOptionsManagerMock.Verify(m => m.Save(It.IsAny<IPersistableOptions>(), false), Times.Once());
+            // updateOverrideTracker:false — LS-pushed values must never be recorded as user overrides (IDE-2152).
+            snykOptionsManagerMock.Verify(m => m.Save(It.IsAny<IPersistableOptions>(), false, false), Times.Once());
         }
 
         [Fact]

--- a/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
@@ -347,7 +347,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             // and without updating the override tracker (LS-delivered auth result, not a user settings-edit).
             optionsMock.VerifySet(o => o.CustomEndpoint = "https://api.snyk.io");
             optionsMock.VerifySet(o => o.ApiToken = It.Is<AuthenticationToken>(t => t.Type == AuthenticationType.OAuth && t.ToString() == "test-token"));
-            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false, false, null), Times.Once);
+            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false, false, null, null), Times.Once);
             authenticationFlowServiceMock.Verify(o => o.HandleAuthenticationSuccessAsync("test-token", "https://api.snyk.io"), Times.Once);
         }
 
@@ -365,7 +365,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             // Assert — Save must be called with triggerSettingsChangedEvent=false (avoid loop) and
             // updateOverrideTracker=false (LS-delivered auth, not a user settings-edit).
-            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false, false, null), Times.Once);
+            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false, false, null, null), Times.Once);
             // HandleAuthenticationSuccessAsync must NOT be called — not a new login
             authenticationFlowServiceMock.Verify(o => o.HandleAuthenticationSuccessAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             // No scan on refresh — old token was non-blank
@@ -404,7 +404,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.Contains("/folder1", optionsMock.Object.TrustedFolders);
             Assert.Contains("/folder2", optionsMock.Object.TrustedFolders);
             // updateOverrideTracker:false — LS is pushing trusted-folder set back; must not record as user override.
-            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false, false, It.IsAny<System.Collections.Generic.IReadOnlyCollection<string>>()), Times.Once);
+            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false, false, It.IsAny<System.Collections.Generic.IReadOnlyCollection<string>>(), It.IsAny<System.Collections.Generic.IReadOnlyCollection<string>>()), Times.Once);
             // Note: DidChangeConfigurationAsync is intentionally not called to avoid infinite loop
             languageClientManagerMock.Verify(s => s.DidChangeConfigurationAsync(It.IsAny<CancellationToken>()), Times.Never);
         }
@@ -706,7 +706,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.True(optionsMock.Object.OssEnabled);
             // ...and persisted without re-triggering DidChangeConfigurationAsync (triggerSettingsChangedEvent=false)
             // updateOverrideTracker:false — LS-pushed values must never be recorded as user overrides (IDE-2152).
-            snykOptionsManagerMock.Verify(m => m.Save(It.IsAny<IPersistableOptions>(), false, false, It.IsAny<System.Collections.Generic.IReadOnlyCollection<string>>()), Times.Once());
+            snykOptionsManagerMock.Verify(m => m.Save(It.IsAny<IPersistableOptions>(), false, false, It.IsAny<System.Collections.Generic.IReadOnlyCollection<string>>(), It.IsAny<System.Collections.Generic.IReadOnlyCollection<string>>()), Times.Once());
         }
 
         [Fact]

--- a/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
@@ -404,7 +404,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.Contains("/folder1", optionsMock.Object.TrustedFolders);
             Assert.Contains("/folder2", optionsMock.Object.TrustedFolders);
             // updateOverrideTracker:false — LS is pushing trusted-folder set back; must not record as user override.
-            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false, false), Times.Once);
+            snykOptionsManagerMock.Verify(s => s.Save(It.IsAny<IPersistableOptions>(), false, false, It.IsAny<System.Collections.Generic.IReadOnlyCollection<string>>()), Times.Once);
             // Note: DidChangeConfigurationAsync is intentionally not called to avoid infinite loop
             languageClientManagerMock.Verify(s => s.DidChangeConfigurationAsync(It.IsAny<CancellationToken>()), Times.Never);
         }
@@ -706,7 +706,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.True(optionsMock.Object.OssEnabled);
             // ...and persisted without re-triggering DidChangeConfigurationAsync (triggerSettingsChangedEvent=false)
             // updateOverrideTracker:false — LS-pushed values must never be recorded as user overrides (IDE-2152).
-            snykOptionsManagerMock.Verify(m => m.Save(It.IsAny<IPersistableOptions>(), false, false), Times.Once());
+            snykOptionsManagerMock.Verify(m => m.Save(It.IsAny<IPersistableOptions>(), false, false, It.IsAny<System.Collections.Generic.IReadOnlyCollection<string>>()), Times.Once());
         }
 
         [Fact]

--- a/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientTest.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.Sdk.TestFramework;
+using Microsoft.VisualStudio.Shell;
 using Moq;
 using Snyk.VisualStudio.Extension.Language;
 using Snyk.VisualStudio.Extension.Service;
@@ -108,6 +109,240 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.Null(result);
         }
 
+
+        // Wires a real seeded UserOverrideTracker (through the OptionsManager mock) with a single
+        // pending reset queued, plus real options, so DidChangeConfigurationAsync exercises the real
+        // peek-then-commit path against BuildSettingsMap. The mock manager's CommitPendingResets is
+        // wired to delegate to the real tracker — mirroring the production SnykOptionsManager, which
+        // owns the tracker and re-persists on commit (IDE-2152 fix #2/#3): the client commits via the
+        // MANAGER (single entry point that keeps persistence in sync), not the tracker directly.
+        private UserOverrideTracker ArrangeTrackerWithPendingReset(string resetKey)
+        {
+            TestUtils.SetupOptionsMock(OptionsMock);
+            var tracker = new UserOverrideTracker();
+            tracker.MarkSeeded(); // seeded so BuildSettingsMap consults the tracker + folds resets
+            tracker.ApplyUserResets(new List<string> { resetKey }); // queue a reset
+            OptionsManagerMock.Setup(m => m.OverrideTracker).Returns(tracker);
+            OptionsManagerMock
+                .Setup(m => m.CommitPendingResets(It.IsAny<IReadOnlyCollection<string>>()))
+                .Callback<IReadOnlyCollection<string>>(sent => tracker.CommitPendingResets(sent));
+            return tracker;
+        }
+
+        // IDE-2152-ACCEPT-002: When the configuration update to the LS fails once (transient), the
+        // pending reset must NOT be lost — it is re-delivered on the next configuration update.
+        [Fact]
+        public async Task DidChangeConfigurationAsync_TransientFailure_ReDeliversPendingResetOnNextUpdate()
+        {
+            cut.IsReady = true;
+            var tracker = ArrangeTrackerWithPendingReset(PflagKeys.SnykOssEnabled);
+
+            // First send fails, second send succeeds.
+            var call = 0;
+            jsonRpcMock
+                .Setup(x => x.InvokeWithParameterObjectAsync<object>(
+                    LsConstants.WorkspaceChangeConfiguration,
+                    It.IsAny<LSP.DidChangeConfigurationParams>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<string, object, CancellationToken>((_, __, ___) =>
+                {
+                    call++;
+                    if (call == 1)
+                        throw new InvalidOperationException("transient RPC failure");
+                    return Task.FromResult<object>(null);
+                });
+
+            // First update: the send throws → the reset MUST remain queued (not consumed).
+            await cut.DidChangeConfigurationAsync(CancellationToken.None);
+            Assert.Contains(PflagKeys.SnykOssEnabled, tracker.PeekPendingResets());
+
+            // Second update: the send succeeds → the reset is delivered again and only now committed.
+            await cut.DidChangeConfigurationAsync(CancellationToken.None);
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, tracker.PeekPendingResets());
+
+            // The reset reached the LS on BOTH attempts (the first, lost, and the re-delivery).
+            jsonRpcMock.Verify(x => x.InvokeWithParameterObjectAsync<object>(
+                LsConstants.WorkspaceChangeConfiguration,
+                It.IsAny<LSP.DidChangeConfigurationParams>(),
+                It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        // IDE-2152-INTEG-003: A successful config send commits (clears) the pending reset so it is not
+        // re-sent on a subsequent update.
+        [Fact]
+        public async Task DidChangeConfigurationAsync_SuccessfulSend_DoesNotReSendCommittedReset()
+        {
+            cut.IsReady = true;
+            var tracker = ArrangeTrackerWithPendingReset(PflagKeys.SnykOssEnabled);
+
+            jsonRpcMock
+                .Setup(x => x.InvokeWithParameterObjectAsync<object>(
+                    LsConstants.WorkspaceChangeConfiguration,
+                    It.IsAny<LSP.DidChangeConfigurationParams>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((object)null);
+
+            // First update succeeds → reset delivered and committed.
+            await cut.DidChangeConfigurationAsync(CancellationToken.None);
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, tracker.PeekPendingResets());
+
+            // Capture the second update's settings map: the reset key must NOT appear as a reset again.
+            LSP.DidChangeConfigurationParams secondParam = null;
+            jsonRpcMock
+                .Setup(x => x.InvokeWithParameterObjectAsync<object>(
+                    LsConstants.WorkspaceChangeConfiguration,
+                    It.IsAny<LSP.DidChangeConfigurationParams>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, object, CancellationToken>((_, p, __) => secondParam = (LSP.DidChangeConfigurationParams)p)
+                .ReturnsAsync((object)null);
+
+            await cut.DidChangeConfigurationAsync(CancellationToken.None);
+
+            var config = (LspConfigurationParam)secondParam.Settings;
+            // snyk_oss_enabled must carry its real value (changed:false, seeded/untouched), NOT a reset.
+            Assert.NotNull(config.Settings[PflagKeys.SnykOssEnabled].Value);
+        }
+
+        // IDE-2152 fix #7: the reset commit persists settings.json, which the whole persistence
+        // subsystem assumes runs on the UI thread. DidChangeConfigurationAsync commits on the RPC
+        // continuation (a thread-pool thread after `await ...ConfigureAwait(false)`), so without a
+        // marshal it would be the FIRST background-thread settings writer and race the unlocked
+        // UI-thread mutation sites. The commit must therefore run on the main thread. This asserts
+        // CommitPendingResets is invoked while on the JTF main thread (ThreadHelper.CheckAccess()).
+        //
+        // This test is only meaningful if the RPC continuation genuinely resumes OFF the main thread —
+        // otherwise the production `await SwitchToMainThreadAsync(...)` is a no-op in-test and
+        // CheckAccess() would return true even with the marshal deleted (a vacuous guard). To make the
+        // marshal load-bearing, the RPC mock below actually hops to the thread pool before returning, so
+        // after `await Rpc...ConfigureAwait(false)` the continuation is provably on a background thread.
+        [Fact]
+        public async Task DidChangeConfigurationAsync_SuccessfulSend_CommitsOnMainThread()
+        {
+            // Sanity: the test body runs on the JTF main thread under MockedVS. If this ever changes,
+            // the off-thread reasoning below (and the marshal it guards) no longer holds.
+            Assert.True(ThreadHelper.CheckAccess(), "Test must start on the JTF main thread under MockedVS.");
+
+            cut.IsReady = true;
+            TestUtils.SetupOptionsMock(OptionsMock);
+
+            var tracker = new UserOverrideTracker();
+            tracker.MarkSeeded();
+            tracker.ApplyUserResets(new List<string> { PflagKeys.SnykOssEnabled });
+            OptionsManagerMock.Setup(m => m.OverrideTracker).Returns(tracker);
+
+            bool? committedOnMainThread = null;
+            OptionsManagerMock
+                .Setup(m => m.CommitPendingResets(It.IsAny<IReadOnlyCollection<string>>()))
+                .Callback<IReadOnlyCollection<string>>(sent =>
+                {
+                    committedOnMainThread = ThreadHelper.CheckAccess();
+                    tracker.CommitPendingResets(sent);
+                });
+
+            // The RPC continuation state captured at the moment the mock returns is exactly the context
+            // the production code resumes onto after `await Rpc...ConfigureAwait(false)` (i.e. BEFORE the
+            // marshal on line ~618). We force a real thread hop so this point is off the main thread.
+            bool? onMainThreadWhenRpcReturned = null;
+            jsonRpcMock
+                .Setup(x => x.InvokeWithParameterObjectAsync<object>(
+                    LsConstants.WorkspaceChangeConfiguration,
+                    It.IsAny<LSP.DidChangeConfigurationParams>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<string, object, CancellationToken>(async (_, __, ___) =>
+                {
+                    // Genuinely leave the main thread: Task.Yield hands off, Task.Run guarantees a
+                    // thread-pool thread. ConfigureAwait(false) keeps the completion off the main thread
+                    // so the production continuation resumes on the thread pool.
+                    await Task.Yield();
+                    await Task.Run(() => { }).ConfigureAwait(false);
+                    onMainThreadWhenRpcReturned = ThreadHelper.CheckAccess();
+                    return null;
+                });
+
+            await cut.DidChangeConfigurationAsync(CancellationToken.None);
+
+            // Precondition for the assertion below to have any teeth: the continuation was genuinely off
+            // the main thread when the RPC completed. If this is true, the ONLY way CheckAccess() can be
+            // true inside CommitPendingResets is the production SwitchToMainThreadAsync marshal.
+            Assert.True(onMainThreadWhenRpcReturned.HasValue, "The RPC mock did not run.");
+            Assert.False(onMainThreadWhenRpcReturned.Value,
+                "The RPC continuation must resume OFF the main thread for this test to guard the marshal; " +
+                "if it stayed on the main thread the assertion below would pass vacuously.");
+
+            Assert.True(committedOnMainThread.HasValue, "CommitPendingResets was not invoked on a successful send.");
+            Assert.True(committedOnMainThread.Value,
+                "CommitPendingResets (which persists settings.json) must run on the UI thread, not the RPC " +
+                "continuation thread — otherwise it is a background settings writer that races UI-thread saves. " +
+                "Because the RPC continuation resumed off the main thread (asserted above), this can only be " +
+                "true via the production SwitchToMainThreadAsync marshal — deleting it makes this assertion fail.");
+        }
+
+        // IDE-2152 fix #3: overlapping DidChangeConfigurationAsync calls must be SERIALIZED — the
+        // peek→send→commit sequence runs one at a time. With a single reset queued and two concurrent
+        // calls, the second must not invoke the RPC until the first has finished; and the reset must be
+        // delivered exactly once as a reset (the second call peeks AFTER the first committed, so it sees
+        // an empty queue and sends the real value). Before the gate, both calls peeked the same queue
+        // and double-delivered the reset.
+        [Fact]
+        public async Task DidChangeConfigurationAsync_OverlappingCalls_AreSerialized_NoDoubleDelivery()
+        {
+            cut.IsReady = true;
+            var tracker = ArrangeTrackerWithPendingReset(PflagKeys.SnykOssEnabled);
+
+            var firstSendEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFirstSend = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var sentParams = new System.Collections.Concurrent.ConcurrentQueue<LSP.DidChangeConfigurationParams>();
+            var callCount = 0;
+
+            jsonRpcMock
+                .Setup(x => x.InvokeWithParameterObjectAsync<object>(
+                    LsConstants.WorkspaceChangeConfiguration,
+                    It.IsAny<LSP.DidChangeConfigurationParams>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<string, object, CancellationToken>(async (_, p, __) =>
+                {
+                    var n = Interlocked.Increment(ref callCount);
+                    sentParams.Enqueue((LSP.DidChangeConfigurationParams)p);
+                    if (n == 1)
+                    {
+                        firstSendEntered.TrySetResult(true);
+                        await releaseFirstSend.Task.ConfigureAwait(false); // hold the gate
+                    }
+                    return null;
+                });
+
+            // Start the first call; it enters the RPC send and blocks there (holding configSendGate).
+            var first = cut.DidChangeConfigurationAsync(CancellationToken.None);
+            await firstSendEntered.Task;
+
+            // Start the second call while the first is still in-flight. It must block on the gate and
+            // NOT invoke the RPC yet.
+            var second = cut.DidChangeConfigurationAsync(CancellationToken.None);
+            await Task.Delay(100); // give the second call a chance to (wrongly) proceed if unserialized
+            Assert.Equal(1, Volatile.Read(ref callCount)); // second must be blocked on the gate
+
+            // Release the first send; both calls complete.
+            releaseFirstSend.TrySetResult(true);
+            await Task.WhenAll(first, second);
+
+            Assert.Equal(2, Volatile.Read(ref callCount));
+
+            // The reset was delivered on exactly ONE of the two sends (the first). The second, having
+            // run after the first committed, must NOT re-send the reset.
+            var payloads = sentParams.ToArray();
+            var resetDeliveries = 0;
+            foreach (var payload in payloads)
+            {
+                var cfg = (LspConfigurationParam)payload.Settings;
+                if (cfg.Settings[PflagKeys.SnykOssEnabled].Value == null &&
+                    cfg.Settings[PflagKeys.SnykOssEnabled].Changed)
+                {
+                    resetDeliveries++;
+                }
+            }
+            Assert.Equal(1, resetDeliveries);
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, tracker.PeekPendingResets());
+        }
 
         [Fact]
         public void Rpc_Disconnected_ShouldSetIsReadyToFalse()

--- a/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientTest.cs
@@ -218,6 +218,13 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
         [Fact]
         public async Task DidChangeConfigurationAsync_SuccessfulSend_CommitsOnMainThread()
         {
+            // xUnit runs async [Fact] bodies on a thread-pool thread, not the JTF main thread. Under
+            // MockedVS the framework pumps a mocked main thread, so this is the supported way to bring the
+            // test body onto it (VSSDKTestFx docs). It must run before the guard below. It also keeps the
+            // main thread pumping while we await DidChangeConfigurationAsync, so the production
+            // SwitchToMainThreadAsync marshal can resolve re-entrantly.
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             // Sanity: the test body runs on the JTF main thread under MockedVS. If this ever changes,
             // the off-thread reasoning below (and the marshal it guards) no longer holds.
             Assert.True(ThreadHelper.CheckAccess(), "Test must start on the JTF main thread under MockedVS.");

--- a/Snyk.VisualStudio.Extension.Tests/Language/UserOverrideTrackerTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/UserOverrideTrackerTests.cs
@@ -529,5 +529,53 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             var resets = sut.ConsumePendingResets();
             Assert.Contains(PflagKeys.SnykOssEnabled, resets); // edited key reset to default must produce pending reset
         }
+
+        // PR-REV-001: Re-typing the same org-pushed value the user genuinely owns must still be
+        // recorded as an override when the form sends the key.
+        // OLD behaviour (snapshot/diff path): before==after equality caused the key to be DROPPED
+        // from the edit-delta, so a user who re-typed a value that happened to equal the current
+        // (org-pushed) Options value would lose their override mark.
+        // NEW behaviour (form-driven): if the form sent the key (HasValue/!=null) it is in
+        // editedKeys, so ApplyUserEdits sees it. Even when the current value is non-default,
+        // the key is classified by IsDefault → Mark (not Unmark), and the override is preserved.
+        [Fact]
+        public void ApplyUserEdits_ReTypingSameOrgPushedValue_IsStillRecordedAsOverride()
+        {
+            // Simulate: org pushed OssEnabled=false (non-default). The tracker was NOT updated
+            // (updateOverrideTracker:false on the LS-push path), so OssEnabled is NOT marked.
+            var options = DefaultOptions();
+            options.SetupGet(x => x.OssEnabled).Returns(false); // org-pushed non-default value
+
+            // User re-types the same value (false) in the form — the form sends the key.
+            // The form-driven approach records this as an edit because the form sent the key.
+            sut.ApplyUserEdits(options.Object, new List<string> { PflagKeys.SnykOssEnabled });
+
+            // The key must be marked as a user override (value is non-default).
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled),
+                "Re-typing an org-pushed non-default value must be recorded as an override " +
+                "because the form sent the key — the value is non-default so IsDefault→Mark");
+        }
+
+        // PR-REV-002: ApplyUserEdits with AdditionalParameters key (List<string> in options,
+        // but the tracker compares the space-joined string representation) must record an override
+        // when the user types any non-empty value. Previously the snapshot/diff path used
+        // ToString() on a List<string> ("System.Collections.Generic.List`1[System.String]") and
+        // compared it to the string "System.Collections.Generic.List`1[System.String]" — which
+        // always compared as equal, so editing AdditionalParameters never registered.
+        [Fact]
+        public void ApplyUserEdits_AdditionalParameters_RecordsOverrideWhenNonEmpty()
+        {
+            // Options: AdditionalParameters has a non-default value (non-empty list → space-joined non-empty string).
+            var options = DefaultOptions();
+            options.SetupGet(x => x.AdditionalParameters).Returns(new List<string> { "--debug" });
+
+            // The form sent additional_parameters.
+            sut.ApplyUserEdits(options.Object, new List<string> { PflagKeys.AdditionalParameters });
+
+            // Must be marked as a user override.
+            Assert.True(sut.IsChanged(PflagKeys.AdditionalParameters),
+                "AdditionalParameters with a non-empty list must be marked as an override — " +
+                "the tracker normalises it to a space-joined string before comparing to default");
+        }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/Language/UserOverrideTrackerTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/UserOverrideTrackerTests.cs
@@ -1,0 +1,544 @@
+// ABOUTME: Unit tests for UserOverrideTracker covering UNIT-001..010 from the IDE-2152 test plan.
+using System.Collections.Generic;
+using Moq;
+using Snyk.VisualStudio.Extension.Authentication;
+using Snyk.VisualStudio.Extension.Download;
+using Snyk.VisualStudio.Extension.Language;
+using Snyk.VisualStudio.Extension.Settings;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.Language
+{
+    public class UserOverrideTrackerTests
+    {
+        private readonly UserOverrideTracker sut = new UserOverrideTracker();
+
+        // Helper: build a mock options with all global keys at their plugin defaults.
+        private static Mock<ISnykOptions> DefaultOptions()
+        {
+            var o = new Mock<ISnykOptions>();
+            o.SetupGet(x => x.OssEnabled).Returns(true);
+            o.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true);
+            o.SetupGet(x => x.IacEnabled).Returns(true);
+            o.SetupGet(x => x.SecretsEnabled).Returns(false);
+            o.SetupGet(x => x.AutoScan).Returns(true);
+            o.SetupGet(x => x.EnableDeltaFindings).Returns(false);
+            o.SetupGet(x => x.FilterCritical).Returns(true);
+            o.SetupGet(x => x.FilterHigh).Returns(true);
+            o.SetupGet(x => x.FilterMedium).Returns(true);
+            o.SetupGet(x => x.FilterLow).Returns(true);
+            o.SetupGet(x => x.OpenIssuesEnabled).Returns(true);
+            o.SetupGet(x => x.IgnoredIssuesEnabled).Returns(false);
+            o.SetupGet(x => x.CustomEndpoint).Returns((string)null);
+            o.SetupGet(x => x.Organization).Returns((string)null);
+            o.SetupGet(x => x.IgnoreUnknownCA).Returns(false);
+            o.SetupGet(x => x.BinariesAutoUpdate).Returns(true);
+            o.SetupGet(x => x.CliCustomPath).Returns(string.Empty);
+            o.SetupGet(x => x.CliReleaseChannel).Returns(SnykCliDownloader.DefaultReleaseChannel);
+            o.SetupGet(x => x.CliBaseDownloadURL).Returns(SnykCliDownloader.DefaultBaseDownloadUrl);
+            o.SetupGet(x => x.AdditionalEnv).Returns(string.Empty);
+            o.SetupGet(x => x.AdditionalParameters).Returns(new List<string>());
+            o.SetupGet(x => x.RiskScoreThreshold).Returns((int?)null);
+            o.SetupGet(x => x.TrustedFolders).Returns(new System.Collections.Generic.HashSet<string>());
+            // Token and AuthenticationMethod at their defaults.
+            o.SetupGet(x => x.ApiToken).Returns(
+                new AuthenticationToken(AuthenticationType.OAuth, string.Empty));
+            o.SetupGet(x => x.AuthenticationMethod).Returns(default(AuthenticationType));
+            return o;
+        }
+
+        // UNIT-001: IsChanged returns true for a key that is in the tracked (marked) set.
+        [Fact]
+        public void IsChanged_TrackedKey_True()
+        {
+            sut.Mark(PflagKeys.SnykOssEnabled);
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled));
+        }
+
+        // UNIT-002: IsChanged returns true for a key that is in AlwaysChanged even if never marked.
+        [Fact]
+        public void IsChanged_AlwaysChangedKey_True()
+        {
+            Assert.True(sut.IsChanged(PflagKeys.TrustedFolders));
+        }
+
+        // UNIT-003: IsChanged returns false for a key that is neither marked nor always-changed.
+        [Fact]
+        public void IsChanged_UntrackedKey_False()
+        {
+            Assert.False(sut.IsChanged(PflagKeys.SnykOssEnabled));
+        }
+
+        // UNIT-004: Unmark enqueues a pending reset; ConsumePendingResets returns it once, then empty.
+        [Fact]
+        public void Unmark_EnqueuesPendingReset_ConsumedOnce()
+        {
+            sut.Mark(PflagKeys.SnykOssEnabled);
+            sut.Unmark(PflagKeys.SnykOssEnabled);
+
+            var first = sut.ConsumePendingResets();
+            Assert.Contains(PflagKeys.SnykOssEnabled, first);
+
+            var second = sut.ConsumePendingResets();
+            Assert.Empty(second);
+        }
+
+        // R6-1: SeedFrom has replace-semantics — a prior Mark is cleared when SeedFrom is called
+        // with all-default options, even without an explicit ClearChanged() before SeedFrom.
+        // Confirms SeedFrom is self-consistent and a future direct caller cannot accumulate stale marks.
+        [Fact]
+        public void SeedFrom_ClearsPriorMarks_ReplaceSemantics()
+        {
+            // Prime with a non-default mark.
+            sut.Mark(PflagKeys.SnykOssEnabled);
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled), "Precondition: key must be marked");
+
+            // SeedFrom with all-default options — should clear the prior mark.
+            sut.SeedFrom(DefaultOptions().Object);
+
+            Assert.Empty(sut.Snapshot(),
+                "SeedFrom with all-default options must clear prior marks — replace, not accumulate");
+            Assert.False(sut.IsChanged(PflagKeys.SnykOssEnabled),
+                "A key marked before SeedFrom(all-defaults) must no longer be considered changed");
+        }
+
+        // R7-2: SeedFrom clears pendingResets (via Clear(), not just ClearChanged()).
+        // A pending reset enqueued before SeedFrom must NOT survive into the next BuildSettingsMap call;
+        // emitting Reset() for a key the user never touched would send spurious {value:null, changed:true}
+        // signals to the LS on the very first DidChangeConfiguration after startup.
+        [Fact]
+        public void SeedFrom_ClearsPendingResets_NotJustChangedSet()
+        {
+            // Enqueue a pending reset: Mark → Unmark leaves a reset in the queue.
+            sut.Mark(PflagKeys.SnykOssEnabled);
+            sut.Unmark(PflagKeys.SnykOssEnabled); // pendingResets now contains SnykOssEnabled
+
+            // SeedFrom with all-default options (simulates upgrade / first-load path).
+            sut.SeedFrom(DefaultOptions().Object);
+
+            // The pending reset must be gone — Clear() at the top of SeedFrom drains it.
+            var resets = sut.ConsumePendingResets();
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, resets,
+                "SeedFrom must clear pendingResets (uses Clear(), not ClearChanged()). " +
+                "A stale pending reset before SeedFrom must NOT survive into BuildSettingsMap.");
+        }
+
+        // UNIT-005: SeedFrom marks only keys whose persisted value differs from the plugin default.
+        [Fact]
+        public void SeedFrom_MarksOnlyNonDefaultKeys()
+        {
+            // All at plugin defaults except OssEnabled which is set to false (non-default).
+            var options = DefaultOptions();
+            options.SetupGet(o => o.OssEnabled).Returns(false);
+
+            sut.SeedFrom(options.Object);
+
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled), "Non-default OssEnabled should be marked");
+            Assert.False(sut.IsChanged(PflagKeys.SnykCodeEnabled), "Default SnykCodeEnabled should NOT be marked");
+        }
+
+        // UNIT-006: ApplyUserEdits unmarks a key when the user resets it to its default,
+        // and enqueues a pending reset for it so BuildSettingsMap can emit {value:null, changed:true}.
+        [Fact]
+        public void ApplyUserEdits_ReturnToDefault_UnmarksAndEnqueuesReset()
+        {
+            // Prime the tracker: OssEnabled was previously overridden.
+            sut.Mark(PflagKeys.SnykOssEnabled);
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled));
+
+            // User resets OssEnabled to the default (true). Provide it as an edited key.
+            var options = DefaultOptions();
+            options.SetupGet(o => o.OssEnabled).Returns(true); // back to default
+
+            sut.ApplyUserEdits(options.Object, new List<string> { PflagKeys.SnykOssEnabled });
+
+            Assert.False(sut.IsChanged(PflagKeys.SnykOssEnabled), "Key returned to default should be unmarked");
+            var pending = sut.ConsumePendingResets();
+            Assert.Contains(PflagKeys.SnykOssEnabled, pending);
+        }
+
+        // UNIT-009 (finding 1): SeedFrom marks Token when ApiToken is non-empty,
+        // and AuthenticationMethod when non-default. Does not mark when at defaults.
+        [Fact]
+        public void SeedFrom_NonDefaultTokenAndAuthMethod_AreBothMarked()
+        {
+            var options = DefaultOptions();
+            options.SetupGet(x => x.ApiToken).Returns(
+                new AuthenticationToken(AuthenticationType.Pat, "my-secret-token"));
+            options.SetupGet(x => x.AuthenticationMethod).Returns(AuthenticationType.Pat);
+
+            sut.SeedFrom(options.Object);
+
+            Assert.True(sut.IsChanged(PflagKeys.Token),
+                "Non-empty token should be marked as changed");
+            Assert.True(sut.IsChanged(PflagKeys.AuthenticationMethod),
+                "Non-default auth method should be marked as changed");
+        }
+
+        [Fact]
+        public void SeedFrom_DefaultTokenAndAuthMethod_AreNotMarked()
+        {
+            var options = DefaultOptions();
+            // ApiToken = empty string (default), AuthenticationMethod = OAuth (default)
+
+            sut.SeedFrom(options.Object);
+
+            Assert.False(sut.IsChanged(PflagKeys.Token),
+                "Empty token (default) should NOT be marked as changed");
+            Assert.False(sut.IsChanged(PflagKeys.AuthenticationMethod),
+                "Default auth method (OAuth) should NOT be marked as changed");
+        }
+
+        // UNIT-010 (finding 3): ApplyUserEdits with null RiskScoreThreshold after it was marked
+        // should unmark it AND enqueue a pending reset so the LS can clear the value.
+        [Fact]
+        public void ApplyUserEdits_RiskScoreThresholdClearedToNull_UnmarksAndEnqueuesReset()
+        {
+            // Seed: threshold was set to 70 (non-default).
+            sut.Mark(PflagKeys.RiskScoreThreshold);
+            Assert.True(sut.IsChanged(PflagKeys.RiskScoreThreshold));
+
+            // User cleared the threshold (returned to default null).
+            var options = DefaultOptions();
+            options.SetupGet(x => x.RiskScoreThreshold).Returns((int?)null);
+
+            sut.ApplyUserEdits(options.Object, new List<string> { PflagKeys.RiskScoreThreshold });
+
+            Assert.False(sut.IsChanged(PflagKeys.RiskScoreThreshold),
+                "Cleared RiskScoreThreshold should be unmarked");
+            var pending = sut.ConsumePendingResets();
+            Assert.Contains(PflagKeys.RiskScoreThreshold, pending);
+        }
+
+        // UNIT-011 (finding 4): Calling Clear() then re-seeding reflects only new data.
+        [Fact]
+        public void Clear_ThenReSeed_ReflectsOnlyNewData()
+        {
+            // First seed: OssEnabled non-default.
+            sut.Mark(PflagKeys.SnykOssEnabled);
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled));
+
+            // Clear and re-seed with all defaults.
+            sut.Clear();
+            var allDefaults = DefaultOptions();
+            sut.SeedFrom(allDefaults.Object);
+
+            // After clear + re-seed with defaults, OssEnabled should no longer be marked.
+            Assert.False(sut.IsChanged(PflagKeys.SnykOssEnabled),
+                "After Clear(), stale marks from first seed should be gone");
+        }
+
+        // S1: SeedFrom with null CliBaseDownloadURL / CliReleaseChannel must NOT mark those
+        // keys changed — null should fall back to the canonical defaults, not to "" which
+        // would differ from ConfigDefaults[BinaryBaseUrl/CliReleaseChannel].
+        [Fact]
+        public void SeedFrom_NullCliUrlAndChannel_NotMarkedChanged()
+        {
+            var options = DefaultOptions();
+            // Simulate SnykOptions with no initializer-set value for these fields.
+            options.SetupGet(x => x.CliBaseDownloadURL).Returns((string)null);
+            options.SetupGet(x => x.CliReleaseChannel).Returns((string)null);
+
+            sut.SeedFrom(options.Object);
+
+            Assert.False(sut.IsChanged(PflagKeys.BinaryBaseUrl),
+                "null CliBaseDownloadURL must fall back to canonical default, not be marked changed");
+            Assert.False(sut.IsChanged(PflagKeys.CliReleaseChannel),
+                "null CliReleaseChannel must fall back to canonical default, not be marked changed");
+        }
+
+        // S3: GetGlobalKeyValues must cover exactly the same Cs()-wrapped keys as BuildSettingsMap,
+        // excluding the always-Of() keys (DeviceId, ClientProtocolVersion) which are never tracked.
+        // This test fails if a key is added to one site but forgotten at the other.
+        [Fact]
+        public void GetGlobalKeyValues_CoversExactlySameKeysAsBuiltSettingsMapTrackerKeys()
+        {
+            // Keys BuildSettingsMap passes through Cs() — the tracker-gated keys.
+            // DeviceId and ClientProtocolVersion are excluded (always sent via ConfigSetting.Of).
+            var buildSettingsMapTrackerKeys = new System.Collections.Generic.HashSet<string>
+            {
+                PflagKeys.SnykOssEnabled,
+                PflagKeys.SnykCodeEnabled,
+                PflagKeys.SnykIacEnabled,
+                PflagKeys.SnykSecretsEnabled,
+                PflagKeys.ScanAutomatic,
+                PflagKeys.ScanNetNew,
+                PflagKeys.SeverityFilterCritical,
+                PflagKeys.SeverityFilterHigh,
+                PflagKeys.SeverityFilterMedium,
+                PflagKeys.SeverityFilterLow,
+                PflagKeys.IssueViewOpenIssues,
+                PflagKeys.IssueViewIgnoredIssues,
+                PflagKeys.ApiEndpoint,
+                PflagKeys.Token,
+                PflagKeys.Organization,
+                PflagKeys.AuthenticationMethod,
+                PflagKeys.ProxyInsecure,
+                PflagKeys.AutomaticDownload,
+                PflagKeys.CliPath,
+                PflagKeys.BinaryBaseUrl,
+                PflagKeys.CliReleaseChannel,
+                PflagKeys.TrustedFolders,
+                PflagKeys.AdditionalEnvironment,
+                PflagKeys.AdditionalParameters,
+                PflagKeys.RiskScoreThreshold,
+            };
+
+            // Keys yielded by GetGlobalKeyValues (via SeedFrom on a fresh tracker).
+            // We drive it through SeedFrom to collect what GetGlobalKeyValues actually yields.
+            // Use a custom ISnykOptions that records which keys were touched is complex —
+            // instead call SeedFrom with all-defaults-plus-one-non-default-per-key and inspect
+            // via reflection. Simpler: call SeedFrom with all non-defaults, then Snapshot gives
+            // exactly the yielded keys (any key not yielded would not be in the snapshot).
+            var trackerForKeys = new UserOverrideTracker();
+
+            // Build options where every value is non-default so every key gets marked.
+            var allNonDefault = new Mock<ISnykOptions>();
+            allNonDefault.SetupGet(x => x.OssEnabled).Returns(false); // non-default
+            allNonDefault.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(false);
+            allNonDefault.SetupGet(x => x.IacEnabled).Returns(false);
+            allNonDefault.SetupGet(x => x.SecretsEnabled).Returns(true);
+            allNonDefault.SetupGet(x => x.AutoScan).Returns(false);
+            allNonDefault.SetupGet(x => x.EnableDeltaFindings).Returns(true);
+            allNonDefault.SetupGet(x => x.FilterCritical).Returns(false);
+            allNonDefault.SetupGet(x => x.FilterHigh).Returns(false);
+            allNonDefault.SetupGet(x => x.FilterMedium).Returns(false);
+            allNonDefault.SetupGet(x => x.FilterLow).Returns(false);
+            allNonDefault.SetupGet(x => x.OpenIssuesEnabled).Returns(false);
+            allNonDefault.SetupGet(x => x.IgnoredIssuesEnabled).Returns(true);
+            allNonDefault.SetupGet(x => x.CustomEndpoint).Returns("https://custom.endpoint");
+            allNonDefault.SetupGet(x => x.ApiToken).Returns(
+                new Authentication.AuthenticationToken(Authentication.AuthenticationType.Pat, "tok"));
+            allNonDefault.SetupGet(x => x.AuthenticationMethod).Returns(Authentication.AuthenticationType.Pat);
+            allNonDefault.SetupGet(x => x.Organization).Returns("my-org");
+            allNonDefault.SetupGet(x => x.IgnoreUnknownCA).Returns(true);
+            allNonDefault.SetupGet(x => x.BinariesAutoUpdate).Returns(false);
+            allNonDefault.SetupGet(x => x.CliCustomPath).Returns("/custom/cli");
+            allNonDefault.SetupGet(x => x.CliReleaseChannel).Returns("rc");
+            allNonDefault.SetupGet(x => x.CliBaseDownloadURL).Returns("https://other.cdn");
+            allNonDefault.SetupGet(x => x.AdditionalEnv).Returns("FOO=bar");
+            allNonDefault.SetupGet(x => x.AdditionalParameters).Returns(new List<string> { "--flag" });
+            allNonDefault.SetupGet(x => x.RiskScoreThreshold).Returns((int?)70);
+            // TrustedFolders: non-empty so not equal to default empty-set.
+            allNonDefault.SetupGet(x => x.TrustedFolders).Returns(
+                new System.Collections.Generic.HashSet<string> { "/some/path" });
+
+            trackerForKeys.SeedFrom(allNonDefault.Object);
+            var trackedKeys = trackerForKeys.Snapshot();
+
+            // Every key in BuildSettingsMap's Cs() set must be yielded by GetGlobalKeyValues.
+            foreach (var key in buildSettingsMapTrackerKeys)
+            {
+                // AlwaysChanged keys are always IsChanged=true regardless of Snapshot,
+                // so exclude them from the Snapshot check (they never appear in the changed set).
+                if (PflagKeys.IsAlwaysChanged(key)) continue;
+                Assert.Contains(key, trackedKeys,
+                    $"GetGlobalKeyValues must yield '{key}' — it is tracked by BuildSettingsMap via Cs() " +
+                    "but was not found in the tracker snapshot after SeedFrom with all-non-default options");
+            }
+
+            // Conversely, no key should appear in the tracker that isn't in the BuildSettingsMap set.
+            foreach (var key in trackedKeys)
+            {
+                Assert.Contains(key, buildSettingsMapTrackerKeys,
+                    $"GetGlobalKeyValues yielded '{key}' which is NOT in BuildSettingsMap's Cs() key set — " +
+                    "remove it from GetGlobalKeyValues or add it to BuildSettingsMap");
+            }
+        }
+
+        // R3-1: ClearChanged() resets only the `changed` set, NOT the pendingResets queue.
+        // A pending reset enqueued by ApplyUserEdits before Load() must survive the Load's ClearChanged call.
+        [Fact]
+        public void ClearChanged_PreservesPendingResets_ClearsOnlyChanged()
+        {
+            // Enqueue a pending reset: mark then Unmark directly (the same outcome as ApplyUserEdits
+            // when the user resets a key to its default — Unmark is the primitive that enqueues).
+            sut.Mark(PflagKeys.SnykOssEnabled);
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled));
+
+            sut.Unmark(PflagKeys.SnykOssEnabled); // enqueues pending reset, removes from changed
+
+            // Pending reset for SnykOssEnabled is queued; changed set has it removed.
+            Assert.False(sut.IsChanged(PflagKeys.SnykOssEnabled));
+
+            // Also mark a second key so ClearChanged has something to clear.
+            sut.Mark(PflagKeys.SnykCodeEnabled);
+            Assert.True(sut.IsChanged(PflagKeys.SnykCodeEnabled));
+
+            // ClearChanged() — must clear changed but NOT pendingResets.
+            sut.ClearChanged();
+
+            // The stale mark for SnykCodeEnabled is gone.
+            Assert.False(sut.IsChanged(PflagKeys.SnykCodeEnabled),
+                "ClearChanged() must clear the changed set");
+
+            // The pending reset for SnykOssEnabled is still consumable.
+            var resets = sut.ConsumePendingResets();
+            Assert.Contains(PflagKeys.SnykOssEnabled, resets,
+                "ClearChanged() must NOT discard pending resets — they are still needed by BuildSettingsMap");
+        }
+
+        // R3-2: Mark() for an AlwaysChanged key must be a no-op on the changed set.
+        // IsChanged still returns true (via IsAlwaysChanged) but Snapshot() must be empty.
+        [Fact]
+        public void Mark_AlwaysChangedKey_NotAddedToChangedSet()
+        {
+            sut.Mark(PflagKeys.TrustedFolders);
+
+            // Snapshot must not contain it (it's not in the changed set).
+            Assert.Empty(sut.Snapshot());
+
+            // IsChanged must still return true (via IsAlwaysChanged).
+            Assert.True(sut.IsChanged(PflagKeys.TrustedFolders),
+                "IsChanged must still be true for an always-changed key even when not in the changed set");
+        }
+
+        // R5-1a: IsSeeded is false on a fresh tracker instance.
+        [Fact]
+        public void IsSeeded_FreshTracker_IsFalse()
+        {
+            var fresh = new UserOverrideTracker();
+            Assert.False(fresh.IsSeeded,
+                "A freshly constructed tracker must not be seeded — it has no persisted data loaded");
+        }
+
+        // R5-1b: IsSeeded becomes true after SeedFrom is called (upgrade / first-load path).
+        [Fact]
+        public void IsSeeded_AfterSeedFrom_IsTrue()
+        {
+            var tracker = new UserOverrideTracker();
+            Assert.False(tracker.IsSeeded);
+
+            tracker.SeedFrom(DefaultOptions().Object);
+
+            Assert.True(tracker.IsSeeded,
+                "IsSeeded must be true after SeedFrom — tracker is now hydrated from persistence");
+        }
+
+        // R5-1c: ClearChanged does NOT reset IsSeeded (reload re-hydrates but tracker stays seeded).
+        [Fact]
+        public void IsSeeded_ClearChanged_DoesNotReset()
+        {
+            var tracker = new UserOverrideTracker();
+            tracker.SeedFrom(DefaultOptions().Object);
+            Assert.True(tracker.IsSeeded);
+
+            tracker.ClearChanged();
+
+            Assert.True(tracker.IsSeeded,
+                "ClearChanged() must not reset IsSeeded — a reload re-hydrates without losing seeded status");
+        }
+
+        // R5-1d: Clear() does NOT reset IsSeeded either.
+        [Fact]
+        public void IsSeeded_Clear_DoesNotReset()
+        {
+            var tracker = new UserOverrideTracker();
+            tracker.SeedFrom(DefaultOptions().Object);
+            Assert.True(tracker.IsSeeded);
+
+            tracker.Clear();
+
+            Assert.True(tracker.IsSeeded,
+                "Clear() must not reset IsSeeded — once seeded, the tracker is always considered seeded");
+        }
+
+        // R5-1e: MarkSeeded() sets IsSeeded to true (covers the Load() persisted-keys branch
+        // which calls Mark in a loop then calls MarkSeeded() explicitly).
+        [Fact]
+        public void IsSeeded_AfterMarkSeeded_IsTrue()
+        {
+            var tracker = new UserOverrideTracker();
+            Assert.False(tracker.IsSeeded);
+
+            tracker.MarkSeeded();
+
+            Assert.True(tracker.IsSeeded,
+                "MarkSeeded() must set IsSeeded to true — it is called by Load() after the " +
+                "persisted-keys Mark-loop to signal the tracker is hydrated");
+        }
+
+        // R4-1: Mark after Unmark (Mark→Unmark→Mark cycle) must cancel the pending reset.
+        // Scenario: user sets OssEnabled=false (Mark), resets to default true (Unmark → pending reset),
+        // then sets false again (Mark). The next ConsumePendingResets() must NOT contain OssEnabled
+        // because the user re-applied the override — sending Reset() would silently drop their change.
+        [Fact]
+        public void Mark_AfterUnmark_CancelsPendingReset()
+        {
+            // Arrange: Mark → Unmark → Mark cycle.
+            sut.Mark(PflagKeys.SnykOssEnabled);
+            sut.Unmark(PflagKeys.SnykOssEnabled);   // enqueues pending reset
+            sut.Mark(PflagKeys.SnykOssEnabled);      // user re-applies the override
+
+            // Assert: pending reset must be cancelled (not in ConsumePendingResets output).
+            var resets = sut.ConsumePendingResets();
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, resets,
+                "Mark() after Unmark() must cancel the pending reset — " +
+                "otherwise BuildSettingsMap overwrites the active override with a Reset() signal");
+
+            // Assert: IsChanged must be true because the key is back in the changed set.
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled),
+                "IsChanged must be true after re-marking a key");
+        }
+
+        // RUNIT-001: ApplyUserEdits only marks / unmarks the explicitly edited keys.
+        // Keys NOT in editedKeys must be completely untouched — whether previously marked or not.
+        [Fact]
+        public void ApplyUserEdits_OnlyEditedKeysAffected_UntouchedKeysUnchanged()
+        {
+            // Pre-condition: OssEnabled and IacEnabled are both marked (previously overridden).
+            sut.Mark(PflagKeys.SnykOssEnabled);
+            sut.Mark(PflagKeys.SnykIacEnabled);
+
+            // Options: OssEnabled=false (non-default), IacEnabled=true (default).
+            var options = DefaultOptions();
+            options.SetupGet(x => x.OssEnabled).Returns(false);
+            options.SetupGet(x => x.IacEnabled).Returns(true); // at default
+
+            // editedKeys: only OssEnabled is in the edit delta (the user only touched OssEnabled).
+            var editedKeys = new List<string> { PflagKeys.SnykOssEnabled };
+
+            sut.ApplyUserEdits(options.Object, editedKeys);
+
+            // OssEnabled was edited and its value (false) deviates from default (true) → must be marked.
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled),
+                "An edited key with a non-default value must be marked");
+
+            // IacEnabled was NOT in editedKeys → its prior mark must be preserved (not cleared).
+            Assert.True(sut.IsChanged(PflagKeys.SnykIacEnabled),
+                "A key NOT in editedKeys must not be touched — its prior mark must survive");
+
+            // SnykCodeEnabled was not in editedKeys and was never marked → must remain unmarked.
+            Assert.False(sut.IsChanged(PflagKeys.SnykCodeEnabled),
+                "A key NOT in editedKeys and not previously marked must remain unmarked");
+        }
+
+        // RUNIT-002: ApplyUserEdits with an edited key whose new value equals the plugin default
+        // must unmark it and enqueue a pending reset — not mark it.
+        [Fact]
+        public void ApplyUserEdits_EditedKeyEqualToDefault_UnmarksAndEnqueuesReset()
+        {
+            // Pre-condition: OssEnabled is marked (user previously set it to non-default).
+            sut.Mark(PflagKeys.SnykOssEnabled);
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled));
+
+            // Options: OssEnabled=true (its plugin default), meaning the user just reset it.
+            var options = DefaultOptions();
+            options.SetupGet(x => x.OssEnabled).Returns(true); // at default
+
+            // The user's save included OssEnabled in the edit delta.
+            var editedKeys = new List<string> { PflagKeys.SnykOssEnabled };
+
+            sut.ApplyUserEdits(options.Object, editedKeys);
+
+            // Must be unmarked.
+            Assert.False(sut.IsChanged(PflagKeys.SnykOssEnabled),
+                "An edited key whose new value equals the default must be unmarked");
+
+            // Must have a pending reset so BuildSettingsMap can emit {value:null, changed:true}.
+            var resets = sut.ConsumePendingResets();
+            Assert.Contains(PflagKeys.SnykOssEnabled, resets,
+                "An edited key reset to default must produce a pending reset signal");
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/Language/UserOverrideTrackerTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/UserOverrideTrackerTests.cs
@@ -1,5 +1,8 @@
 // ABOUTME: Unit tests for UserOverrideTracker covering UNIT-001..010 from the IDE-2152 test plan.
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Moq;
 using Snyk.VisualStudio.Extension.Authentication;
 using Snyk.VisualStudio.Extension.Download;
@@ -69,17 +72,20 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.False(sut.IsChanged(PflagKeys.SnykOssEnabled));
         }
 
-        // UNIT-004: Unmark enqueues a pending reset; ConsumePendingResets returns it once, then empty.
+        // UNIT-004: Unmark enqueues a pending reset; PeekPendingResets returns it, and after
+        // CommitPendingResets confirms delivery the queue no longer contains it.
         [Fact]
-        public void Unmark_EnqueuesPendingReset_ConsumedOnce()
+        public void Unmark_EnqueuesPendingReset_ClearedAfterCommit()
         {
             sut.Mark(PflagKeys.SnykOssEnabled);
             sut.Unmark(PflagKeys.SnykOssEnabled);
 
-            var first = sut.ConsumePendingResets();
+            var first = sut.PeekPendingResets();
             Assert.Contains(PflagKeys.SnykOssEnabled, first);
 
-            var second = sut.ConsumePendingResets();
+            sut.CommitPendingResets(first);
+
+            var second = sut.PeekPendingResets();
             Assert.Empty(second);
         }
 
@@ -116,7 +122,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             sut.SeedFrom(DefaultOptions().Object);
 
             // The pending reset must be gone — Clear() at the top of SeedFrom drains it.
-            var resets = sut.ConsumePendingResets();
+            var resets = sut.PeekPendingResets();
             Assert.DoesNotContain(PflagKeys.SnykOssEnabled, resets); // SeedFrom must drain pendingResets
         }
 
@@ -153,7 +159,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             // Edited key is an explicit user choice → remains marked; no reset inferred from default.
             Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled),
                 "An edited key at the default value must remain marked — reset is not inferred here");
-            var pending = sut.ConsumePendingResets();
+            var pending = sut.PeekPendingResets();
             Assert.DoesNotContain(PflagKeys.SnykOssEnabled, pending);
         }
 
@@ -203,7 +209,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             Assert.True(sut.IsChanged(PflagKeys.RiskScoreThreshold),
                 "An edited RiskScoreThreshold key is an explicit user choice and must be marked");
-            var pending = sut.ConsumePendingResets();
+            var pending = sut.PeekPendingResets();
             Assert.DoesNotContain(PflagKeys.RiskScoreThreshold, pending); // no inferred reset from value==default
         }
 
@@ -366,7 +372,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
                 "ClearChanged() must clear the changed set");
 
             // The pending reset for SnykOssEnabled is still consumable.
-            var resets = sut.ConsumePendingResets();
+            var resets = sut.PeekPendingResets();
             Assert.Contains(PflagKeys.SnykOssEnabled, resets); // ClearChanged must NOT discard pending resets
         }
 
@@ -452,7 +458,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
         // R4-1: Mark after Unmark (Mark→Unmark→Mark cycle) must cancel the pending reset.
         // Scenario: user sets OssEnabled=false (Mark), resets to default true (Unmark → pending reset),
-        // then sets false again (Mark). The next ConsumePendingResets() must NOT contain OssEnabled
+        // then sets false again (Mark). The pending-reset queue must NOT contain OssEnabled
         // because the user re-applied the override — sending Reset() would silently drop their change.
         [Fact]
         public void Mark_AfterUnmark_CancelsPendingReset()
@@ -462,8 +468,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             sut.Unmark(PflagKeys.SnykOssEnabled);   // enqueues pending reset
             sut.Mark(PflagKeys.SnykOssEnabled);      // user re-applies the override
 
-            // Assert: pending reset must be cancelled (not in ConsumePendingResets output).
-            var resets = sut.ConsumePendingResets();
+            // Assert: pending reset must be cancelled (not in the pending-reset queue).
+            var resets = sut.PeekPendingResets();
             Assert.DoesNotContain(PflagKeys.SnykOssEnabled, resets); // Mark after Unmark must cancel pending reset
 
             // Assert: IsChanged must be true because the key is back in the changed set.
@@ -528,7 +534,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
                 "and must be marked changed — reset is never inferred from value==default");
 
             // No reset must be enqueued via this path — value==default no longer implies a reset.
-            var resets = sut.ConsumePendingResets();
+            var resets = sut.PeekPendingResets();
             Assert.DoesNotContain(PflagKeys.SnykCodeEnabled, resets); // no inferred reset from value==default
         }
 
@@ -558,6 +564,163 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
                 "because the form sent the key — the value is non-default so IsDefault→Mark");
         }
 
+        // IDE-2152-UNIT-003a: Peek is non-destructive — the reset stays queued after a peek, so a
+        // build-without-commit (e.g. a config send that fails) does not lose the reset intent.
+        [Fact]
+        public void PeekPendingResets_IsNonDestructive_QueueSurvives()
+        {
+            sut.ApplyUserResets(new List<string> { PflagKeys.SnykOssEnabled });
+
+            var first = sut.PeekPendingResets();
+            Assert.Contains(PflagKeys.SnykOssEnabled, first);
+
+            // A second peek still sees it — nothing was consumed.
+            var second = sut.PeekPendingResets();
+            Assert.Contains(PflagKeys.SnykOssEnabled, second);
+        }
+
+        // IDE-2152-UNIT-003b: Commit clears only the named (delivered) keys, never the whole queue.
+        [Fact]
+        public void CommitPendingResets_ClearsOnlyNamedKeys()
+        {
+            sut.ApplyUserResets(new List<string> { PflagKeys.SnykOssEnabled, PflagKeys.SnykCodeEnabled });
+
+            // Only OssEnabled was delivered.
+            sut.CommitPendingResets(new List<string> { PflagKeys.SnykOssEnabled });
+
+            var remaining = sut.PeekPendingResets();
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, remaining); // delivered → cleared
+            Assert.Contains(PflagKeys.SnykCodeEnabled, remaining);      // not delivered → still queued
+        }
+
+        // IDE-2152-UNIT-003c: A reset for a DIFFERENT key enqueued between the peek (what the build
+        // folded in and sent) and the commit must survive the commit — commit removes exactly the
+        // sent set, never a blanket clear. This is the interleaving the re-delivery design must not
+        // lose: the newer key was never in the confirmed message, so it must remain queued.
+        [Fact]
+        public void CommitPendingResets_InterleavedResetForDifferentKey_Survives()
+        {
+            sut.ApplyUserResets(new List<string> { PflagKeys.SnykOssEnabled });
+            var peeked = sut.PeekPendingResets(); // what the build folded in and sent
+
+            // Between the send and the commit, a reset for a different key is enqueued.
+            sut.ApplyUserResets(new List<string> { PflagKeys.SnykCodeEnabled });
+
+            // The send is confirmed only for the originally peeked keys; commit removes exactly those.
+            sut.CommitPendingResets(peeked);
+
+            var remaining = sut.PeekPendingResets();
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, remaining); // delivered → cleared
+            Assert.Contains(PflagKeys.SnykCodeEnabled, remaining);      // enqueued after send → survives
+        }
+
+        // IDE-2152-UNIT-003d: CommitPendingResets is a safe no-op on null/empty.
+        [Fact]
+        public void CommitPendingResets_NullOrEmpty_IsNoOp()
+        {
+            sut.ApplyUserResets(new List<string> { PflagKeys.SnykOssEnabled });
+
+            sut.CommitPendingResets(null);
+            sut.CommitPendingResets(new List<string>());
+
+            Assert.Contains(PflagKeys.SnykOssEnabled, sut.PeekPendingResets());
+        }
+
+        // IDE-2152-UNIT-002a: ApplyUserResets un-marks each reset key (drops out of Snapshot) and
+        // enqueues a pending reset that BuildSettingsMap will consume as {value:null, changed:true}.
+        [Fact]
+        public void ApplyUserResets_UnmarksKey_AndEnqueuesPendingReset()
+        {
+            // The key was previously a user override.
+            sut.Mark(PflagKeys.SnykOssEnabled);
+            Assert.Contains(PflagKeys.SnykOssEnabled, sut.Snapshot());
+
+            sut.ApplyUserResets(new List<string> { PflagKeys.SnykOssEnabled });
+
+            // No longer a persisted override.
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, sut.Snapshot());
+            Assert.False(sut.IsChanged(PflagKeys.SnykOssEnabled));
+
+            // Reset signal is queued.
+            var resets = sut.PeekPendingResets();
+            Assert.Contains(PflagKeys.SnykOssEnabled, resets);
+        }
+
+        // IDE-2152-UNIT-002b: A form reset ALWAYS enqueues the LS reset signal — even when the plugin
+        // had no local mark for the key (e.g. an org-pushed value the user wants cleared). Local
+        // un-mark is best-effort; the LS still needs {value:null, changed:true} to Unset user:global.
+        [Fact]
+        public void ApplyUserResets_KeyNeverMarked_StillEnqueuesResetSignal()
+        {
+            Assert.DoesNotContain(PflagKeys.Organization, sut.Snapshot()); // precondition: no mark
+
+            sut.ApplyUserResets(new List<string> { PflagKeys.Organization });
+
+            var resets = sut.PeekPendingResets();
+            Assert.Contains(PflagKeys.Organization, resets);
+        }
+
+        // IDE-2152-UNIT-002c: Re-enabling a key (Mark) after a reset was queued cancels that reset —
+        // the user re-applied an override, so the next build must not clobber it with a reset signal.
+        [Fact]
+        public void ApplyUserResets_ThenMark_CancelsQueuedReset()
+        {
+            sut.ApplyUserResets(new List<string> { PflagKeys.SnykOssEnabled }); // reset queued
+            sut.Mark(PflagKeys.SnykOssEnabled); // user re-applies the override
+
+            var resets = sut.PeekPendingResets();
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, resets);
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled));
+        }
+
+        // IDE-2152-UNIT-002d: ApplyUserResets with a null/empty set is a harmless no-op.
+        [Fact]
+        public void ApplyUserResets_NullOrEmpty_IsNoOp()
+        {
+            sut.Mark(PflagKeys.SnykOssEnabled);
+
+            sut.ApplyUserResets(null);
+            sut.ApplyUserResets(new List<string>());
+
+            Assert.Contains(PflagKeys.SnykOssEnabled, sut.Snapshot());
+            Assert.Empty(sut.PeekPendingResets());
+        }
+
+        // IDE-2152-UNIT-P1 (fix #2): RehydratePendingResets re-queues persisted-but-unconfirmed resets
+        // on Load without un-marking anything (Load hydrates `changed` separately). The rehydrated key
+        // must appear in the pending-reset queue for re-delivery.
+        [Fact]
+        public void RehydratePendingResets_ReQueuesPersistedReset()
+        {
+            sut.RehydratePendingResets(new List<string> { PflagKeys.SnykOssEnabled });
+
+            Assert.Contains(PflagKeys.SnykOssEnabled, sut.PeekPendingResets());
+        }
+
+        // IDE-2152-UNIT-P2 (fix #2): RehydratePendingResets must NOT re-queue a reset for a key that is
+        // a live override mark — a persisted override means the user re-applied the key after the reset
+        // was queued, so the override wins (invariant: never in both `changed` and pendingResets).
+        [Fact]
+        public void RehydratePendingResets_SkipsKeyThatIsLiveOverride()
+        {
+            sut.Mark(PflagKeys.SnykOssEnabled); // live override
+
+            sut.RehydratePendingResets(new List<string> { PflagKeys.SnykOssEnabled });
+
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, sut.PeekPendingResets());
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled));
+        }
+
+        // IDE-2152-UNIT-P3 (fix #2): RehydratePendingResets with a null/empty set is a harmless no-op.
+        [Fact]
+        public void RehydratePendingResets_NullOrEmpty_IsNoOp()
+        {
+            sut.RehydratePendingResets(null);
+            sut.RehydratePendingResets(new List<string>());
+
+            Assert.Empty(sut.PeekPendingResets());
+        }
+
         // PR-REV-002: ApplyUserEdits with AdditionalParameters key (List<string> in options,
         // but the tracker compares the space-joined string representation) must record an override
         // when the user types any non-empty value. Previously the snapshot/diff path used
@@ -578,6 +741,108 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.True(sut.IsChanged(PflagKeys.AdditionalParameters),
                 "AdditionalParameters with a non-empty list must be marked as an override — " +
                 "the tracker normalises it to a space-joined string before comparing to default");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // THREAD-SAFETY tests (IDE-2152 critical fix #1)
+        // The tracker's `changed` / `pendingResets` are mutated from the UI thread (Save →
+        // ApplyUserEdits/ApplyUserResets) AND from thread-pool continuations (the config-send
+        // path commits after `await ...ConfigureAwait(false)`), from multiple fire-and-forget
+        // call sites. Every read and mutation must be guarded by a single lock, and Peek/Snapshot
+        // must return an independent copy taken under the lock.
+        // ─────────────────────────────────────────────────────────────────────
+
+        // TS-001: Snapshot returns an independent copy — mutating the tracker after taking a
+        // snapshot must not change the already-returned snapshot, and vice versa.
+        [Fact]
+        public void Snapshot_ReturnsIndependentCopy()
+        {
+            sut.Mark(PflagKeys.SnykOssEnabled);
+
+            var snap = sut.Snapshot();
+            Assert.Contains(PflagKeys.SnykOssEnabled, snap);
+
+            // Mutate the tracker after the snapshot was taken.
+            sut.Mark(PflagKeys.SnykCodeEnabled);
+            // The previously-returned snapshot must be unaffected.
+            Assert.DoesNotContain(PflagKeys.SnykCodeEnabled, snap);
+
+            // Mutating the returned copy must not affect the tracker.
+            snap.Add(PflagKeys.SnykIacEnabled);
+            Assert.False(sut.IsChanged(PflagKeys.SnykIacEnabled),
+                "Mutating the returned Snapshot copy must not leak back into the tracker");
+        }
+
+        // TS-002: PeekPendingResets returns an independent copy — enqueuing a further reset after a
+        // peek must not change the already-returned peek result.
+        [Fact]
+        public void PeekPendingResets_ReturnsIndependentCopy()
+        {
+            sut.ApplyUserResets(new List<string> { PflagKeys.SnykOssEnabled });
+
+            var peek = sut.PeekPendingResets();
+            Assert.Contains(PflagKeys.SnykOssEnabled, peek);
+
+            sut.ApplyUserResets(new List<string> { PflagKeys.SnykCodeEnabled });
+            Assert.DoesNotContain(PflagKeys.SnykCodeEnabled, peek);
+        }
+
+        // TS-003: Concurrent access from many threads must not throw or corrupt state, and the core
+        // invariant — a key is never simultaneously in both `changed` and `pendingResets` — must
+        // hold after the storm. With plain (unsynchronised) HashSets this test throws
+        // InvalidOperationException ("collection was modified") or corrupts the sets; the single
+        // lock makes every method atomic so it passes.
+        [Fact]
+        public void ConcurrentAccess_DoesNotThrowOrCorruptState()
+        {
+            var keys = new[]
+            {
+                PflagKeys.SnykOssEnabled, PflagKeys.SnykCodeEnabled, PflagKeys.SnykIacEnabled,
+                PflagKeys.SnykSecretsEnabled, PflagKeys.ScanAutomatic, PflagKeys.ScanNetNew,
+                PflagKeys.SeverityFilterCritical, PflagKeys.SeverityFilterHigh,
+                PflagKeys.SeverityFilterMedium, PflagKeys.SeverityFilterLow,
+            };
+
+            const int threads = 8;
+            const int iterations = 2000;
+            var barrier = new Barrier(threads);
+            var exceptions = new System.Collections.Concurrent.ConcurrentQueue<System.Exception>();
+
+            var tasks = Enumerable.Range(0, threads).Select(t => Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                try
+                {
+                    for (var i = 0; i < iterations; i++)
+                    {
+                        var key = keys[(t + i) % keys.Length];
+                        switch (i % 6)
+                        {
+                            case 0: sut.Mark(key); break;
+                            case 1: sut.ApplyUserResets(new List<string> { key }); break;
+                            case 2: sut.CommitPendingResets(sut.PeekPendingResets()); break;
+                            case 3: _ = sut.Snapshot(); break;
+                            case 4: _ = sut.IsChanged(key); break;
+                            case 5: sut.ApplyUserEdits(null, new List<string> { key }); break;
+                        }
+                    }
+                }
+                catch (System.Exception ex)
+                {
+                    exceptions.Enqueue(ex);
+                }
+            })).ToArray();
+
+            Task.WaitAll(tasks);
+
+            Assert.True(exceptions.IsEmpty,
+                "Concurrent tracker access must not throw — the internal sets must be lock-guarded. " +
+                "First exception: " + (exceptions.TryPeek(out var first) ? first.ToString() : "none"));
+
+            // Invariant: no key is in both the changed set and the pending-reset queue.
+            var changed = sut.Snapshot();
+            var resets = sut.PeekPendingResets();
+            Assert.Empty(changed.Intersect(resets));
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/Language/UserOverrideTrackerTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/UserOverrideTrackerTests.cs
@@ -96,8 +96,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             // SeedFrom with all-default options — should clear the prior mark.
             sut.SeedFrom(DefaultOptions().Object);
 
-            Assert.Empty(sut.Snapshot(),
-                "SeedFrom with all-default options must clear prior marks — replace, not accumulate");
+            Assert.Empty(sut.Snapshot()); // SeedFrom with all-default options must clear prior marks
             Assert.False(sut.IsChanged(PflagKeys.SnykOssEnabled),
                 "A key marked before SeedFrom(all-defaults) must no longer be considered changed");
         }
@@ -118,9 +117,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             // The pending reset must be gone — Clear() at the top of SeedFrom drains it.
             var resets = sut.ConsumePendingResets();
-            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, resets,
-                "SeedFrom must clear pendingResets (uses Clear(), not ClearChanged()). " +
-                "A stale pending reset before SeedFrom must NOT survive into BuildSettingsMap.");
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, resets); // SeedFrom must drain pendingResets
         }
 
         // UNIT-005: SeedFrom marks only keys whose persisted value differs from the plugin default.
@@ -308,8 +305,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             allNonDefault.SetupGet(x => x.IgnoredIssuesEnabled).Returns(true);
             allNonDefault.SetupGet(x => x.CustomEndpoint).Returns("https://custom.endpoint");
             allNonDefault.SetupGet(x => x.ApiToken).Returns(
-                new Authentication.AuthenticationToken(Authentication.AuthenticationType.Pat, "tok"));
-            allNonDefault.SetupGet(x => x.AuthenticationMethod).Returns(Authentication.AuthenticationType.Pat);
+                new AuthenticationToken(AuthenticationType.Pat, "tok"));
+            allNonDefault.SetupGet(x => x.AuthenticationMethod).Returns(AuthenticationType.Pat);
             allNonDefault.SetupGet(x => x.Organization).Returns("my-org");
             allNonDefault.SetupGet(x => x.IgnoreUnknownCA).Returns(true);
             allNonDefault.SetupGet(x => x.BinariesAutoUpdate).Returns(false);
@@ -332,17 +329,13 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
                 // AlwaysChanged keys are always IsChanged=true regardless of Snapshot,
                 // so exclude them from the Snapshot check (they never appear in the changed set).
                 if (PflagKeys.IsAlwaysChanged(key)) continue;
-                Assert.Contains(key, trackedKeys,
-                    $"GetGlobalKeyValues must yield '{key}' — it is tracked by BuildSettingsMap via Cs() " +
-                    "but was not found in the tracker snapshot after SeedFrom with all-non-default options");
+                Assert.Contains(key, trackedKeys); // GetGlobalKeyValues must yield this key
             }
 
             // Conversely, no key should appear in the tracker that isn't in the BuildSettingsMap set.
             foreach (var key in trackedKeys)
             {
-                Assert.Contains(key, buildSettingsMapTrackerKeys,
-                    $"GetGlobalKeyValues yielded '{key}' which is NOT in BuildSettingsMap's Cs() key set — " +
-                    "remove it from GetGlobalKeyValues or add it to BuildSettingsMap");
+                Assert.Contains(key, buildSettingsMapTrackerKeys); // key must be in BuildSettingsMap Cs() set
             }
         }
 
@@ -374,8 +367,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             // The pending reset for SnykOssEnabled is still consumable.
             var resets = sut.ConsumePendingResets();
-            Assert.Contains(PflagKeys.SnykOssEnabled, resets,
-                "ClearChanged() must NOT discard pending resets — they are still needed by BuildSettingsMap");
+            Assert.Contains(PflagKeys.SnykOssEnabled, resets); // ClearChanged must NOT discard pending resets
         }
 
         // R3-2: Mark() for an AlwaysChanged key must be a no-op on the changed set.
@@ -472,9 +464,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             // Assert: pending reset must be cancelled (not in ConsumePendingResets output).
             var resets = sut.ConsumePendingResets();
-            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, resets,
-                "Mark() after Unmark() must cancel the pending reset — " +
-                "otherwise BuildSettingsMap overwrites the active override with a Reset() signal");
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, resets); // Mark after Unmark must cancel pending reset
 
             // Assert: IsChanged must be true because the key is back in the changed set.
             Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled),
@@ -537,8 +527,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
             // Must have a pending reset so BuildSettingsMap can emit {value:null, changed:true}.
             var resets = sut.ConsumePendingResets();
-            Assert.Contains(PflagKeys.SnykOssEnabled, resets,
-                "An edited key reset to default must produce a pending reset signal");
+            Assert.Contains(PflagKeys.SnykOssEnabled, resets); // edited key reset to default must produce pending reset
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/Language/UserOverrideTrackerTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/UserOverrideTrackerTests.cs
@@ -134,24 +134,27 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.False(sut.IsChanged(PflagKeys.SnykCodeEnabled), "Default SnykCodeEnabled should NOT be marked");
         }
 
-        // UNIT-006: ApplyUserEdits unmarks a key when the user resets it to its default,
-        // and enqueues a pending reset for it so BuildSettingsMap can emit {value:null, changed:true}.
+        // UNIT-006 (corrected semantics, PR #515): ApplyUserEdits marks every edited key — even one
+        // whose value equals the plugin default — and never infers a reset from value==default.
+        // Setting a key to its default value via the form is still an explicit user choice.
         [Fact]
-        public void ApplyUserEdits_ReturnToDefault_UnmarksAndEnqueuesReset()
+        public void ApplyUserEdits_EditedKeyAtDefaultValue_StaysMarked_NoInferredReset()
         {
             // Prime the tracker: OssEnabled was previously overridden.
             sut.Mark(PflagKeys.SnykOssEnabled);
             Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled));
 
-            // User resets OssEnabled to the default (true). Provide it as an edited key.
+            // User re-applies OssEnabled at the default (true) through the form; it is in the delta.
             var options = DefaultOptions();
-            options.SetupGet(o => o.OssEnabled).Returns(true); // back to default
+            options.SetupGet(o => o.OssEnabled).Returns(true); // equals default
 
             sut.ApplyUserEdits(options.Object, new List<string> { PflagKeys.SnykOssEnabled });
 
-            Assert.False(sut.IsChanged(PflagKeys.SnykOssEnabled), "Key returned to default should be unmarked");
+            // Edited key is an explicit user choice → remains marked; no reset inferred from default.
+            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled),
+                "An edited key at the default value must remain marked — reset is not inferred here");
             var pending = sut.ConsumePendingResets();
-            Assert.Contains(PflagKeys.SnykOssEnabled, pending);
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, pending);
         }
 
         // UNIT-009 (finding 1): SeedFrom marks Token when ApiToken is non-empty,
@@ -186,25 +189,22 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
                 "Default auth method (OAuth) should NOT be marked as changed");
         }
 
-        // UNIT-010 (finding 3): ApplyUserEdits with null RiskScoreThreshold after it was marked
-        // should unmark it AND enqueue a pending reset so the LS can clear the value.
+        // UNIT-010 (corrected semantics, PR #515): ApplyUserEdits with the RiskScoreThreshold key in
+        // the edit delta marks it as an explicit user choice and does NOT infer a reset from
+        // value==default (null). Reset-to-default is no longer derived inside ApplyUserEdits.
         [Fact]
-        public void ApplyUserEdits_RiskScoreThresholdClearedToNull_UnmarksAndEnqueuesReset()
+        public void ApplyUserEdits_RiskScoreThresholdEdited_MarksChanged_NoInferredReset()
         {
-            // Seed: threshold was set to 70 (non-default).
-            sut.Mark(PflagKeys.RiskScoreThreshold);
-            Assert.True(sut.IsChanged(PflagKeys.RiskScoreThreshold));
-
-            // User cleared the threshold (returned to default null).
+            // User submits the risk-score field; it is in the edit delta with the default (null) value.
             var options = DefaultOptions();
             options.SetupGet(x => x.RiskScoreThreshold).Returns((int?)null);
 
             sut.ApplyUserEdits(options.Object, new List<string> { PflagKeys.RiskScoreThreshold });
 
-            Assert.False(sut.IsChanged(PflagKeys.RiskScoreThreshold),
-                "Cleared RiskScoreThreshold should be unmarked");
+            Assert.True(sut.IsChanged(PflagKeys.RiskScoreThreshold),
+                "An edited RiskScoreThreshold key is an explicit user choice and must be marked");
             var pending = sut.ConsumePendingResets();
-            Assert.Contains(PflagKeys.RiskScoreThreshold, pending);
+            Assert.DoesNotContain(PflagKeys.RiskScoreThreshold, pending); // no inferred reset from value==default
         }
 
         // UNIT-011 (finding 4): Calling Clear() then re-seeding reflects only new data.
@@ -503,31 +503,33 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
                 "A key NOT in editedKeys and not previously marked must remain unmarked");
         }
 
-        // RUNIT-002: ApplyUserEdits with an edited key whose new value equals the plugin default
-        // must unmark it and enqueue a pending reset — not mark it.
+        // RUNIT-002 (corrected semantics, PR #515): ApplyUserEdits with an edited key whose new
+        // value equals the plugin default must MARK it (changed:true) and must NOT enqueue a reset.
+        //
+        // This is the core of the "enabling Snyk Code doesn't persist" fix: any key the form posted
+        // (present in editedKeys) is an explicit user choice. Snyk Code's default is `true`, so a
+        // user *enabling* it posts a value equal to the default — the OLD code inferred a reset from
+        // value==default and let the org default win. Reset-to-default is no longer inferred here.
         [Fact]
-        public void ApplyUserEdits_EditedKeyEqualToDefault_UnmarksAndEnqueuesReset()
+        public void ApplyUserEdits_EditedKeyEqualToDefault_MarksChanged_NoReset()
         {
-            // Pre-condition: OssEnabled is marked (user previously set it to non-default).
-            sut.Mark(PflagKeys.SnykOssEnabled);
-            Assert.True(sut.IsChanged(PflagKeys.SnykOssEnabled));
-
-            // Options: OssEnabled=true (its plugin default), meaning the user just reset it.
+            // The user enables Snyk Code (posts true, which equals the plugin default true).
             var options = DefaultOptions();
-            options.SetupGet(x => x.OssEnabled).Returns(true); // at default
+            options.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true); // at default
 
-            // The user's save included OssEnabled in the edit delta.
-            var editedKeys = new List<string> { PflagKeys.SnykOssEnabled };
+            // The user's save included snyk_code_enabled in the edit delta.
+            var editedKeys = new List<string> { PflagKeys.SnykCodeEnabled };
 
             sut.ApplyUserEdits(options.Object, editedKeys);
 
-            // Must be unmarked.
-            Assert.False(sut.IsChanged(PflagKeys.SnykOssEnabled),
-                "An edited key whose new value equals the default must be unmarked");
+            // An edited key is an explicit user choice → must be marked, even at the default value.
+            Assert.True(sut.IsChanged(PflagKeys.SnykCodeEnabled),
+                "An edited key whose value equals the default is still an explicit user choice " +
+                "and must be marked changed — reset is never inferred from value==default");
 
-            // Must have a pending reset so BuildSettingsMap can emit {value:null, changed:true}.
+            // No reset must be enqueued via this path — value==default no longer implies a reset.
             var resets = sut.ConsumePendingResets();
-            Assert.Contains(PflagKeys.SnykOssEnabled, resets); // edited key reset to default must produce pending reset
+            Assert.DoesNotContain(PflagKeys.SnykCodeEnabled, resets); // no inferred reset from value==default
         }
 
         // PR-REV-001: Re-typing the same org-pushed value the user genuinely owns must still be

--- a/Snyk.VisualStudio.Extension.Tests/Service/WorkspaceTrustServiceTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Service/WorkspaceTrustServiceTest.cs
@@ -12,14 +12,17 @@ namespace Snyk.VisualStudio.Extension.Tests.Service
     {
         private readonly Mock<ISnykOptions> optionsMock;
         private readonly Mock<ISnykServiceProvider> serviceProviderMock;
+        private readonly Mock<ISnykOptionsManager> optionsManagerMock;
         private readonly WorkspaceTrustService cut;
 
         public WorkspaceTrustServiceTest()
         {
             optionsMock = new Mock<ISnykOptions>();
             optionsMock.Setup(x => x.TrustedFolders).Returns(new HashSet<string>());
+            optionsManagerMock = new Mock<ISnykOptionsManager>();
             serviceProviderMock = new Mock<ISnykServiceProvider>();
             serviceProviderMock.Setup(x => x.Options).Returns(optionsMock.Object);
+            serviceProviderMock.Setup(x => x.SnykOptionsManager).Returns(optionsManagerMock.Object);
 
             cut = new WorkspaceTrustService(serviceProviderMock.Object);
         }
@@ -125,6 +128,28 @@ namespace Snyk.VisualStudio.Extension.Tests.Service
 
             // Must not append new entry to collection
             optionsMock.VerifySet(s => s.TrustedFolders = new HashSet<string> { folderPath1 }, Times.Exactly(2));
+        }
+
+        [Fact]
+        public void WorkspaceTrustServiceTest_AddFolderToTrusted_DoesNotUpdateOverrideTracker()
+        {
+            optionsMock.Setup(s => s.TrustedFolders).Returns(new HashSet<string>());
+
+            var folderPath = this.CreateTempDirectory();
+
+            cut.AddFolderToTrusted(folderPath);
+
+            // Adding a trusted folder is a system-driven action, not a user override edit, so the
+            // save must NOT run the override-tracker path (updateOverrideTracker == false). Every
+            // other system/LS-driven save already passes updateOverrideTracker:false (IDE-2152).
+            optionsManagerMock.Verify(
+                m => m.Save(
+                    It.IsAny<IPersistableOptions>(),
+                    false,
+                    false,
+                    It.IsAny<IReadOnlyCollection<string>>(),
+                    It.IsAny<IReadOnlyCollection<string>>()),
+                Times.Once);
         }
 
         private string CreateTempDirectory()

--- a/Snyk.VisualStudio.Extension.Tests/Settings/GlobalResetPropagationTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/GlobalResetPropagationTests.cs
@@ -1,0 +1,284 @@
+// ABOUTME: Acceptance + integration tests for global reset-to-default propagation (IDE-2152 CP 2.1).
+// ABOUTME: Drives the real HtmlSettingsScriptingBridge → real SnykOptionsManager → real UserOverrideTracker
+// ABOUTME: → real LsSettingsV25, so the reset flows through the production composition, not a fake at the seam.
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Moq;
+using Newtonsoft.Json;
+using Snyk.VisualStudio.Extension.Authentication;
+using Snyk.VisualStudio.Extension.Download;
+using Snyk.VisualStudio.Extension.Language;
+using Snyk.VisualStudio.Extension.Service;
+using Snyk.VisualStudio.Extension.Settings;
+using Snyk.VisualStudio.Extension.UI.Html;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.Settings
+{
+    [Collection(MockedVS.Collection)]
+    public class GlobalResetPropagationTests
+    {
+        public GlobalResetPropagationTests(GlobalServiceProvider sp)
+        {
+            sp.Reset();
+        }
+
+        // Wire a REAL SnykOptionsManager (temp-file backed) + real UserOverrideTracker into a real
+        // service provider, plus a real bridge and a real LsSettingsV25 reading the same manager.
+        // This is the production composition: the reset must survive every hand-off.
+        private sealed class Harness
+        {
+            public HtmlSettingsScriptingBridge Bridge;
+            public SnykOptionsManager Manager;
+            public LsSettingsV25 LsSettings;
+            public Mock<ISnykOptions> Options;
+            public string Path;
+        }
+
+        private static Harness BuildHarness()
+        {
+            var path = System.IO.Path.GetTempFileName();
+
+            var optMock = new Mock<ISnykOptions>();
+            optMock.SetupAllProperties();
+            // Plugin defaults so an empty save is a no-op and Save() does not null-ref.
+            optMock.Object.OssEnabled = true;
+            optMock.Object.SnykCodeSecurityEnabled = true;
+            optMock.Object.IacEnabled = true;
+            optMock.Object.SecretsEnabled = false;
+            optMock.Object.AutoScan = true;
+            optMock.Object.EnableDeltaFindings = false;
+            optMock.Object.FilterCritical = true;
+            optMock.Object.FilterHigh = true;
+            optMock.Object.FilterMedium = true;
+            optMock.Object.FilterLow = true;
+            optMock.Object.OpenIssuesEnabled = true;
+            optMock.Object.IgnoredIssuesEnabled = false;
+            optMock.Object.IgnoreUnknownCA = false;
+            optMock.Object.BinariesAutoUpdate = true;
+            optMock.Object.CliCustomPath = string.Empty;
+            optMock.Object.CliReleaseChannel = SnykCliDownloader.DefaultReleaseChannel;
+            optMock.Object.CliBaseDownloadURL = SnykCliDownloader.DefaultBaseDownloadUrl;
+            optMock.Object.AdditionalEnv = string.Empty;
+            optMock.Object.AdditionalParameters = new List<string>();
+            optMock.Object.RiskScoreThreshold = null;
+            optMock.Object.TrustedFolders = new HashSet<string>();
+            optMock.Object.DeviceId = "test-device";
+            optMock.Object.Organization = "acme-user-org"; // a user override to be reset
+            optMock.Object.IntegrationEnvironment = "Visual Studio 2022";
+            optMock.Object.IntegrationName = "VISUAL_STUDIO";
+            optMock.Object.IntegrationEnvironmentVersion = "2022";
+            optMock.Object.IntegrationVersion = "1.0.0";
+            optMock.Object.ApiToken = new AuthenticationToken(AuthenticationType.OAuth, string.Empty);
+            optMock.Object.AuthenticationMethod = AuthenticationType.OAuth;
+            optMock.Object.FolderConfigs = new List<FolderConfig>();
+
+            var spMock = new Mock<ISnykServiceProvider>();
+            spMock.Setup(x => x.Options).Returns(optMock.Object);
+            spMock.Setup(x => x.LanguageClientManager).Returns((ILanguageClientManager)null);
+
+            var manager = new SnykOptionsManager(path, spMock.Object);
+            // Wire the real manager into the provider so both the bridge and LsSettingsV25 use the
+            // same tracker instance (the production composition root behaviour).
+            spMock.Setup(x => x.SnykOptionsManager).Returns(manager);
+
+            var bridge = new HtmlSettingsScriptingBridge(spMock.Object, onModified: () => { });
+            var lsSettings = new LsSettingsV25(spMock.Object);
+
+            return new Harness
+            {
+                Bridge = bridge,
+                Manager = manager,
+                LsSettings = lsSettings,
+                Options = optMock,
+                Path = path,
+            };
+        }
+
+        // IDE-2152-ACCEPT-001: When a user resets global settings to default (a form save payload with
+        // those keys posted as explicit JSON null), the settings the plugin sends to the LS clear those
+        // keys as {value:null, changed:true} so the org/LDX-sync default takes effect again.
+        // Covers a bool key (snyk_code_enabled), a string key (organization) and the unset int key
+        // (risk_score_threshold, which the value path never emits).
+        [Fact]
+        public void ResetPayload_ClearsKeysInLsBoundSettingsMap()
+        {
+            var h = BuildHarness();
+            try
+            {
+                h.Manager.Load(); // seed the real tracker
+
+                // The "Reset overrides" form save: the reset-eligible keys are posted as explicit null.
+                var payload = "{" +
+                    "\"snyk_code_enabled\":null," +
+                    "\"organization\":null," +
+                    "\"risk_score_threshold\":null" +
+                    "}";
+
+                h.Bridge.__saveIdeConfig__(payload);
+                Assert.True(h.Bridge.SaveCompletion.IsCompleted);
+                Assert.True(h.Bridge.SaveCompletion.Result, "the reset save must succeed");
+
+                var map = h.LsSettings.BuildSettingsMap(h.Options.Object);
+
+                AssertReset(map, PflagKeys.SnykCodeEnabled);
+                AssertReset(map, PflagKeys.Organization);
+                AssertReset(map, PflagKeys.RiskScoreThreshold);
+            }
+            finally
+            {
+                File.Delete(h.Path);
+            }
+        }
+
+        // IDE-2152-INTEG-001: A reset save un-marks the key so it no longer appears in the persisted
+        // override set and stays cleared across a reload (fresh manager over the same file).
+        [Fact]
+        public void ResetSave_UnmarksKey_StaysClearedAcrossReload()
+        {
+            var h = BuildHarness();
+            try
+            {
+                h.Manager.Load();
+
+                // First: the user overrides snyk_code_enabled (edit to non-default false).
+                h.Options.Object.SnykCodeSecurityEnabled = false;
+                h.Manager.Save(h.Options.Object, triggerSettingsChangedEvent: false,
+                    editedKeys: new List<string> { PflagKeys.SnykCodeEnabled });
+                Assert.Contains(PflagKeys.SnykCodeEnabled, h.Manager.OverrideTracker.Snapshot());
+
+                // Then: the user resets it. Reset payload posts snyk_code_enabled as JSON null.
+                h.Bridge.__saveIdeConfig__("{\"snyk_code_enabled\":null}");
+                Assert.True(h.Bridge.SaveCompletion.Result);
+
+                // The key must be gone from the tracker's persisted set.
+                Assert.DoesNotContain(PflagKeys.SnykCodeEnabled, h.Manager.OverrideTracker.Snapshot());
+
+                // And it must stay cleared across a restart (fresh manager over the same file).
+                var spMock2 = new Mock<ISnykServiceProvider>();
+                spMock2.Setup(x => x.Options).Returns(h.Options.Object);
+                var manager2 = new SnykOptionsManager(h.Path, spMock2.Object);
+                spMock2.Setup(x => x.SnykOptionsManager).Returns(manager2);
+                var loaded = manager2.Load();
+
+                Assert.DoesNotContain(PflagKeys.SnykCodeEnabled,
+                    loaded.ChangedConfigKeys ?? new HashSet<string>());
+            }
+            finally
+            {
+                File.Delete(h.Path);
+            }
+        }
+
+        // IDE-2152-INTEG-002: A reset for organization (string) and risk_score_threshold (unset int)
+        // both reach the LS as reset signals through the production bridge → manager → LsSettings path.
+        [Fact]
+        public void Reset_OrganizationAndRiskScoreThreshold_BothReachLs()
+        {
+            var h = BuildHarness();
+            try
+            {
+                h.Manager.Load();
+
+                h.Bridge.__saveIdeConfig__("{\"organization\":null,\"risk_score_threshold\":null}");
+                Assert.True(h.Bridge.SaveCompletion.Result);
+
+                var map = h.LsSettings.BuildSettingsMap(h.Options.Object);
+
+                AssertReset(map, PflagKeys.Organization);
+                AssertReset(map, PflagKeys.RiskScoreThreshold);
+            }
+            finally
+            {
+                File.Delete(h.Path);
+            }
+        }
+
+        // IDE-2152 critical fix #2: A reset applied while the LS was not ready (so the reset signal
+        // was never confirmed-delivered) must SURVIVE a restart and be re-emitted by BuildSettingsMap
+        // after a Save→Load round-trip through a fresh manager over the same settings file. Before the
+        // fix, the reset lived only in the in-memory pendingResets queue, so it was lost on restart and
+        // the LS override was never cleared.
+        [Fact]
+        public void PendingReset_SurvivesRestart_ReEmittedByBuildSettingsMapAfterReload()
+        {
+            var h = BuildHarness();
+            try
+            {
+                h.Manager.Load(); // seed the real tracker
+
+                // The user resets a global setting. The reset is queued but (simulating "LS not ready")
+                // it is never committed via a confirmed config send — it stays pending.
+                h.Bridge.__saveIdeConfig__("{\"snyk_code_enabled\":null,\"organization\":null}");
+                Assert.True(h.Bridge.SaveCompletion.Result, "the reset save must succeed");
+                // Precondition: the reset is queued in the (unconfirmed) pending set.
+                Assert.Contains(PflagKeys.SnykCodeEnabled, h.Manager.OverrideTracker.PeekPendingResets());
+
+                // Simulate an IDE restart: a FRESH manager + FRESH LsSettings over the SAME file.
+                var spMock2 = new Mock<ISnykServiceProvider>();
+                spMock2.Setup(x => x.Options).Returns(h.Options.Object);
+                var manager2 = new SnykOptionsManager(h.Path, spMock2.Object);
+                spMock2.Setup(x => x.SnykOptionsManager).Returns(manager2);
+                var lsSettings2 = new LsSettingsV25(spMock2.Object);
+
+                manager2.Load(); // rehydrates the persisted pending resets
+
+                // The un-confirmed reset must have survived the restart and be re-emitted to the LS.
+                var map = lsSettings2.BuildSettingsMap(h.Options.Object);
+                AssertReset(map, PflagKeys.SnykCodeEnabled);
+                AssertReset(map, PflagKeys.Organization);
+            }
+            finally
+            {
+                File.Delete(h.Path);
+            }
+        }
+
+        // IDE-2152 critical fix #2: A reset that WAS confirmed-delivered (committed via the manager's
+        // CommitPendingResets) must be removed from persistence too, so it is NOT re-sent after a
+        // restart. Otherwise every delivered reset would be re-delivered forever.
+        [Fact]
+        public void CommittedReset_RemovedFromPersistence_NotReEmittedAfterRestart()
+        {
+            var h = BuildHarness();
+            try
+            {
+                h.Manager.Load();
+
+                h.Bridge.__saveIdeConfig__("{\"snyk_code_enabled\":null}");
+                Assert.True(h.Bridge.SaveCompletion.Result);
+                Assert.Contains(PflagKeys.SnykCodeEnabled, h.Manager.OverrideTracker.PeekPendingResets());
+
+                // The config send is confirmed successful → commit through the manager (which must also
+                // update persistence, not just the in-memory queue).
+                h.Manager.CommitPendingResets(new List<string> { PflagKeys.SnykCodeEnabled });
+                Assert.DoesNotContain(PflagKeys.SnykCodeEnabled, h.Manager.OverrideTracker.PeekPendingResets());
+
+                // Restart: fresh manager + LsSettings over the same file.
+                var spMock2 = new Mock<ISnykServiceProvider>();
+                spMock2.Setup(x => x.Options).Returns(h.Options.Object);
+                var manager2 = new SnykOptionsManager(h.Path, spMock2.Object);
+                spMock2.Setup(x => x.SnykOptionsManager).Returns(manager2);
+                var lsSettings2 = new LsSettingsV25(spMock2.Object);
+                manager2.Load();
+
+                // The committed reset must NOT come back as a reset signal — its real value is sent.
+                var map = lsSettings2.BuildSettingsMap(h.Options.Object);
+                Assert.NotNull(map[PflagKeys.SnykCodeEnabled].Value); // not a reset (value:null)
+                Assert.Empty(manager2.OverrideTracker.PeekPendingResets());
+            }
+            finally
+            {
+                File.Delete(h.Path);
+            }
+        }
+
+        private static void AssertReset(IDictionary<string, ConfigSetting> map, string key)
+        {
+            Assert.True(map.ContainsKey(key), $"{key} must be present as a reset signal");
+            Assert.Null(map[key].Value);
+            Assert.True(map[key].Changed, $"{key} reset must be changed:true");
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/Settings/GlobalResetPropagationTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/GlobalResetPropagationTests.cs
@@ -67,9 +67,9 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
             optMock.Object.DeviceId = "test-device";
             optMock.Object.Organization = "acme-user-org"; // a user override to be reset
             optMock.Object.IntegrationEnvironment = "Visual Studio 2022";
-            optMock.Object.IntegrationName = "VISUAL_STUDIO";
+            optMock.Setup(x => x.IntegrationName).Returns("VISUAL_STUDIO");
             optMock.Object.IntegrationEnvironmentVersion = "2022";
-            optMock.Object.IntegrationVersion = "1.0.0";
+            optMock.Setup(x => x.IntegrationVersion).Returns("1.0.0");
             optMock.Object.ApiToken = new AuthenticationToken(AuthenticationType.OAuth, string.Empty);
             optMock.Object.AuthenticationMethod = AuthenticationType.OAuth;
             optMock.Object.FolderConfigs = new List<FolderConfig>();

--- a/Snyk.VisualStudio.Extension.Tests/Settings/LoadReadUnderPersistGateTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/LoadReadUnderPersistGateTests.cs
@@ -145,7 +145,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
                         return;
                     }
 
-                    if ((this.writerThread.ThreadState & ThreadState.WaitSleepJoin) != 0)
+                    if ((this.writerThread.ThreadState & System.Threading.ThreadState.WaitSleepJoin) != 0)
                     {
                         // Writer is blocked on lock(persistGate) (see thread-state note above): the fix
                         // is holding and the writer cannot enter Save's critical section mid-read.

--- a/Snyk.VisualStudio.Extension.Tests/Settings/LoadReadUnderPersistGateTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/LoadReadUnderPersistGateTests.cs
@@ -1,0 +1,214 @@
+// ABOUTME: Thread-safety test pinning the invariant that SnykOptionsManager.Load() reads the shared
+// ABOUTME: snykSettings object while holding persistGate, so a concurrent Save() cannot mutate those
+// ABOUTME: fields mid-read and yield a torn/mixed options object (PR #515 reviewer finding, IDE-2152).
+// Uses a real SnykOptionsManager + real SnykSettingsLoader on a temp file, with an overridable
+// read-region hook (protected virtual OnLoadReadRegionEntered) as a deterministic interleave seam
+// instead of a flaky sleep-based race.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using Moq;
+using Snyk.VisualStudio.Extension.Authentication;
+using Snyk.VisualStudio.Extension.Download;
+using Snyk.VisualStudio.Extension.Service;
+using Snyk.VisualStudio.Extension.Settings;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.Settings
+{
+    public class LoadReadUnderPersistGateTests
+    {
+        // Build a fully-defaulted options mock so Save() never null-refs (Token/TrustedFolders/params).
+        private static Mock<ISnykOptions> BuildOptions()
+        {
+            var optMock = new Mock<ISnykOptions>();
+            optMock.SetupAllProperties();
+            optMock.Object.OssEnabled = true;
+            optMock.Object.SnykCodeSecurityEnabled = true;
+            optMock.Object.IacEnabled = true;
+            optMock.Object.SecretsEnabled = false;
+            optMock.Object.AutoScan = true;
+            optMock.Object.EnableDeltaFindings = false;
+            optMock.Object.FilterCritical = true;
+            optMock.Object.FilterHigh = true;
+            optMock.Object.FilterMedium = true;
+            optMock.Object.FilterLow = true;
+            optMock.Object.OpenIssuesEnabled = true;
+            optMock.Object.IgnoredIssuesEnabled = false;
+            optMock.Object.IgnoreUnknownCA = false;
+            optMock.Object.BinariesAutoUpdate = true;
+            optMock.Object.CliCustomPath = string.Empty;
+            optMock.Object.CliReleaseChannel = SnykCliDownloader.DefaultReleaseChannel;
+            optMock.Object.CliBaseDownloadURL = SnykCliDownloader.DefaultBaseDownloadUrl;
+            optMock.Object.AdditionalEnv = string.Empty;
+            optMock.Object.AdditionalParameters = new List<string>();
+            optMock.Object.TrustedFolders = new HashSet<string>();
+            optMock.Object.DeviceId = "load-gate-device";
+            optMock.Object.ApiToken = new AuthenticationToken(AuthenticationType.OAuth, string.Empty);
+            return optMock;
+        }
+
+        // A manager that, on the first Load() read region, launches a concurrent Save() on a DEDICATED
+        // thread (standing in for an LS-push Save on a StreamJsonRpc dispatch thread) and asserts the
+        // writer is BLOCKED on persistGate while Load()'s read region is executing — using a DETERMINISTIC
+        // state transition, not a wall-clock timeout.
+        //
+        // Why a dedicated Thread (not Task.Run) and why observe ThreadState: the decision must not depend
+        // on how quickly the writer is scheduled or on how long File.WriteAllText takes. While this read
+        // region holds persistGate, the writer's Save() will, in a CORRECT build, block on lock(persistGate)
+        // and park in ThreadState.WaitSleepJoin; in a REGRESSION build (read region not under the gate) the
+        // writer instead acquires the free lock and fires OnSaveCriticalSectionEntered, setting
+        // saveEnteredCriticalSection. We spin until ONE of those two definite states is observed, so the
+        // outcome is a true state transition rather than "did the seam fire within 200ms". An earlier
+        // version waited a fixed 200ms on the event; on a thread-pool-starved runner a REGRESSION build
+        // could keep the writer off-CPU for >200ms, the wait would return false, and the test would
+        // false-green against the very torn-read it guards. The safety-net timeout below is deliberately
+        // huge (10s) so it never decides pass/fail under any plausible scheduling delay — it only prevents
+        // an infinite hang if something is genuinely broken.
+        //
+        // Thread-state key: production Save()'s first action after entry is lock(persistGate); the only
+        // thing the writer does before that is the non-blocking writerThreadRunning.Set(). So the FIRST
+        // time the writer thread enters WaitSleepJoin it is parked on the persistGate monitor — safe to
+        // treat WaitSleepJoin as "correctly blocked".
+        private sealed class ConcurrentSaveDuringLoadManager : SnykOptionsManager
+        {
+            private readonly Mock<ISnykOptions> writerOptions;
+            private int hookFired; // guard: only interleave on the first read region
+
+            // Set by the writer thread once it is scheduled and about to call Save().
+            private readonly ManualResetEventSlim writerThreadRunning = new ManualResetEventSlim(false);
+            // Set from Save()'s OnSaveCriticalSectionEntered seam — the deterministic signal that the
+            // writer has acquired persistGate and entered Save's critical section.
+            private readonly ManualResetEventSlim saveEnteredCriticalSection = new ManualResetEventSlim(false);
+            private Thread writerThread;
+
+            // Observed by the test after Load() returns: did the concurrent Save() enter its persistGate
+            // critical section WHILE the Load() read region was still executing? True == invariant
+            // violated (Load() did not hold the gate across its read).
+            public bool WriterEnteredCriticalSectionDuringRead { get; private set; }
+
+            public ConcurrentSaveDuringLoadManager(
+                string settingsFilePath, ISnykServiceProvider serviceProvider, Mock<ISnykOptions> writerOptions)
+                : base(settingsFilePath, serviceProvider)
+            {
+                this.writerOptions = writerOptions;
+            }
+
+            protected override void OnSaveCriticalSectionEntered()
+            {
+                // The writer has acquired persistGate and entered Save's critical section.
+                this.saveEnteredCriticalSection.Set();
+            }
+
+            protected override void OnLoadReadRegionEntered()
+            {
+                // Only drive the interleave once (the very first read region). Later Load() calls, and
+                // any re-entrant read, are left untouched.
+                if (Interlocked.Exchange(ref this.hookFired, 1) != 0)
+                    return;
+
+                // Launch a writer that mutates the SAME snykSettings via a real Save(). Save is not
+                // overridden for behaviour here, so this resolves to the base persistGate-guarded
+                // implementation; its OnSaveCriticalSectionEntered override sets the handshake event.
+                // A dedicated Thread (not Task.Run) so we can observe the writer's ThreadState.
+                this.writerThread = new Thread(() =>
+                {
+                    this.writerThreadRunning.Set();
+                    // System/LS-driven save: updateOverrideTracker:false, no settings-changed event.
+                    this.Save(this.writerOptions.Object, triggerSettingsChangedEvent: false,
+                        updateOverrideTracker: false);
+                })
+                {
+                    IsBackground = true,
+                    Name = "concurrent-save-during-load-writer",
+                };
+                this.writerThread.Start();
+
+                // Ensure the writer thread is actually scheduled and about to (or trying to) Save().
+                Assert.True(this.writerThreadRunning.Wait(TimeSpan.FromSeconds(5)),
+                    "writer thread never started");
+
+                // Deterministic decision by STATE TRANSITION (not a fixed timeout): spin until EITHER
+                //   (a) the writer entered Save's critical section  -> event set  -> REGRESSION, or
+                //   (b) the writer is parked acquiring the monitor  -> WaitSleepJoin -> correctly BLOCKED.
+                // The safety net is far larger than any plausible scheduling delay, so it never decides
+                // the outcome under normal or starved load; it only guards against a genuine hang.
+                var safetyNet = TimeSpan.FromSeconds(10);
+                var sw = Stopwatch.StartNew();
+                while (sw.Elapsed < safetyNet)
+                {
+                    if (this.saveEnteredCriticalSection.IsSet)
+                    {
+                        this.WriterEnteredCriticalSectionDuringRead = true;
+                        return;
+                    }
+
+                    if ((this.writerThread.ThreadState & ThreadState.WaitSleepJoin) != 0)
+                    {
+                        // Writer is blocked on lock(persistGate) (see thread-state note above): the fix
+                        // is holding and the writer cannot enter Save's critical section mid-read.
+                        this.WriterEnteredCriticalSectionDuringRead = false;
+                        return;
+                    }
+
+                    Thread.Sleep(1);
+                }
+
+                // Safety net hit without a definite transition (should not happen). Fall back to the
+                // event's current state so we never claim "blocked" if the writer had in fact entered.
+                this.WriterEnteredCriticalSectionDuringRead = this.saveEnteredCriticalSection.IsSet;
+            }
+
+            public void WaitForWriter()
+            {
+                this.writerThread?.Join(TimeSpan.FromSeconds(10));
+            }
+        }
+
+        private static ISnykServiceProvider BuildServiceProvider(ISnykOptions options)
+        {
+            var spMock = new Mock<ISnykServiceProvider>();
+            spMock.Setup(x => x.Options).Returns(options);
+            return spMock.Object;
+        }
+
+        // GATE-001: A Save() running concurrently with Load()'s read of snykSettings must be serialized
+        // by persistGate — it must NOT be able to mutate the shared object while Load() is mid-read.
+        // Without the lock over the read region, Load() can return an options object that mixes fields
+        // written before and after a concurrent Save() (the torn read PR #515 flagged).
+        [Fact]
+        public void Load_ReadOfSnykSettings_IsSerializedWithConcurrentSave()
+        {
+            var path = Path.GetTempFileName();
+            ConcurrentSaveDuringLoadManager manager = null;
+            try
+            {
+                var options = BuildOptions();
+                var writerOptions = BuildOptions();
+                var sp = BuildServiceProvider(options.Object);
+
+                manager = new ConcurrentSaveDuringLoadManager(path, sp, writerOptions);
+
+                // First Load(): enters the read region, which drives the concurrent Save() interleave.
+                manager.Load();
+
+                Assert.False(manager.WriterEnteredCriticalSectionDuringRead,
+                    "A concurrent Save() entered its persistGate critical section while Load() was " +
+                    "mid-read — Load()'s read region is not serialized under persistGate, so Load() can " +
+                    "return a torn/mixed options object (PR #515 finding). Guard the read with persistGate.");
+            }
+            finally
+            {
+                // Always join the writer BEFORE deleting the temp file, even if the assert above threw.
+                // The read region has exited and released persistGate, so the previously-blocked writer
+                // completes its Save(); joining here proves the gate was released (not deadlocked) AND
+                // guarantees the writer can no longer File.WriteAllText to `path` after File.Delete
+                // (which would otherwise leak cross-test filesystem noise).
+                manager?.WaitForWriter();
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/Settings/SettingsPersistenceConcurrencyTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/SettingsPersistenceConcurrencyTests.cs
@@ -1,0 +1,160 @@
+// ABOUTME: Concurrency tests for settings.json persistence (IDE-2152 fix #4).
+// ABOUTME: Drives a UI-thread Save concurrently with the background CommitPendingResets on the
+// ABOUTME: SAME real temp-file-backed manager, proving the mutate+serialize+write region is
+// ABOUTME: mutually exclusive: no throw, no torn/corrupt file, converged deserializable state.
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Snyk.VisualStudio.Extension.Authentication;
+using Snyk.VisualStudio.Extension.Download;
+using Snyk.VisualStudio.Extension.Language;
+using Snyk.VisualStudio.Extension.Service;
+using Snyk.VisualStudio.Extension.Settings;
+using Snyk.VisualStudio.Extension.Utils;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.Settings
+{
+    public class SettingsPersistenceConcurrencyTests
+    {
+        // Build a real SnykOptionsManager backed by a temp file (mirrors UserOverridePersistenceTests).
+        private static (SnykOptionsManager manager, Mock<ISnykOptions> options, string path)
+            BuildManager(string existingPath = null)
+        {
+            var path = existingPath ?? Path.GetTempFileName();
+            var optMock = new Mock<ISnykOptions>();
+            optMock.SetupAllProperties();
+
+            optMock.Object.OssEnabled = true;
+            optMock.Object.SnykCodeSecurityEnabled = true;
+            optMock.Object.IacEnabled = true;
+            optMock.Object.SecretsEnabled = false;
+            optMock.Object.AutoScan = true;
+            optMock.Object.EnableDeltaFindings = false;
+            optMock.Object.FilterCritical = true;
+            optMock.Object.FilterHigh = true;
+            optMock.Object.FilterMedium = true;
+            optMock.Object.FilterLow = true;
+            optMock.Object.OpenIssuesEnabled = true;
+            optMock.Object.IgnoredIssuesEnabled = false;
+            optMock.Object.IgnoreUnknownCA = false;
+            optMock.Object.BinariesAutoUpdate = true;
+            optMock.Object.CliCustomPath = string.Empty;
+            optMock.Object.CliReleaseChannel = SnykCliDownloader.DefaultReleaseChannel;
+            optMock.Object.CliBaseDownloadURL = SnykCliDownloader.DefaultBaseDownloadUrl;
+            optMock.Object.AdditionalEnv = string.Empty;
+            optMock.Object.AdditionalParameters = new List<string>();
+            optMock.Object.TrustedFolders = new HashSet<string>();
+            optMock.Object.DeviceId = "concurrency-device";
+            optMock.Object.ApiToken = new AuthenticationToken(AuthenticationType.OAuth, string.Empty);
+
+            var spMock = new Mock<ISnykServiceProvider>();
+            spMock.Setup(x => x.Options).Returns(optMock.Object);
+
+            var manager = new SnykOptionsManager(path, spMock.Object);
+            return (manager, optMock, path);
+        }
+
+        // CONCUR-001 (fix #4): Two persisting paths hitting the SAME manager on different threads must
+        // not throw and must not corrupt settings.json. In production the concurrent pair is a UI-thread
+        // user Save (updateOverrideTracker:true) racing an LS-push Save on a StreamJsonRpc background
+        // dispatch thread (SnykLanguageClientCustomTarget.OnSnykConfiguration/OnHasAuthenticated/
+        // OnAddTrustedFolders). This test drives Save concurrently with CommitPendingResets — an
+        // equivalent second writer that mutates+serializes+writes the same snykSettings — to stress the
+        // shared critical section directly. (The DidChangeConfiguration reset-commit itself is now
+        // marshaled to the UI thread by IDE-2152 fix #7, so it is no longer a background writer; the gate
+        // remains load-bearing for the LS-push background Saves above.) Without the gate, both paths
+        // mutate the shared snykSettings object AND call an unsynchronized File.WriteAllText on the same
+        // path, so under load this throws (IOException / "collection was modified" during serialization)
+        // or leaves a torn, non-deserializable file.
+        //
+        // The write region (mutate snykSettings + serialize + write) must be a single critical section
+        // shared by all persisting callers. After the storm the file must deserialize and reflect a
+        // converged state: OssEnabled=false was persisted (user override), and the reset for
+        // Organization was committed (drained from the pending queue).
+        [Fact]
+        public void ConcurrentSaveAndCommit_DoesNotThrowOrCorruptSettingsFile()
+        {
+            var (manager, optMock, path) = BuildManager();
+            try
+            {
+                manager.Load(); // seed the tracker
+
+                // Pre-enqueue a pending reset so the background CommitPendingResets has something to
+                // drain and persist on every iteration.
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                    resetKeys: new List<string> { PflagKeys.Organization });
+                Assert.Contains(PflagKeys.Organization, manager.OverrideTracker.PeekPendingResets());
+
+                // The user override we expect to survive the storm.
+                optMock.Object.OssEnabled = false;
+
+                const int iterations = 500;
+                var exceptions = new System.Collections.Concurrent.ConcurrentQueue<System.Exception>();
+                var barrier = new Barrier(2);
+
+                // UI-thread role: repeated user Save with an edit-delta (marks snyk_oss_enabled),
+                // mutating snykSettings + persisting on each call.
+                var saver = Task.Run(() =>
+                {
+                    barrier.SignalAndWait();
+                    try
+                    {
+                        for (var i = 0; i < iterations; i++)
+                            manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                                editedKeys: new List<string> { PflagKeys.SnykOssEnabled });
+                    }
+                    catch (System.Exception ex) { exceptions.Enqueue(ex); }
+                });
+
+                // Background writer role: repeated CommitPendingResets on a separate thread stands in
+                // for any concurrent background persister (e.g. an LS-push Save on a StreamJsonRpc
+                // dispatch thread). It mutates+serializes+writes the same snykSettings, stressing the
+                // shared critical section from a non-UI thread.
+                // Re-enqueue each round so there is always something to commit + persist.
+                var committer = Task.Run(() =>
+                {
+                    barrier.SignalAndWait();
+                    try
+                    {
+                        for (var i = 0; i < iterations; i++)
+                        {
+                            manager.OverrideTracker.ApplyUserResets(new List<string> { PflagKeys.Organization });
+                            manager.CommitPendingResets(new List<string> { PflagKeys.Organization });
+                        }
+                    }
+                    catch (System.Exception ex) { exceptions.Enqueue(ex); }
+                });
+
+                Task.WaitAll(saver, committer);
+
+                Assert.True(exceptions.IsEmpty,
+                    "Concurrent Save + CommitPendingResets must not throw — the mutate+serialize+write " +
+                    "region must be one critical section. First exception: " +
+                    (exceptions.TryPeek(out var first) ? first.ToString() : "none"));
+
+                // The on-disk file must be intact and deserializable (not torn by two writers).
+                var rawJson = File.ReadAllText(path);
+                var settings = Json.Deserialize<SnykSettings>(rawJson);
+                Assert.NotNull(settings);
+
+                // Converged state: the user's OssEnabled override was recorded.
+                Assert.NotNull(settings.ChangedConfigKeys);
+                Assert.Contains(PflagKeys.SnykOssEnabled, settings.ChangedConfigKeys);
+
+                // A fresh manager over the same file must load without error (final proof of no torn write).
+                var (manager2, _, _) = BuildManager(path);
+                var loaded = manager2.Load();
+                Assert.NotNull(loaded);
+                Assert.Contains(PflagKeys.SnykOssEnabled, loaded.ChangedConfigKeys);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
@@ -122,12 +122,22 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
             }
         }
 
-        // INT-004 (finding 4): Calling Load() twice on the same manager must not union marks.
-        // The second Load must reflect only what is on disk, not a union of both loads.
+        // INT-004: Calling Load() twice on the same manager must not union/accumulate marks.
+        // The second Load must yield exactly the same set as the first — not a superset.
+        //
+        // Under the seeded-marker design: the first Load (marker absent, OssEnabled=false non-default)
+        // seeds and writes the marker + {snyk_oss_enabled} to disk. The second Load (marker now present
+        // in snykSettings in-memory) takes Branch C: clears changed marks via ClearChanged(), then
+        // hydrates from the persisted set ({snyk_oss_enabled}) verbatim. The result must be identical
+        // to the first load — exactly {snyk_oss_enabled}, not duplicated or grown.
+        //
+        // Note: SnykSettingsLoader.Load() caches the SnykSettings object after the first file read,
+        // so the manager's in-memory snykSettings is the source of truth between loads on the same
+        // manager. A simulated IDE restart requires a FRESH manager (see SACC-001/002).
         [Fact]
         public void Load_CalledTwice_DoesNotUnionStaleMarks()
         {
-            // Write a settings.json with OssEnabled=false (non-default) -> snyk_oss_enabled marked.
+            // Write a settings.json with OssEnabled=false (non-default) — no seeded marker yet.
             var path = Path.GetTempFileName();
             try
             {
@@ -148,21 +158,20 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
 }";
                 File.WriteAllText(path, rawJson);
 
-                var (manager, optMock, _) = BuildManager(path);
+                var (manager, _, _) = BuildManager(path);
 
-                // First load: OssEnabled=false -> marked.
+                // First load: marker absent + OssEnabled=false non-default → Branch A seeds →
+                // {snyk_oss_enabled} marked, marker written to disk.
                 var first = manager.Load();
                 Assert.Contains(PflagKeys.SnykOssEnabled, first.ChangedConfigKeys);
+                var firstCount = first.ChangedConfigKeys.Count;
 
-                // Now update the file so OssEnabled=true (default) — simulates an external reset.
-                var rawJson2 = rawJson.Replace(@"""ossEnabled"": false", @"""ossEnabled"": true");
-                File.WriteAllText(path, rawJson2);
-                // Reload the settings from disk (mimic what the manager would do on a second Load).
-                manager.LoadSettingsFromFile();
-
-                // Second load: should NOT carry over the stale snyk_oss_enabled mark.
+                // Second load on the SAME manager: marker now present in the in-memory snykSettings
+                // (Branch C) → ClearChanged() then hydrate verbatim from the persisted set.
+                // Result must equal the first load — no stale-mark unioning, no growth.
                 var second = manager.Load();
-                Assert.DoesNotContain(PflagKeys.SnykOssEnabled, second.ChangedConfigKeys);
+                Assert.Contains(PflagKeys.SnykOssEnabled, second.ChangedConfigKeys);
+                Assert.Equal(firstCount, second.ChangedConfigKeys.Count);
             }
             finally
             {
@@ -197,8 +206,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
 
                 // Reload and confirm the persisted ChangedConfigKeys did NOT grow.
                 var loaded = manager.Load();
-                if (loaded.ChangedConfigKeys != null)
-                    Assert.DoesNotContain(PflagKeys.Organization, loaded.ChangedConfigKeys); // must not persist LS-pushed key
+                Assert.NotNull(loaded.ChangedConfigKeys);
+                Assert.DoesNotContain(PflagKeys.Organization, loaded.ChangedConfigKeys); // must not persist LS-pushed key
             }
             finally
             {
@@ -331,7 +340,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
 }";
                 File.WriteAllText(path, rawJson);
 
-                // Load: since ChangedConfigKeys is absent, manager should seed from values.
+                // Load: since ChangedConfigKeys is absent (and marker is absent), manager should seed from values.
                 var (manager, _, _) = BuildManager(path);
                 var loaded = manager.Load();
 
@@ -339,6 +348,236 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
                 Assert.Contains(PflagKeys.SnykOssEnabled, loaded.ChangedConfigKeys);
                 // SnykCodeEnabled = true is the default, so it must NOT be in ChangedConfigKeys.
                 Assert.DoesNotContain(PflagKeys.SnykCodeEnabled, loaded.ChangedConfigKeys);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // REFINEMENT-S tests — LOAD-TIME SEEDING LIFECYCLE (CP-S.1)
+        // ─────────────────────────────────────────────────────────────────────
+
+        // SACC-001: Customer-outcome acceptance test.
+        // Org pushes a non-default value via LS (updateOverrideTracker:false).
+        // After the LS save and a simulated IDE restart, the loaded ChangedConfigKeys
+        // must NOT contain the org-pushed key — it is still an org value, not a user override.
+        // Reproduces the org-value-freezing-across-restart bug:
+        //   Load() re-seeds (value-vs-default) → marks the org-pushed org value → frozen.
+        // Requires the persisted seeded-marker so the second Load trusts the persisted set (incl. empty).
+        [Fact]
+        public void OrgPushedValueSurvivesRestart_StillReachesUserWhenOrgChangesItAgain()
+        {
+            var (manager, optMock, path) = BuildManager();
+            try
+            {
+                // Step 1: Initial load on a fresh-install (all-default) file.
+                // Seeding finds no deviations → empty override set → marker written.
+                manager.Load();
+                Assert.Empty(manager.OverrideTracker.Snapshot()); // precondition: no overrides
+
+                // Step 2: LS pushes a non-default org value (e.g. org set by central config).
+                optMock.Object.Organization = "acme-from-org";
+                // LS-originated save — updateOverrideTracker:false.
+                // Must NOT touch ChangedConfigKeys or the seeded marker.
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false, updateOverrideTracker: false);
+
+                // Step 3: Simulate IDE restart — construct a FRESH manager from the same file.
+                var (manager2, _, _) = BuildManager(path);
+                var loaded = manager2.Load();
+
+                // The seeded marker must be present → persisted-keys branch used → empty set returned.
+                // The org-pushed organization key must NOT appear in ChangedConfigKeys.
+                Assert.NotNull(loaded.ChangedConfigKeys);
+                Assert.DoesNotContain(PflagKeys.Organization, loaded.ChangedConfigKeys);
+
+                Assert.False(manager2.OverrideTracker.IsChanged(PflagKeys.Organization),
+                    "IsChanged must be false: organization was set by the org/LS, not by the user");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // SACC-002: Customer-outcome acceptance test.
+        // A user override is reset to default (override set becomes empty, marker set, persisted).
+        // After a simulated IDE restart, the reset key (and every other current-non-default value
+        // present in the file) must NOT be marked as an override — the empty set is trusted verbatim.
+        [Fact]
+        public void ResetSettingStaysResetAcrossRestart_NotReMarkedAsOverride()
+        {
+            var (manager, optMock, path) = BuildManager();
+            try
+            {
+                // Step 1: User marks IacEnabled as an override (non-default: false).
+                manager.Load();
+                optMock.Object.IacEnabled = false;
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                    editedKeys: new List<string> { PflagKeys.SnykIacEnabled });
+
+                // Confirm it is marked before the reset.
+                Assert.Contains(PflagKeys.SnykIacEnabled, manager.OverrideTracker.Snapshot());
+
+                // Step 2: User resets IacEnabled back to its default (true).
+                optMock.Object.IacEnabled = true;
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                    editedKeys: new List<string> { PflagKeys.SnykIacEnabled });
+
+                // Confirm it is now unmarked (override set empty, marker still set on disk).
+                Assert.DoesNotContain(PflagKeys.SnykIacEnabled, manager.OverrideTracker.Snapshot());
+
+                // Step 3: Simulate IDE restart — FRESH manager from the same file.
+                // The file now carries changedConfigKeysSeeded=true and an empty ChangedConfigKeys
+                // (written by step 2's save). The fresh manager must take Branch C and trust the
+                // empty set verbatim — the reset key must stay unmarked.
+                var (manager2, _, _) = BuildManager(path);
+                var loaded = manager2.Load();
+
+                // The reset key must remain unmarked across restart (trusted empty set).
+                Assert.NotNull(loaded.ChangedConfigKeys);
+                Assert.DoesNotContain(PflagKeys.SnykIacEnabled, loaded.ChangedConfigKeys);
+
+                Assert.False(manager2.OverrideTracker.IsChanged(PflagKeys.SnykIacEnabled),
+                    "A key reset to default must stay unmarked after restart — seeded-marker must gate re-seed");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // SINT-001: Integration test.
+        // A settings file with the seeded-marker present and ChangedConfigKeys absent/empty must
+        // hydrate to an EMPTY override set — Load must NOT call SeedFrom.
+        // Verified by observable state: a current-non-default value in options is NOT marked after load.
+        [Fact]
+        public void Load_SeededEmptySet_DoesNotReSeedFromValues()
+        {
+            // Write a settings.json with the seeded marker present but ChangedConfigKeys absent.
+            // This models the steady state after a fresh install: user has zero overrides, marker is set.
+            var path = Path.GetTempFileName();
+            try
+            {
+                var rawJson = @"{
+  ""ossEnabled"": false,
+  ""snykCodeSecurityEnabled"": true,
+  ""iacEnabled"": true,
+  ""binariesAutoUpdateEnabled"": true,
+  ""trustedFolders"": [],
+  ""openIssuesEnabled"": true,
+  ""filterCritical"": true,
+  ""filterHigh"": true,
+  ""filterMedium"": true,
+  ""filterLow"": true,
+  ""autoScan"": true,
+  ""deviceId"": ""sint001-device"",
+  ""token"": """",
+  ""changedConfigKeysSeeded"": true
+}";
+                File.WriteAllText(path, rawJson);
+
+                var (manager, _, _) = BuildManager(path);
+                var loaded = manager.Load();
+
+                // The marker is present → Branch C taken → empty set hydrated verbatim.
+                // OssEnabled=false is non-default, but it MUST NOT be marked (no re-seed).
+                Assert.Empty(loaded.ChangedConfigKeys);
+
+                Assert.False(manager.OverrideTracker.IsChanged(PflagKeys.SnykOssEnabled),
+                    "With seeded-marker present and empty ChangedConfigKeys, no re-seed must occur — " +
+                    "a non-default value in the file must NOT be marked as a user override");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // SINT-002: Integration test — seed runs at most once; a fresh manager over the same file
+        // (simulating IDE restart) does not re-seed when the seeded marker is present on disk.
+        //
+        // Scenario: first manager loads an all-default file (no marker) → Branch A seeds empty set →
+        // writes marker to disk. A FRESH manager (simulating restart) reads the same file; the marker
+        // is now present → Branch C hydrates empty set verbatim. Even if the file now also contains
+        // a non-default value (e.g. org-pushed ossEnabled=false), it must NOT be marked.
+        //
+        // Note: SnykSettingsLoader caches the SnykSettings object, so rewriting the file and calling
+        // LoadSettingsFromFile() on the SAME manager does not re-read from disk. A fresh manager is
+        // required to genuinely simulate a restart and verify the persisted marker is honoured.
+        [Fact]
+        public void Load_AfterSeed_DoesNotReSeedOnNextLoad()
+        {
+            var (manager, _, path) = BuildManager();
+            try
+            {
+                // First load on an all-default file (no marker): Branch A seeds empty set,
+                // writes changedConfigKeysSeeded=true to disk.
+                var first = manager.Load();
+                Assert.Empty(first.ChangedConfigKeys);
+
+                // Simulate IDE restart with a FRESH manager over the same file.
+                // The file now has changedConfigKeysSeeded=true (written by the first Load above),
+                // so the fresh manager must take Branch C and never re-derive from values.
+                var (manager2, _, _) = BuildManager(path);
+                var second = manager2.Load();
+
+                // OssEnabled is at its default on disk — confirmed not marked in first load.
+                // The marker is present → Branch C → empty set hydrated verbatim.
+                Assert.Empty(second.ChangedConfigKeys);
+
+                Assert.False(manager2.OverrideTracker.IsChanged(PflagKeys.SnykOssEnabled),
+                    "Fresh manager with seeded marker present must not re-seed — " +
+                    "seeding runs at most once per settings file");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // R2 migration-guard test: a settings.json written by a prior version (no seeded marker)
+        // that already has a non-empty ChangedConfigKeys set must NOT be discarded by re-seeding.
+        // Branch B in Load(): marker absent + keys non-empty → hydrate verbatim + persist marker.
+        [Fact]
+        public void Load_PriorVersionPersistedKeys_HydratesVerbatimWithoutReseeding()
+        {
+            // Write a settings.json as a prior version would have: ChangedConfigKeys present,
+            // no changedConfigKeysSeeded marker. OssEnabled=true (default), but snyk_oss_enabled
+            // is in ChangedConfigKeys — simulating a user override that was written before the
+            // marker was introduced. A re-seed would DISCARD this because OssEnabled==default.
+            var path = Path.GetTempFileName();
+            try
+            {
+                var rawJson = @"{
+  ""ossEnabled"": true,
+  ""snykCodeSecurityEnabled"": true,
+  ""iacEnabled"": true,
+  ""binariesAutoUpdateEnabled"": true,
+  ""trustedFolders"": [],
+  ""openIssuesEnabled"": true,
+  ""filterCritical"": true,
+  ""filterHigh"": true,
+  ""filterMedium"": true,
+  ""filterLow"": true,
+  ""autoScan"": true,
+  ""deviceId"": ""migration-guard-device"",
+  ""token"": """",
+  ""changedConfigKeys"": [""snyk_oss_enabled""]
+}";
+                File.WriteAllText(path, rawJson);
+
+                var (manager, _, _) = BuildManager(path);
+                var loaded = manager.Load();
+
+                // Branch B must hydrate snyk_oss_enabled from the persisted set verbatim.
+                // Re-seeding would discard it (ossEnabled=true == default → not marked).
+                Assert.NotNull(loaded.ChangedConfigKeys);
+                Assert.Contains(PflagKeys.SnykOssEnabled, loaded.ChangedConfigKeys);
+                Assert.True(manager.OverrideTracker.IsChanged(PflagKeys.SnykOssEnabled),
+                    "A key persisted by a prior version must survive the migration load — " +
+                    "Branch B must hydrate verbatim, not re-seed and discard the stored override");
             }
             finally
             {

--- a/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using Moq;
+using Snyk.VisualStudio.Extension.Authentication;
 using Snyk.VisualStudio.Extension.Download;
 using Snyk.VisualStudio.Extension.Language;
 using Snyk.VisualStudio.Extension.Service;
@@ -48,8 +49,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
             // Fresh-install default: OAuth is the zero value of AuthenticationType (pinned by R3-4 test).
             // Using Token here would mask auth-seeding regressions because SeedFrom would see a
             // non-default auth method and spuriously mark AuthenticationMethod as changed.
-            optMock.Object.ApiToken = new Authentication.AuthenticationToken(
-                Authentication.AuthenticationType.OAuth, string.Empty);
+            optMock.Object.ApiToken = new AuthenticationToken(
+                AuthenticationType.OAuth, string.Empty);
 
             var spMock = new Mock<ISnykServiceProvider>();
             spMock.Setup(x => x.Options).Returns(optMock.Object);
@@ -190,16 +191,14 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
                 manager.Save(optMock.Object, triggerSettingsChangedEvent: false, updateOverrideTracker: false);
 
                 // Tracker must stay clean — no phantom user override.
-                Assert.DoesNotContain(PflagKeys.Organization, manager.OverrideTracker.Snapshot(),
-                    "Save(updateOverrideTracker:false) must NOT mark LS-pushed values as user overrides");
+                Assert.DoesNotContain(PflagKeys.Organization, manager.OverrideTracker.Snapshot()); // LS-pushed must not be marked
                 Assert.False(manager.OverrideTracker.IsChanged(PflagKeys.Organization),
                     "IsChanged must be false for a key set only by the LS, not the user");
 
                 // Reload and confirm the persisted ChangedConfigKeys did NOT grow.
                 var loaded = manager.Load();
                 if (loaded.ChangedConfigKeys != null)
-                    Assert.DoesNotContain(PflagKeys.Organization, loaded.ChangedConfigKeys,
-                        "ChangedConfigKeys must not persist the LS-pushed key as a user override");
+                    Assert.DoesNotContain(PflagKeys.Organization, loaded.ChangedConfigKeys); // must not persist LS-pushed key
             }
             finally
             {
@@ -226,8 +225,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
                     editedKeys: new List<string> { PflagKeys.SnykOssEnabled });
 
                 // Tracker must record the override.
-                Assert.Contains(PflagKeys.SnykOssEnabled, manager.OverrideTracker.Snapshot(),
-                    "Save(updateOverrideTracker:true) with editedKeys must mark user-changed values");
+                Assert.Contains(PflagKeys.SnykOssEnabled, manager.OverrideTracker.Snapshot());
                 Assert.True(manager.OverrideTracker.IsChanged(PflagKeys.SnykOssEnabled),
                     "IsChanged must be true for a key the user explicitly changed");
             }
@@ -259,12 +257,10 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
                     editedKeys: new List<string> { PflagKeys.SnykIacEnabled });
 
                 // IacEnabled was edited and its value (false) deviates from default (true) → marked.
-                Assert.Contains(PflagKeys.SnykIacEnabled, manager.OverrideTracker.Snapshot(),
-                    "An edited key with a non-default value must be marked as a user override");
+                Assert.Contains(PflagKeys.SnykIacEnabled, manager.OverrideTracker.Snapshot());
 
                 // OssEnabled was NOT in editedKeys (org-pushed) → must NOT be marked.
-                Assert.DoesNotContain(PflagKeys.SnykOssEnabled, manager.OverrideTracker.Snapshot(),
-                    "An org-pushed value not in editedKeys must NOT be marked as a user override");
+                Assert.DoesNotContain(PflagKeys.SnykOssEnabled, manager.OverrideTracker.Snapshot());
             }
             finally
             {
@@ -291,8 +287,7 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
                     editedKeys: new List<string> { PflagKeys.SnykIacEnabled });
 
                 // Immediately: tracker has the key marked.
-                Assert.Contains(PflagKeys.SnykIacEnabled, manager.OverrideTracker.Snapshot(),
-                    "ApplyUserEdits must mark the edited non-default key immediately");
+                Assert.Contains(PflagKeys.SnykIacEnabled, manager.OverrideTracker.Snapshot());
 
                 // After restart (fresh manager from same file): the key must come back via
                 // the persisted-keys branch of Load (ChangedConfigKeys is non-null on disk).
@@ -300,11 +295,9 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
                 var loaded = manager2.Load();
 
                 Assert.NotNull(loaded.ChangedConfigKeys);
-                Assert.Contains(PflagKeys.SnykIacEnabled, loaded.ChangedConfigKeys,
-                    "The edited key must survive a full save→reload cycle via persisted-keys branch");
+                Assert.Contains(PflagKeys.SnykIacEnabled, loaded.ChangedConfigKeys);
                 // OssEnabled was never edited — must not appear.
-                Assert.DoesNotContain(PflagKeys.SnykOssEnabled, loaded.ChangedConfigKeys,
-                    "Only explicitly edited keys must appear in ChangedConfigKeys");
+                Assert.DoesNotContain(PflagKeys.SnykOssEnabled, loaded.ChangedConfigKeys);
             }
             finally
             {

--- a/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
@@ -1,0 +1,356 @@
+// ABOUTME: Integration tests for user-override persistence covering INT-001, INT-002, ACC-003,
+// ABOUTME: ACC-006 from the IDE-2152 test plan.
+// Uses real SnykOptionsManager + real SnykSettingsLoader on a temp file + real UserOverrideTracker.
+using System.Collections.Generic;
+using System.IO;
+using Moq;
+using Snyk.VisualStudio.Extension.Download;
+using Snyk.VisualStudio.Extension.Language;
+using Snyk.VisualStudio.Extension.Service;
+using Snyk.VisualStudio.Extension.Settings;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.Settings
+{
+    public class UserOverridePersistenceTests
+    {
+        // Build a real SnykOptionsManager backed by a temp file. Returns the path so callers
+        // can re-construct a second manager (simulating an IDE restart).
+        private static (SnykOptionsManager manager, Mock<ISnykOptions> options, string path)
+            BuildManager(string existingPath = null)
+        {
+            var path = existingPath ?? Path.GetTempFileName();
+            var optMock = new Mock<ISnykOptions>();
+            optMock.SetupAllProperties();
+
+            // Seed reasonable defaults so Save() doesn't null-ref on Token or TrustedFolders.
+            optMock.Object.OssEnabled = true;
+            optMock.Object.SnykCodeSecurityEnabled = true;
+            optMock.Object.IacEnabled = true;
+            optMock.Object.SecretsEnabled = false;
+            optMock.Object.AutoScan = true;
+            optMock.Object.EnableDeltaFindings = false;
+            optMock.Object.FilterCritical = true;
+            optMock.Object.FilterHigh = true;
+            optMock.Object.FilterMedium = true;
+            optMock.Object.FilterLow = true;
+            optMock.Object.OpenIssuesEnabled = true;
+            optMock.Object.IgnoredIssuesEnabled = false;
+            optMock.Object.IgnoreUnknownCA = false;
+            optMock.Object.BinariesAutoUpdate = true;
+            optMock.Object.CliCustomPath = string.Empty;
+            optMock.Object.CliReleaseChannel = SnykCliDownloader.DefaultReleaseChannel;
+            optMock.Object.CliBaseDownloadURL = SnykCliDownloader.DefaultBaseDownloadUrl;
+            optMock.Object.AdditionalEnv = string.Empty;
+            optMock.Object.AdditionalParameters = new List<string>();
+            optMock.Object.TrustedFolders = new System.Collections.Generic.HashSet<string>();
+            optMock.Object.DeviceId = "test-device";
+            // Fresh-install default: OAuth is the zero value of AuthenticationType (pinned by R3-4 test).
+            // Using Token here would mask auth-seeding regressions because SeedFrom would see a
+            // non-default auth method and spuriously mark AuthenticationMethod as changed.
+            optMock.Object.ApiToken = new Authentication.AuthenticationToken(
+                Authentication.AuthenticationType.OAuth, string.Empty);
+
+            var spMock = new Mock<ISnykServiceProvider>();
+            spMock.Setup(x => x.Options).Returns(optMock.Object);
+
+            var manager = new SnykOptionsManager(path, spMock.Object);
+            return (manager, optMock, path);
+        }
+
+        // INT-001 / ACC-003: Save then Load round-trips the override set through settings.json.
+        // After saving options with OssEnabled=false (non-default) — passing it as an editedKey so
+        // ApplyUserEdits records it — then loading in a fresh manager, the tracker must report
+        // OssEnabled's key as changed and it must round-trip through the persisted-keys branch of Load.
+        [Fact]
+        public void Manager_SaveThenLoad_PersistsChangedConfigKeys()
+        {
+            var (manager, optMock, path) = BuildManager();
+            try
+            {
+                manager.Load(); // seed tracker first
+                // Mark OssEnabled as user-overridden: set to non-default and declare as edited key.
+                optMock.Object.OssEnabled = false;
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                    editedKeys: new List<string> { PflagKeys.SnykOssEnabled });
+
+                // Simulate IDE restart: construct a fresh manager from the same file.
+                var (manager2, _, _) = BuildManager(path);
+                var loaded = manager2.Load();
+
+                // The persisted ChangedConfigKeys should include snyk_oss_enabled.
+                Assert.NotNull(loaded.ChangedConfigKeys);
+                Assert.Contains(PflagKeys.SnykOssEnabled, loaded.ChangedConfigKeys);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // INT-002: Save applies the edit-delta to the tracker.
+        // Passing OssEnabled in editedKeys with a non-default value marks it;
+        // passing it again with the default value unmarks it and enqueues a reset.
+        [Fact]
+        public void Manager_Save_SyncsTrackerFromDeltas()
+        {
+            var (manager, optMock, path) = BuildManager();
+            try
+            {
+                manager.Load(); // seed tracker first
+
+                // First save: OssEnabled = false (non-default), declared as edited key → marked.
+                optMock.Object.OssEnabled = false;
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                    editedKeys: new List<string> { PflagKeys.SnykOssEnabled });
+
+                var afterFirstSave = manager.Load();
+                Assert.Contains(PflagKeys.SnykOssEnabled, afterFirstSave.ChangedConfigKeys);
+
+                // Second save: OssEnabled back to true (default), declared as edited key → unmarked.
+                optMock.Object.OssEnabled = true;
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                    editedKeys: new List<string> { PflagKeys.SnykOssEnabled });
+
+                var afterSecondSave = manager.Load();
+                Assert.DoesNotContain(PflagKeys.SnykOssEnabled, afterSecondSave.ChangedConfigKeys);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // INT-004 (finding 4): Calling Load() twice on the same manager must not union marks.
+        // The second Load must reflect only what is on disk, not a union of both loads.
+        [Fact]
+        public void Load_CalledTwice_DoesNotUnionStaleMarks()
+        {
+            // Write a settings.json with OssEnabled=false (non-default) -> snyk_oss_enabled marked.
+            var path = Path.GetTempFileName();
+            try
+            {
+                var rawJson = @"{
+  ""ossEnabled"": false,
+  ""snykCodeSecurityEnabled"": true,
+  ""iacEnabled"": true,
+  ""binariesAutoUpdateEnabled"": true,
+  ""trustedFolders"": [],
+  ""openIssuesEnabled"": true,
+  ""filterCritical"": true,
+  ""filterHigh"": true,
+  ""filterMedium"": true,
+  ""filterLow"": true,
+  ""autoScan"": true,
+  ""deviceId"": ""load-twice-device"",
+  ""token"": """"
+}";
+                File.WriteAllText(path, rawJson);
+
+                var (manager, optMock, _) = BuildManager(path);
+
+                // First load: OssEnabled=false -> marked.
+                var first = manager.Load();
+                Assert.Contains(PflagKeys.SnykOssEnabled, first.ChangedConfigKeys);
+
+                // Now update the file so OssEnabled=true (default) — simulates an external reset.
+                var rawJson2 = rawJson.Replace(@"""ossEnabled"": false", @"""ossEnabled"": true");
+                File.WriteAllText(path, rawJson2);
+                // Reload the settings from disk (mimic what the manager would do on a second Load).
+                manager.LoadSettingsFromFile();
+
+                // Second load: should NOT carry over the stale snyk_oss_enabled mark.
+                var second = manager.Load();
+                Assert.DoesNotContain(PflagKeys.SnykOssEnabled, second.ChangedConfigKeys);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // R7-1a: Save with updateOverrideTracker:false does NOT mark LS-pushed non-default values.
+        // Simulates OnSnykConfiguration receiving e.g. organization="acme" from the LS and calling
+        // Save(options, triggerSettingsChangedEvent:false, updateOverrideTracker:false).
+        // The tracker must stay empty — the LS push must never create phantom user overrides.
+        [Fact]
+        public void Save_UpdateOverrideTrackerFalse_DoesNotMarkNonDefaultValues()
+        {
+            var (manager, optMock, path) = BuildManager();
+            try
+            {
+                // Load first so the tracker is seeded (reflects a fresh install with no overrides).
+                manager.Load();
+                Assert.Empty(manager.OverrideTracker.Snapshot()); // precondition: no user overrides
+
+                // Simulate LS pushing a non-default value (e.g. org set by LDX).
+                optMock.Object.Organization = "acme-from-ls";
+
+                // LS-originated save: updateOverrideTracker:false.
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false, updateOverrideTracker: false);
+
+                // Tracker must stay clean — no phantom user override.
+                Assert.DoesNotContain(PflagKeys.Organization, manager.OverrideTracker.Snapshot(),
+                    "Save(updateOverrideTracker:false) must NOT mark LS-pushed values as user overrides");
+                Assert.False(manager.OverrideTracker.IsChanged(PflagKeys.Organization),
+                    "IsChanged must be false for a key set only by the LS, not the user");
+
+                // Reload and confirm the persisted ChangedConfigKeys did NOT grow.
+                var loaded = manager.Load();
+                if (loaded.ChangedConfigKeys != null)
+                    Assert.DoesNotContain(PflagKeys.Organization, loaded.ChangedConfigKeys,
+                        "ChangedConfigKeys must not persist the LS-pushed key as a user override");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // R7-1b: Save with updateOverrideTracker:true and a non-empty editedKeys DOES mark the key.
+        // Proves the flag gates the behavior — both branches tested (contrast with R7-1a above).
+        [Fact]
+        public void Save_UpdateOverrideTrackerTrue_DoesMarkNonDefaultValues()
+        {
+            var (manager, optMock, path) = BuildManager();
+            try
+            {
+                manager.Load();
+                Assert.Empty(manager.OverrideTracker.Snapshot()); // precondition: no user overrides
+
+                // User explicitly sets a non-default value and the call site declares it as edited.
+                optMock.Object.OssEnabled = false;
+
+                // User-initiated save: updateOverrideTracker:true, editedKeys declares what changed.
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false, updateOverrideTracker: true,
+                    editedKeys: new List<string> { PflagKeys.SnykOssEnabled });
+
+                // Tracker must record the override.
+                Assert.Contains(PflagKeys.SnykOssEnabled, manager.OverrideTracker.Snapshot(),
+                    "Save(updateOverrideTracker:true) with editedKeys must mark user-changed values");
+                Assert.True(manager.OverrideTracker.IsChanged(PflagKeys.SnykOssEnabled),
+                    "IsChanged must be true for a key the user explicitly changed");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // RINT-001 (Integration): Manager.Save with editedKeys marks only the keys in the set.
+        // A non-default value NOT in editedKeys (org-pushed) must never be marked.
+        [Fact]
+        public void Manager_Save_WithEditedKeys_MarksOnlyEditedDeviations()
+        {
+            var (manager, optMock, path) = BuildManager();
+            try
+            {
+                manager.Load(); // seed tracker
+
+                // Simulate: org pushed OssEnabled=false (non-default) AND user edited IacEnabled=false.
+                optMock.Object.OssEnabled = false;   // org-pushed, NOT in editedKeys
+                optMock.Object.IacEnabled = false;   // user-edited, in editedKeys
+
+                // Save with only IacEnabled in the edited set.
+                manager.Save(
+                    optMock.Object,
+                    triggerSettingsChangedEvent: false,
+                    updateOverrideTracker: true,
+                    editedKeys: new List<string> { PflagKeys.SnykIacEnabled });
+
+                // IacEnabled was edited and its value (false) deviates from default (true) → marked.
+                Assert.Contains(PflagKeys.SnykIacEnabled, manager.OverrideTracker.Snapshot(),
+                    "An edited key with a non-default value must be marked as a user override");
+
+                // OssEnabled was NOT in editedKeys (org-pushed) → must NOT be marked.
+                Assert.DoesNotContain(PflagKeys.SnykOssEnabled, manager.OverrideTracker.Snapshot(),
+                    "An org-pushed value not in editedKeys must NOT be marked as a user override");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // F4: Focused edit-delta path test. Starting from a seeded tracker with NO marks,
+        // Save with a non-empty editedKeys causes ApplyUserEdits to mark the key, and that
+        // mark persists through Load via the persisted-keys branch (not SeedFrom).
+        [Fact]
+        public void Save_WithEditedKey_MarksKeyAndPersistsViaPersistedKeysBranch()
+        {
+            var (manager, optMock, path) = BuildManager();
+            try
+            {
+                // Load to seed tracker from all-default options — snapshot must be empty.
+                manager.Load();
+                Assert.Empty(manager.OverrideTracker.Snapshot());
+
+                // User changes IacEnabled to false (non-default) and the call site declares it edited.
+                optMock.Object.IacEnabled = false;
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                    editedKeys: new List<string> { PflagKeys.SnykIacEnabled });
+
+                // Immediately: tracker has the key marked.
+                Assert.Contains(PflagKeys.SnykIacEnabled, manager.OverrideTracker.Snapshot(),
+                    "ApplyUserEdits must mark the edited non-default key immediately");
+
+                // After restart (fresh manager from same file): the key must come back via
+                // the persisted-keys branch of Load (ChangedConfigKeys is non-null on disk).
+                var (manager2, _, _) = BuildManager(path);
+                var loaded = manager2.Load();
+
+                Assert.NotNull(loaded.ChangedConfigKeys);
+                Assert.Contains(PflagKeys.SnykIacEnabled, loaded.ChangedConfigKeys,
+                    "The edited key must survive a full save→reload cycle via persisted-keys branch");
+                // OssEnabled was never edited — must not appear.
+                Assert.DoesNotContain(PflagKeys.SnykOssEnabled, loaded.ChangedConfigKeys,
+                    "Only explicitly edited keys must appear in ChangedConfigKeys");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // ACC-006: SeedOnFirstLoad — pre-existing non-default values are recognized as overrides
+        // on upgrade (when the persisted ChangedConfigKeys set is absent / empty).
+        [Fact]
+        public void SeedOnFirstLoad_NonDefaultPersistedValues_AreRecognizedAsOverrides()
+        {
+            // Write a settings.json WITHOUT ChangedConfigKeys (simulates a pre-upgrade file).
+            var path = Path.GetTempFileName();
+            try
+            {
+                var rawJson = @"{
+  ""ossEnabled"": false,
+  ""snykCodeSecurityEnabled"": true,
+  ""iacEnabled"": true,
+  ""binariesAutoUpdateEnabled"": true,
+  ""trustedFolders"": [],
+  ""openIssuesEnabled"": true,
+  ""filterCritical"": true,
+  ""filterHigh"": true,
+  ""filterMedium"": true,
+  ""filterLow"": true,
+  ""autoScan"": true,
+  ""deviceId"": ""upgrade-test-device"",
+  ""token"": """"
+}";
+                File.WriteAllText(path, rawJson);
+
+                // Load: since ChangedConfigKeys is absent, manager should seed from values.
+                var (manager, _, _) = BuildManager(path);
+                var loaded = manager.Load();
+
+                // OssEnabled = false is non-default, so it must be in ChangedConfigKeys.
+                Assert.Contains(PflagKeys.SnykOssEnabled, loaded.ChangedConfigKeys);
+                // SnykCodeEnabled = true is the default, so it must NOT be in ChangedConfigKeys.
+                Assert.DoesNotContain(PflagKeys.SnykCodeEnabled, loaded.ChangedConfigKeys);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
@@ -535,6 +535,142 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
             }
         }
 
+        // PENDING-RESET-PERSIST-001 (fix #2): A reset applied but not yet confirmed-delivered persists
+        // to settings.json and is rehydrated into the tracker's pending-reset queue by a fresh manager
+        // over the same file (simulated restart). Uses Save(resetKeys:...) — the same channel the bridge
+        // uses — so the tracker un-marks + enqueues, and Save persists PendingResetConfigKeys.
+        [Fact]
+        public void PendingReset_PersistsAndRehydratesAcrossRestart()
+        {
+            var (manager, optMock, path) = BuildManager();
+            try
+            {
+                manager.Load(); // seed tracker
+
+                // First: user overrides OssEnabled (so there is a mark to un-mark on reset).
+                optMock.Object.OssEnabled = false;
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                    editedKeys: new List<string> { PflagKeys.SnykOssEnabled });
+                Assert.Contains(PflagKeys.SnykOssEnabled, manager.OverrideTracker.Snapshot());
+
+                // Then: user resets it. Not committed (LS not ready) → stays pending + persisted.
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                    resetKeys: new List<string> { PflagKeys.SnykOssEnabled });
+                Assert.Contains(PflagKeys.SnykOssEnabled, manager.OverrideTracker.PeekPendingResets());
+                // Un-marked → no longer in the persisted override set.
+                Assert.DoesNotContain(PflagKeys.SnykOssEnabled, manager.OverrideTracker.Snapshot());
+
+                // Restart: fresh manager over the same file must rehydrate the pending reset.
+                var (manager2, _, _) = BuildManager(path);
+                manager2.Load();
+
+                Assert.Contains(PflagKeys.SnykOssEnabled, manager2.OverrideTracker.PeekPendingResets());
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // INIT-DEFERRED-COMMIT-001 (fix #3 invariant): An init-only delivery folds the pending reset
+        // into the handshake wire map (proving it is SENT at init) but must NOT commit it — after init
+        // the reset stays QUEUED in the tracker AND PERSISTED in settings.json (so a crash before the
+        // first config-update does not lose it). A subsequent SUCCESSFUL config-update (peek→send→
+        // commit, simulated via CommitPendingResets of the peeked snapshot) then drains it from both
+        // the queue and persistence. This pins the deferred-commit invariant documented on
+        // SnykLanguageClient.GetInitializationOptions.
+        [Fact]
+        public void InitOnlyDelivery_LeavesResetQueuedAndPersisted_SubsequentConfigUpdateCommits()
+        {
+            var (manager, optMock, path) = BuildManager();
+            try
+            {
+                manager.Load(); // seed tracker
+
+                // User overrides then resets OssEnabled → reset queued + persisted (LS not ready yet).
+                optMock.Object.OssEnabled = false;
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                    editedKeys: new List<string> { PflagKeys.SnykOssEnabled });
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                    resetKeys: new List<string> { PflagKeys.SnykOssEnabled });
+                Assert.Contains(PflagKeys.SnykOssEnabled, manager.OverrideTracker.PeekPendingResets());
+
+                // Wire a real LsSettingsV25 to the same real options + real manager (so it reads the
+                // manager's real tracker). This is the exact init path SnykLanguageClient uses.
+                var spMock = new Mock<ISnykServiceProvider>();
+                spMock.Setup(x => x.Options).Returns(optMock.Object);
+                spMock.Setup(x => x.SnykOptionsManager).Returns(manager);
+                optMock.Object.FolderConfigs = new List<FolderConfig>();
+                var lsSettings = new LsSettingsV25(spMock.Object);
+
+                // Init-only delivery: build the handshake options. This folds the reset into the wire
+                // map (SENT) but must NOT commit it.
+                var init = lsSettings.GetInitializationOptions();
+
+                // The reset was folded into the init settings map as {value:null, changed:true}.
+                Assert.True(init.Settings.ContainsKey(PflagKeys.SnykOssEnabled));
+                Assert.Null(init.Settings[PflagKeys.SnykOssEnabled].Value);
+                Assert.True(init.Settings[PflagKeys.SnykOssEnabled].Changed);
+
+                // Invariant part 1: after init the reset is STILL queued in the tracker (not committed).
+                Assert.Contains(PflagKeys.SnykOssEnabled, manager.OverrideTracker.PeekPendingResets());
+
+                // Invariant part 2: it is STILL persisted — a fresh manager over the same file (a crash
+                // right after a successful init) rehydrates it, so nothing is lost.
+                var (managerAfterCrash, _, _) = BuildManager(path);
+                managerAfterCrash.Load();
+                Assert.Contains(PflagKeys.SnykOssEnabled,
+                    managerAfterCrash.OverrideTracker.PeekPendingResets());
+
+                // Subsequent successful config-update: peek→send→commit. Commit the exact peeked set
+                // through the manager (what DidChangeConfigurationAsync does on RPC success).
+                var peeked = manager.OverrideTracker.PeekPendingResets();
+                manager.CommitPendingResets(peeked);
+
+                // Now drained from the queue...
+                Assert.DoesNotContain(PflagKeys.SnykOssEnabled, manager.OverrideTracker.PeekPendingResets());
+                // ...and from persistence: a fresh manager over the same file does NOT rehydrate it.
+                var (managerAfterCommit, _, _) = BuildManager(path);
+                managerAfterCommit.Load();
+                Assert.DoesNotContain(PflagKeys.SnykOssEnabled,
+                    managerAfterCommit.OverrideTracker.PeekPendingResets());
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // PENDING-RESET-PERSIST-002 (fix #2): A committed (confirmed-delivered) reset is removed from
+        // persistence too, so a fresh manager over the same file does NOT rehydrate it.
+        [Fact]
+        public void CommittedPendingReset_RemovedFromPersistence_NotRehydrated()
+        {
+            var (manager, optMock, path) = BuildManager();
+            try
+            {
+                manager.Load();
+
+                manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
+                    resetKeys: new List<string> { PflagKeys.Organization });
+                Assert.Contains(PflagKeys.Organization, manager.OverrideTracker.PeekPendingResets());
+
+                // Confirmed-delivered → commit through the manager (updates persistence too).
+                manager.CommitPendingResets(new List<string> { PflagKeys.Organization });
+                Assert.DoesNotContain(PflagKeys.Organization, manager.OverrideTracker.PeekPendingResets());
+
+                // Restart: the committed reset must NOT come back.
+                var (manager2, _, _) = BuildManager(path);
+                manager2.Load();
+
+                Assert.DoesNotContain(PflagKeys.Organization, manager2.OverrideTracker.PeekPendingResets());
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
         // R2 migration-guard test: a settings.json written by a prior version (no seeded marker)
         // that already has a non-empty ChangedConfigKeys set must NOT be discarded by re-seeding.
         // Branch B in Load(): marker absent + keys non-empty → hydrate verbatim + persist marker.

--- a/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
@@ -89,9 +89,10 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
             }
         }
 
-        // INT-002: Save applies the edit-delta to the tracker.
-        // Passing OssEnabled in editedKeys with a non-default value marks it;
-        // passing it again with the default value unmarks it and enqueues a reset.
+        // INT-002 (corrected semantics, PR #515): Save applies the edit-delta to the tracker.
+        // Any key present in editedKeys is an explicit user choice → marked, whether its value is
+        // non-default OR equal to the plugin default. Reset-to-default is no longer inferred from
+        // value==default (that inference caused "enabling Snyk Code doesn't persist").
         [Fact]
         public void Manager_Save_SyncsTrackerFromDeltas()
         {
@@ -108,13 +109,14 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
                 var afterFirstSave = manager.Load();
                 Assert.Contains(PflagKeys.SnykOssEnabled, afterFirstSave.ChangedConfigKeys);
 
-                // Second save: OssEnabled back to true (default), declared as edited key → unmarked.
+                // Second save: OssEnabled at true (its default), declared as edited key → still an
+                // explicit user choice → stays marked (no inferred reset from value==default).
                 optMock.Object.OssEnabled = true;
                 manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
                     editedKeys: new List<string> { PflagKeys.SnykOssEnabled });
 
                 var afterSecondSave = manager.Load();
-                Assert.DoesNotContain(PflagKeys.SnykOssEnabled, afterSecondSave.ChangedConfigKeys);
+                Assert.Contains(PflagKeys.SnykOssEnabled, afterSecondSave.ChangedConfigKeys);
             }
             finally
             {
@@ -401,12 +403,12 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
             }
         }
 
-        // SACC-002: Customer-outcome acceptance test.
-        // A user override is reset to default (override set becomes empty, marker set, persisted).
-        // After a simulated IDE restart, the reset key (and every other current-non-default value
-        // present in the file) must NOT be marked as an override — the empty set is trusted verbatim.
+        // SACC-002 (corrected semantics, PR #515): A key the user edits through the form is an
+        // explicit override, even when the value they land on equals the plugin default. That
+        // explicit override must survive a restart (persisted verbatim, not dropped). Reset-to-default
+        // is no longer inferred from value==default inside the Save/ApplyUserEdits path.
         [Fact]
-        public void ResetSettingStaysResetAcrossRestart_NotReMarkedAsOverride()
+        public void EditedKeyAtDefaultValue_StaysMarkedAsOverrideAcrossRestart()
         {
             var (manager, optMock, path) = BuildManager();
             try
@@ -417,30 +419,26 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
                 manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
                     editedKeys: new List<string> { PflagKeys.SnykIacEnabled });
 
-                // Confirm it is marked before the reset.
                 Assert.Contains(PflagKeys.SnykIacEnabled, manager.OverrideTracker.Snapshot());
 
-                // Step 2: User resets IacEnabled back to its default (true).
+                // Step 2: User edits IacEnabled through the form again, landing on the default (true).
+                // Under the corrected semantics this is still an explicit user choice → stays marked.
                 optMock.Object.IacEnabled = true;
                 manager.Save(optMock.Object, triggerSettingsChangedEvent: false,
                     editedKeys: new List<string> { PflagKeys.SnykIacEnabled });
 
-                // Confirm it is now unmarked (override set empty, marker still set on disk).
-                Assert.DoesNotContain(PflagKeys.SnykIacEnabled, manager.OverrideTracker.Snapshot());
+                Assert.Contains(PflagKeys.SnykIacEnabled, manager.OverrideTracker.Snapshot());
 
-                // Step 3: Simulate IDE restart — FRESH manager from the same file.
-                // The file now carries changedConfigKeysSeeded=true and an empty ChangedConfigKeys
-                // (written by step 2's save). The fresh manager must take Branch C and trust the
-                // empty set verbatim — the reset key must stay unmarked.
+                // Step 3: Simulate IDE restart — FRESH manager from the same file. The explicit
+                // override must survive verbatim (persisted-keys branch), not be dropped.
                 var (manager2, _, _) = BuildManager(path);
                 var loaded = manager2.Load();
 
-                // The reset key must remain unmarked across restart (trusted empty set).
                 Assert.NotNull(loaded.ChangedConfigKeys);
-                Assert.DoesNotContain(PflagKeys.SnykIacEnabled, loaded.ChangedConfigKeys);
+                Assert.Contains(PflagKeys.SnykIacEnabled, loaded.ChangedConfigKeys);
 
-                Assert.False(manager2.OverrideTracker.IsChanged(PflagKeys.SnykIacEnabled),
-                    "A key reset to default must stay unmarked after restart — seeded-marker must gate re-seed");
+                Assert.True(manager2.OverrideTracker.IsChanged(PflagKeys.SnykIacEnabled),
+                    "An explicitly edited key must remain an override after restart");
             }
             finally
             {

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
@@ -473,7 +473,7 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
             Assert.False(await AwaitWithTimeout(localBridge.SaveCompletion)); // apply failed
             Assert.False(localOptions.Object.OssEnabled); // rolled back to baseline, not left at true
             // A failed apply never reaches the persistence step.
-            localManager.Verify(m => m.Save(It.IsAny<IPersistableOptions>(), It.IsAny<bool>()), Times.Never);
+            localManager.Verify(m => m.Save(It.IsAny<IPersistableOptions>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<System.Collections.Generic.IReadOnlyCollection<string>>()), Times.Never);
         }
 
         private static async Task<bool> AwaitWithTimeout(Task<bool> task)

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
@@ -473,7 +473,7 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
             Assert.False(await AwaitWithTimeout(localBridge.SaveCompletion)); // apply failed
             Assert.False(localOptions.Object.OssEnabled); // rolled back to baseline, not left at true
             // A failed apply never reaches the persistence step.
-            localManager.Verify(m => m.Save(It.IsAny<IPersistableOptions>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<System.Collections.Generic.IReadOnlyCollection<string>>()), Times.Never);
+            localManager.Verify(m => m.Save(It.IsAny<IPersistableOptions>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<System.Collections.Generic.IReadOnlyCollection<string>>(), It.IsAny<System.Collections.Generic.IReadOnlyCollection<string>>()), Times.Never);
         }
 
         private static async Task<bool> AwaitWithTimeout(Task<bool> task)
@@ -496,9 +496,10 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
                     It.IsAny<IPersistableOptions>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>(),
+                    It.IsAny<IReadOnlyCollection<string>>(),
                     It.IsAny<IReadOnlyCollection<string>>()))
-                .Callback<IPersistableOptions, bool, bool, IReadOnlyCollection<string>>(
-                    (_, __, ___, keys) => capturedEditedKeys = keys);
+                .Callback<IPersistableOptions, bool, bool, IReadOnlyCollection<string>, IReadOnlyCollection<string>>(
+                    (_, __, ___, keys, ____) => capturedEditedKeys = keys);
 
             // Form sends snyk_oss_enabled.
             var config = JsonConvert.SerializeObject(new { snyk_oss_enabled = true });
@@ -522,9 +523,10 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
                     It.IsAny<IPersistableOptions>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>(),
+                    It.IsAny<IReadOnlyCollection<string>>(),
                     It.IsAny<IReadOnlyCollection<string>>()))
-                .Callback<IPersistableOptions, bool, bool, IReadOnlyCollection<string>>(
-                    (_, __, ___, keys) => capturedEditedKeys = keys);
+                .Callback<IPersistableOptions, bool, bool, IReadOnlyCollection<string>, IReadOnlyCollection<string>>(
+                    (_, __, ___, keys, ____) => capturedEditedKeys = keys);
 
             optionsMock.SetupAllProperties();
 
@@ -547,9 +549,10 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
                     It.IsAny<IPersistableOptions>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>(),
+                    It.IsAny<IReadOnlyCollection<string>>(),
                     It.IsAny<IReadOnlyCollection<string>>()))
-                .Callback<IPersistableOptions, bool, bool, IReadOnlyCollection<string>>(
-                    (_, __, ___, keys) => capturedEditedKeys = keys);
+                .Callback<IPersistableOptions, bool, bool, IReadOnlyCollection<string>, IReadOnlyCollection<string>>(
+                    (_, __, ___, keys, ____) => capturedEditedKeys = keys);
 
             // Form only sends snyk_oss_enabled; snyk_iac_enabled is absent.
             var config = JsonConvert.SerializeObject(new { snyk_oss_enabled = true });
@@ -557,6 +560,66 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
 
             Assert.NotNull(capturedEditedKeys);
             Assert.DoesNotContain(PflagKeys.SnykIacEnabled, capturedEditedKeys);
+        }
+
+        // IDE-2152-UNIT-001: Raw-JSON reset detection distinguishes three cases for a reset-eligible
+        // global key: present JSON null → reset (in resetKeys, NOT in editedKeys); present with a value
+        // → edit (in editedKeys, NOT in resetKeys); absent → untouched (in neither). The reset and
+        // edit channels are disjoint.
+        [Fact]
+        public void SaveIdeConfig_ResetNull_RoutedToResetKeys_DisjointFromEditedKeys()
+        {
+            IReadOnlyCollection<string> capturedEdited = null;
+            IReadOnlyCollection<string> capturedResets = null;
+            snykOptionsManagerMock
+                .Setup(m => m.Save(
+                    It.IsAny<IPersistableOptions>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<IReadOnlyCollection<string>>(),
+                    It.IsAny<IReadOnlyCollection<string>>()))
+                .Callback<IPersistableOptions, bool, bool, IReadOnlyCollection<string>, IReadOnlyCollection<string>>(
+                    (_, __, ___, edited, resets) => { capturedEdited = edited; capturedResets = resets; });
+
+            // snyk_code_enabled = null (reset), snyk_oss_enabled = false (edit), snyk_iac_enabled absent.
+            var config = "{\"snyk_code_enabled\":null,\"snyk_oss_enabled\":false}";
+            bridge.__saveIdeConfig__(config);
+
+            Assert.NotNull(capturedResets);
+            Assert.Contains(PflagKeys.SnykCodeEnabled, capturedResets);
+            Assert.DoesNotContain(PflagKeys.SnykOssEnabled, capturedResets);
+            Assert.DoesNotContain(PflagKeys.SnykIacEnabled, capturedResets);
+
+            Assert.NotNull(capturedEdited);
+            Assert.Contains(PflagKeys.SnykOssEnabled, capturedEdited);
+            // Disjointness: a reset-null key must NOT also be in the edited channel.
+            Assert.DoesNotContain(PflagKeys.SnykCodeEnabled, capturedEdited);
+        }
+
+        // IDE-2152-UNIT-001b: A present JSON null on a key that is NOT reset-eligible must NOT be
+        // routed as a reset (only the 14 GlobalResettableSettings are reset-eligible).
+        [Fact]
+        public void SaveIdeConfig_NullOnNonResettableKey_NotRoutedAsReset()
+        {
+            IReadOnlyCollection<string> capturedResets = null;
+            snykOptionsManagerMock
+                .Setup(m => m.Save(
+                    It.IsAny<IPersistableOptions>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<IReadOnlyCollection<string>>(),
+                    It.IsAny<IReadOnlyCollection<string>>()))
+                .Callback<IPersistableOptions, bool, bool, IReadOnlyCollection<string>, IReadOnlyCollection<string>>(
+                    (_, __, ___, ____, resets) => capturedResets = resets);
+
+            // cli_path is a global key but NOT in the reset-eligible set; a null must not be a reset.
+            // Include a reset-eligible null so the save has at least one recognised key and succeeds.
+            var config = "{\"cli_path\":null,\"organization\":null}";
+            bridge.__saveIdeConfig__(config);
+
+            Assert.NotNull(capturedResets);
+            Assert.DoesNotContain(PflagKeys.CliPath, capturedResets);
+            Assert.Contains(PflagKeys.Organization, capturedResets);
         }
 
         [Fact]

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/HtmlSettingsScriptingBridgeTest.cs
@@ -483,6 +483,82 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
             return await task;
         }
 
+        // PR-REV-BRIDGE-001: Form-driven edit detection — keys present in the form payload must
+        // be passed to Save as editedKeys, regardless of whether the value changed in Options.
+        // This replaces the old snapshot/diff mechanism which dropped keys when before==after.
+        [Fact]
+        public void SaveIdeConfig_FormSentKey_PassesKeyToSaveAsEditedKey()
+        {
+            // Capture what editedKeys is passed to OptionsManager.Save.
+            IReadOnlyCollection<string> capturedEditedKeys = null;
+            snykOptionsManagerMock
+                .Setup(m => m.Save(
+                    It.IsAny<IPersistableOptions>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<IReadOnlyCollection<string>>()))
+                .Callback<IPersistableOptions, bool, bool, IReadOnlyCollection<string>>(
+                    (_, __, ___, keys) => capturedEditedKeys = keys);
+
+            // Form sends snyk_oss_enabled.
+            var config = JsonConvert.SerializeObject(new { snyk_oss_enabled = true });
+            bridge.__saveIdeConfig__(config);
+
+            Assert.NotNull(capturedEditedKeys);
+            Assert.Contains(PflagKeys.SnykOssEnabled, capturedEditedKeys);
+        }
+
+        // PR-REV-BRIDGE-002: Form-driven edit detection — AdditionalParameters in form payload
+        // must produce PflagKeys.AdditionalParameters in editedKeys.
+        // The old snapshot/diff path used ToString() on List<string> and always got equality
+        // (both before and after = "System.Collections.Generic.List`1[...]"), silently dropping
+        // AdditionalParameters from the edit-delta and never recording it as a user override.
+        [Fact]
+        public void SaveIdeConfig_AdditionalParameters_PassedAsEditedKeyToSave()
+        {
+            IReadOnlyCollection<string> capturedEditedKeys = null;
+            snykOptionsManagerMock
+                .Setup(m => m.Save(
+                    It.IsAny<IPersistableOptions>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<IReadOnlyCollection<string>>()))
+                .Callback<IPersistableOptions, bool, bool, IReadOnlyCollection<string>>(
+                    (_, __, ___, keys) => capturedEditedKeys = keys);
+
+            optionsMock.SetupAllProperties();
+
+            // Form sends additional_parameters — a value the user typed.
+            var config = JsonConvert.SerializeObject(new { additional_parameters = "--debug" });
+            bridge.__saveIdeConfig__(config);
+
+            Assert.NotNull(capturedEditedKeys);
+            Assert.Contains(PflagKeys.AdditionalParameters, capturedEditedKeys);
+        }
+
+        // PR-REV-BRIDGE-003: Keys NOT sent by the form must NOT appear in editedKeys.
+        // Only the keys the form actually sent should be passed to Save.
+        [Fact]
+        public void SaveIdeConfig_AbsentKey_NotPassedAsEditedKeyToSave()
+        {
+            IReadOnlyCollection<string> capturedEditedKeys = null;
+            snykOptionsManagerMock
+                .Setup(m => m.Save(
+                    It.IsAny<IPersistableOptions>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<IReadOnlyCollection<string>>()))
+                .Callback<IPersistableOptions, bool, bool, IReadOnlyCollection<string>>(
+                    (_, __, ___, keys) => capturedEditedKeys = keys);
+
+            // Form only sends snyk_oss_enabled; snyk_iac_enabled is absent.
+            var config = JsonConvert.SerializeObject(new { snyk_oss_enabled = true });
+            bridge.__saveIdeConfig__(config);
+
+            Assert.NotNull(capturedEditedKeys);
+            Assert.DoesNotContain(PflagKeys.SnykIacEnabled, capturedEditedKeys);
+        }
+
         [Fact]
         public void SaveIdeConfig_SetsOssEnabled_FromSnakeCaseKey()
         {


### PR DESCRIPTION
### **User description**
## Summary
Visual Studio now records which **global** Snyk configuration keys the user has explicitly overridden, persists that set across sessions, and emits `changed:true` only for those keys (plus the always-changed keys) when sending settings to the language server. This stops organization / LDX-sync defaults from being clobbered for settings the user never touched, bringing VS in line with the VS Code and IntelliJ plugins. (Global settings only — per-folder/project-defaults are out of scope per the ticket.)

## What changed
- **`UserOverrideTracker` + `ConfigDefaults`** (new): seed on first load by comparing each value to its plugin default; thereafter mark only keys the user **actually edits**. The user-edit set is an *edit-delta* computed by the HTML settings dialog (snapshot of global key values before applying the form vs. after) — so a value the org pushed that merely sits in the live options object is never recorded as a user override.
- Persist the override set via `SnykSettings.ChangedConfigKeys` (`NullValueHandling.Ignore`); emit `{value:null, changed:true}` resets when a setting returns to default.
- **Save-path classification:** LS/system-originated saves (config push, auth result, CLI download, legacy migration) persist values *without* touching the tracker (`updateOverrideTracker:false`); only genuine user edits record overrides.
- **`IsSeeded` gate:** until `Load()` seeds the tracker, `BuildSettingsMap` falls back to `changed:true` for every key, so a startup-ordering race can't silently downgrade overrides.
- `alwaysChanged` keys (`trusted_folders`, `trust_enabled`, `automatic_authentication`) always emit `changed:true`.

## Testing
This is a **Windows-only** extension; build + unit/integration tests run on the `windows-2022` CI runners (they cannot run on the authoring environment). New xUnit coverage: `UserOverrideTrackerTests`, `ConfigDefaultsTests`, `UserOverridePersistenceTests`, plus additions to `LsSettingsV25Tests` and `SnykLanguageClientCustomTargetTests`. **Please confirm the CI run is green before merge.**

## PR size
~2.2k changed lines, but **~1.4k is tests**; production is ~770 lines and is a single interdependent unit (tracker + persistence + LS wiring + settings-UI). It is intentionally **not** split into a stack — an artificial split would produce dead-code intermediate PRs (e.g. a tracker with no callers) that are harder to review and wouldn't pass CI in isolation.

## Notes for reviewers (by-design / follow-ups)
- **Upgrade seed trade-off:** on the one-time first load after this change, the override set is seeded by comparing persisted values to plugin defaults (the strategy the ticket specifies and the VS Code/IntelliJ references use). Pre-upgrade `settings.json` carries no provenance, so an org-pushed non-default value present before upgrade is treated as a user override. The alternative (seed empty) would *lose genuine* pre-existing user overrides, which is worse.
- **`cli_path` / `scan_automatic`:** when the user hasn't overridden these, they are sent `changed:false` (deferring to org/LDX defaults) — this is the intended behavior of the feature, not a regression from the prior always-`changed:true`.
- **Follow-up (minor):** `BranchSelectorDialogWindow.Save` (a folder-only change) could pass `updateOverrideTracker:false` for consistency; current behavior is safe (verified) since the tracker is always seeded by the time that dialog can open.

## Test plan
- [ ] `windows-2022` CI: build + unit + integration green
- [ ] Manual: org pushes a non-default setting; user opens & saves the settings page without touching it; org later changes that setting → the change still takes effect (no freeze)
- [ ] Manual: user explicitly changes a setting → sent `changed:true`, survives restart; resetting to default sends a reset


___

### **PR Type**
Enhancement


___

### **Description**
- Track user-overridden global settings keys.

- Prevent accidental overwrites of defaults/org values.

- Handle resets via UI and LS events.

- Improve persistence thread-safety and sync.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI[Settings UI] -->|User edits value| HtmlSettingsScriptingBridge
  LS[Language Server] -->|LS pushes settings| SnykLanguageClientCustomTarget
  HtmlSettingsScriptingBridge -->|Save request| SnykOptionsManager
  SnykLanguageClientCustomTarget -->|LS Save| SnykOptionsManager
  SnykOptionsManager -->|Mutate Options + Tracker| UserOverrideTracker
  UserOverrideTracker -->|Track overrides / resets| ConfigDefaults
  SnykOptionsManager -->|Persist state| settings.json
  SnykOptionsManager -->|Notify LS| SnykLanguageClient
  SnykLanguageClient -->|Build settings map| LsSettingsV25
  LsSettingsV25 -->|Use Tracker state| ConfigSetting
  ConfigSetting -->|Send to LS| LanguageServer
  UI -->|Reset overrides| HtmlSettingsScriptingBridge
  HtmlSettingsScriptingBridge -->|Detects nulls| ParseAndSaveConfigAsync
  ParseAndSaveConfigAsync -->|Identifies resets| DetectGlobalResetKeys
  SnykOptionsManager -->|Commit resets (on confirmed send)| UserOverrideTracker
  UserOverrideTracker -->|Clear pending resets| SnykOptionsManager
  SnykOptionsManager -->|Persist cleared resets| settings.json
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>UserOverrideTracker.cs</strong><dd><code>Implement core user override tracking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-ac2d248df99e377a24bcb8bfb98dff1c92ada642fc95cb4c7146cbe67ab1df04">+284/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ConfigDefaults.cs</strong><dd><code>Define default values for global settings keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-ef76604714a96630ddeaebc748510bc8c2296959914b91b9563c29ea036f5480">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SnykOptionsManager.cs</strong><dd><code>Manage persistence with override tracking and thread-safety</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-9719f1759d69640780fac0222473c9ab8233003553897a17b6b2bb2d77c768ae">+377/-7</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SnykLanguageClient.cs</strong><dd><code>Serialize configuration updates and handle pending resets</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-d60ea7fa16cd69736011b8cad474f5de77abb66f63a73e3a749bbeffc2b69634">+118/-6</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>HtmlSettingsScriptingBridge.cs</strong><dd><code>Derive edit/reset deltas from UI save payloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-4c0d10ba077f83735e5f1b8914c303574d69914e348658e01a188be777f64faa">+148/-35</a></td>

</tr>

<tr>
  <td><strong>LsSettingsV25.cs</strong><dd><code>Integrate tracker state into settings map sent to LS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-f1b9978895992d23a441bc01c7d003d26b3c07fa047cb184937f7bf54437180c">+94/-36</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SnykOptions.cs</strong><dd><code>Add fields for tracking overrides and pending resets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-662346a68ff116cc42e065f67cfd634519beb1d62e338efaad46637cfff2595f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PflagKeys.cs</strong><dd><code>Define always-changed and resettable key properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-695bdf7605c9dba89b89f83216679499f968463b5e4907cb6f342328b40da524">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ConfigSetting.cs</strong><dd><code>Add factory methods for config settings and resets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-3e4ecc1567bf867abc7905ff49e2f358734f82f24980089f969e71af9b83edbb">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WorkspaceTrustService.cs</strong><dd><code>Prevent trusted folder changes from polluting user overrides</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-aabbeee2bacc6951c6b7acaecf2e08cc8c2dfced24223f0a9f255946c8d4b8d7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>SnykSettingsLoader.cs</strong><dd><code>Improve corrupt file handling for token recovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-356d5b303e1180b383ee854697477ca16c8c85f6008dd51673464a6eb90f0b93">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>LoadReadUnderPersistGateTests.cs</strong><dd><code>Test Load serialization safety with concurrent writes</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>SettingsPersistenceConcurrencyTests.cs</strong><dd><code>Test concurrent Save and CommitPendingResets operations</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-621d132c58e7e928592edff080bb86852dd72c69704af4f3dfcaf1abb338c35d">+160/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>UserOverridePersistenceTests.cs</strong><dd><code>Integration tests for override persistence and seeding</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-f352c857a3750c68bf5b6a632de97b1c316905194aea6d5ac721dda57c914ef8">+722/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>UserOverrideTrackerTests.cs</strong><dd><code>Unit tests for user override tracker logic and invariants</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-e56312274b6c6342d390227842ee8e1ac4102e60f62e0c441ab0b41a554e0be5">+848/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>LsSettingsV25Tests.cs</strong><dd><code>Tests for BuildSettingsMap incorporating override tracking</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-df5c7ba10f6ff233a9cddbc98511c075645dd0dcb65930deb4f03b08aba519ae">+417/-5</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SnykOptionsManagerCorruptFileTests.cs</strong><dd><code>Tests for handling corrupt settings files and token recovery</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-1e9cbc7ec3af849fd5327f6e5d2a555cfe70f8ac14f97f1ff3796fef95dfecfa">+347/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SnykLanguageClientTest.cs</strong><dd><code>Tests for DidChangeConfigurationAsync serialization and reset handling</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-7139953b3320c0d0efb51924a1dec18b2497511d4b80f7c3e07edef95da650ae">+242/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>BranchSelectorDialogWindow.xaml.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-c15f3c2db4680e4fa5bad62f1d1ab1775c404c9b5594bc82339bded23423c94e">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SnykLanguageClientCustomTarget.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-5556d7cbff3426e2b03f52e3ef3ea7c14685992d483cb67eed6e1d4851eb464e">+16/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>IUserOverrideTracker.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-37f4605abe1c5dd85809586da9c12b9a5249810a5cbfc485ac39d1fd87f4bb9d">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SnykTasksService.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-b78dc99337b2fb845b90748a56562271701b26c37e213653762251c54ca960b8">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>IPersistableOption.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-208f0a293d534d7561c22128792906c80e7fe5628a6088b0a0b6e572a3712cab">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ISnykOptionsManager.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-b2d047c2b33525b2a7bba3128d78df3e30fc76eb03f160fa520483da9fed4952">+38/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SnykSettings.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-66df776dbc99ed39a16e4ce974d885f78348445f17bebf3bffe177c51573ec57">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Snyk.VisualStudio.Extension.2022.csproj</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-ffc9b9d614511c8a19eb20120b39b7dfcb6fc091e2ec16c1fb2377faea08b0a7">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SnykScriptManager.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-c26082b0a92a84e1c20479a1c820c848dbda0d7f3935b08da0feb5ccd2e9a361">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ConfigDefaultsTests.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-f939316304f7bf511f87528590a76bbcbeb96e04f533cacd50fad78f5df1b031">+187/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SnykLanguageClientCustomTargetTests.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-de628f760a5e4a949d0a8fc52ae612cdce9eb8ac6f7ce0a26c0b5c5287622806">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WorkspaceTrustServiceTest.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-c6e78910ae45ee0b4542992181707f82b07db57552413b1e5ca588a140ec79e3">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GlobalResetPropagationTests.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-9869f8723328b4e0eb4d832767ea185ca5f6f4411267b2e231948019975769a4">+284/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>LoadReadUnderPersistGateTests.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-2405dd208c962566603d8edfc1bad5d0b424e6882c91683673fb5fc86cd4fc1e">+214/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>HtmlSettingsScriptingBridgeTest.cs</strong></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/515/changes#diff-1716093281e3251a1c09073a640a50cf36fce573ca7110dea88e5e961ccac4f1">+140/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

