### PR TITLE
fix: send automatic_authentication=false to the language server

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/Authentication/AuthenticationFlowService.cs
+++ b/Snyk.VisualStudio.Extension.2022/Authentication/AuthenticationFlowService.cs
@@ -91,6 +91,12 @@ namespace Snyk.VisualStudio.Extension.Authentication
                     {
                         try
                         {
+                            // The logout is load-bearing, not just hygiene: InvokeLogin sends
+                            // snyk.login with no arguments, which skips the LS's own provider
+                            // configuration. The LS configures its auth provider unconditionally on
+                            // logout, so this ordering is what leaves a provider in place for the
+                            // login that follows. Reversing or dropping it fails a fresh-install
+                            // login with "authentication provider is not configured".
                             await serviceProvider.LanguageClientManager.InvokeLogout(serviceProvider.DisposalToken);
                             Logger.Information("Invoking InvokeLogin for auth");
                             await serviceProvider.LanguageClientManager.InvokeLogin(serviceProvider.DisposalToken);

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/LsSettingsV25.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/LsSettingsV25.cs
@@ -102,6 +102,15 @@ namespace Snyk.VisualStudio.Extension.Language
                 [PflagKeys.Token]                   = Cs(PflagKeys.Token,                  options.ApiToken?.ToString() ?? string.Empty),
                 [PflagKeys.Organization]            = Cs(PflagKeys.Organization,           options.Organization ?? string.Empty),
                 [PflagKeys.AuthenticationMethod]    = Cs(PflagKeys.AuthenticationMethod,   options.AuthenticationMethod.ToString().ToLowerInvariant()),
+                // automatic_authentication=false: the IDE owns the auth flow, so the LS must not
+                // auto-authenticate on startup. Matches VS Code, JetBrains and Eclipse.
+                //
+                // Of(), not Cs(): the LS ignores a setting sent with changed:false and applies its
+                // own default of true. Auto-authenticating fails on a fresh install, and that error
+                // aborts the LS's scanner init before it initialises the scan-state aggregator —
+                // which is what pushes the issue tree, so the tree never populates for the rest of
+                // the session. See snyk-ls infrastructure/authentication/initializer.go.
+                [PflagKeys.AutomaticAuthentication] = ConfigSetting.Of(false),
                 [PflagKeys.ProxyInsecure]           = Cs(PflagKeys.ProxyInsecure,          options.IgnoreUnknownCA),
 
                 [PflagKeys.AutomaticDownload]       = Cs(PflagKeys.AutomaticDownload,      options.BinariesAutoUpdate),

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/PflagKeys.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/PflagKeys.cs
@@ -43,9 +43,11 @@ namespace Snyk.VisualStudio.Extension.Language
 
         // Trust
         public const string TrustedFolders = "trusted_folders";
-        // Keys for always-changed set per AC M4 (defined in LS spec; not currently in VS BuildSettingsMap
-        // but included so the AlwaysChanged set is complete for when they are added).
+        // trust_enabled is defined in the LS spec and belongs to the always-changed set, but is not
+        // yet emitted by BuildSettingsMap — trust enforcement still lives on the IDE side.
         public const string TrustEnabled = "trust_enabled";
+        // Emitted as an unconditional false by BuildSettingsMap via ConfigSetting.Of, so it is
+        // deliberately NOT in the always-changed set below — that set is for tracker-gated keys.
         public const string AutomaticAuthentication = "automatic_authentication";
 
         // Folder-level
@@ -71,7 +73,6 @@ namespace Snyk.VisualStudio.Extension.Language
         {
             TrustedFolders,
             TrustEnabled,
-            AutomaticAuthentication,
         };
 
         /// <summary>

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
@@ -309,6 +309,37 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
                 "because PflagKeys.IsAlwaysChanged must return true for it");
         }
 
+        // automatic_authentication=false stops the LS auto-authenticating on startup — the IDE owns
+        // the auth flow (matches VS Code, JetBrains and Eclipse). It must carry changed:true: the LS
+        // ignores changed:false and applies its own default of true, which on a fresh install aborts
+        // its scanner init and leaves the issue tree empty for the whole session.
+        //
+        // The tracker is real and seeded with no marks, and this key is deliberately NOT in
+        // PflagKeys._alwaysChanged — so the changed:true assertion below genuinely fails if the
+        // emission is switched to the tracker-gated Cs() helper.
+        [Fact]
+        public void BuildSettingsMap_AutomaticAuthentication_AlwaysSentFalse()
+        {
+            SetupDefaults();
+            var realTracker = new UserOverrideTracker();
+            realTracker.SeedFrom(BuildDefaultOptionsForSeed());
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(realTracker);
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            Assert.True(map.ContainsKey(PflagKeys.AutomaticAuthentication),
+                "automatic_authentication must be present so the LS does not auto-authenticate on startup");
+            Assert.Equal(false, map[PflagKeys.AutomaticAuthentication].Value);
+            Assert.True(map[PflagKeys.AutomaticAuthentication].Changed,
+                "automatic_authentication must be sent with changed:true, " +
+                "because the LS ignores entries with changed:false and applies its default of true");
+
+            // The handshake is the path that actually matters: the LS reads this key during
+            // initialize, before the auth initializer runs.
+            Assert.True(cut.GetInitializationOptions().Settings.ContainsKey(PflagKeys.AutomaticAuthentication),
+                "the key must reach the LS in the initialize handshake, not just in BuildSettingsMap");
+        }
+
         // ACC-004: A peeked pending reset is folded into the map as {value:null, changed:true}.
         // BuildSettingsMap peeks non-destructively (IDE-2152 CP 2.2); the caller commits on send success.
         [Fact]


### PR DESCRIPTION
### **User description**
## Summary

On a fresh install the issue tree stays empty after a scan, even though the scan completes and the language server reports success. Only closing and reopening the solution recovers it.

`BuildSettingsMap` never emitted the `automatic_authentication` pflag, so snyk-ls applied its own default of `true` and ran its startup auth initializer. On a fresh install that fails (`"authentication provider is not configured"`), and the error aborts snyk-ls's scanner init **before** it initialises the scan-state aggregator:

1. `scannerInstance.Init()` errors → `initializedHandler` returns early (`application/server/server.go:986`), skipping `command.HandleFolders` on `:991`
2. `HandleFolders` is the only caller of `initScanStateAggregator` (`domain/ide/command/folder_handler.go:163`), so the aggregator's maps stay empty for the whole session
3. every `SetScanState` then early-returns at `domain/scanstates/scan_state_aggregator.go:244` **without** calling `Emit`
4. the tree emitter (`domain/ide/treeview/tree_scan_emitter.go:133`) fires only on that `Emit`, so the issue tree is never pushed

`$/snyk.scan` travels a different path, which is why the LS log looks healthy while the tree stays blank.

VS Code, JetBrains and Eclipse all pin this key to `false` already — the IDE owns the auth flow in every one of them. VS was the only client that omitted it.

## Notes for review

- Emitted via `ConfigSetting.Of` rather than the tracker-gated `Cs` helper: snyk-ls **ignores** any setting sent with `changed:false` and applies its own default, so this value must not depend on user-override state.
- The key is correspondingly dropped from `PflagKeys._alwaysChanged` (which is for tracker-gated keys). Keeping both mechanisms would have made the new test unable to detect a regression back to `Cs()` — `IsChanged` short-circuits on always-changed keys, so the two would be indistinguishable.
- Also documents why `AuthenticationFlowService` logs out before logging in: `snyk.login` is sent with no arguments, so it skips the LS's own provider configuration, and the unconditional configure-on-logout is the only thing leaving a provider in place for the login that follows. Comment only — worth pinning so it isn't "simplified" away.

## Known follow-ups (not in this PR)

- **snyk-ls:** this closes one of at least three routes to the same blank-tree symptom. `cliInitializer` has two further error returns (`infrastructure/cli/initializer.go:75` and `:101`) that abort the same init chain — the first reachable simply by disabling CLI auto-download. `HandleFolders` should not be gated behind `scannerInstance.Init()` succeeding.
- **This repo:** the VS client has no `window/showMessageRequest` handler, so snyk-ls's re-auth prompt for a server-side-revoked token is never surfaced. Pre-existing, neither caused nor worsened here.

## Test plan

- [x] New unit test asserts the key is present, `false`, `changed:true`, and reaches `GetInitializationOptions().Settings` (the handshake path snyk-ls actually reads).
- [ ] **CI must run the suite** — the change was developed on macOS, where these net48 projects cannot be built (`MSB3644`, no .NET Framework reference assemblies). Compile and test success is unverified locally.
- [ ] Manual: fresh install against a clean profile, scan, confirm the tree populates without reopening the solution.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix empty issue tree on fresh install.

- Prevent language server auto-authentication on startup.

- Ensure correct auth provider configuration flow.

- Add new test for authentication setting.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  VS_Extension["Visual Studio Extension"] --> SettingsMap["BuildSettingsMap"]
  SettingsMap -- "automatic_authentication=false" --> LanguageServer["Language Server"]
  VS_Extension -- "InvokeLogout/Login" --> LanguageServer
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AuthenticationFlowService.cs</strong><dd><code>Ensure proper auth flow initiation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Snyk.VisualStudio.Extension.2022/Authentication/AuthenticationFlowService.cs

<ul><li>Explicitly invoke <code>InvokeLogout</code> and <code>InvokeLogin</code> for authentication.<br> <li> Ensures the language server correctly configures its auth provider.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/527/changes#diff-72a7ae56be34991fb2817767359876b977a0146d0e9b7d4b6924c254ba3a3d7e">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LsSettingsV25.cs</strong><dd><code>Configure language server auto-authentication setting</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Snyk.VisualStudio.Extension.2022/Language/V25/LsSettingsV25.cs

<ul><li>Add <code>automatic_authentication</code> setting and explicitly set it to <code>false</code>.<br> <li> Use <code>ConfigSetting.Of()</code> to ensure the setting is sent correctly to the <br>language server.<br> <li> Added comments explaining the purpose and impact of this setting.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/527/changes#diff-f1b9978895992d23a441bc01c7d003d26b3c07fa047cb184937f7bf54437180c">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PflagKeys.cs</strong><dd><code>Update language server flag definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Snyk.VisualStudio.Extension.2022/Language/V25/PflagKeys.cs

<ul><li>Define the <code>AutomaticAuthentication</code> pflag key.<br> <li> Remove <code>AutomaticAuthentication</code> from the <code>_alwaysChanged</code> set as it's now <br>handled differently.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/527/changes#diff-695bdf7605c9dba89b89f83216679499f968463b5e4907cb6f342328b40da524">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LsSettingsV25Tests.cs</strong><dd><code>Test language server authentication configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs

<ul><li>Add a new test to verify <code>automatic_authentication</code> is set to <code>false</code>.<br> <li> Ensure the setting is marked as <code>Changed: true</code> and is present in <br>initialization options.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/527/changes#diff-df5c7ba10f6ff233a9cddbc98511c075645dd0dcb65930deb4f03b08aba519ae">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

