### PR TITLE
fix: code enablement on upgrade [IDE-2403]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigDefaults.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigDefaults.cs
@@ -13,14 +13,19 @@ namespace Snyk.VisualStudio.Extension.Language
         // Mirrors SnykSettings field initializers exactly so seed comparison is accurate.
         // CLI string defaults reference SnykCliDownloader constants (same source as SnykSettings
         // initializers) so they cannot silently drift. Boolean product/scan/severity/view defaults
-        // are set to the same literal values as SnykSettings field initializers; the test
+        // are set to the same literal values as SnykSettings field initializers (except
+        // snyk_code_enabled, which references SnykSettings.DefaultSnykCodeSecurityEnabled); the test
         // ConfigDefaults_BooleanValues_MatchSnykSettingsFieldInitializers (ConfigDefaultsTests.cs)
         // acts as a drift guard by constructing new SnykSettings() and comparing via GetDefaultForTest.
         private static readonly Dictionary<string, object> Defaults = new Dictionary<string, object>
         {
             // Products
             [PflagKeys.SnykOssEnabled]           = true,
-            [PflagKeys.SnykCodeEnabled]           = true,
+            // References the SnykSettings const rather than repeating the literal: Snyk Code is the
+            // one product whose default must track the Language Server (which does not
+            // default-enable it), and a drift between the two defaults silently downgrades an
+            // enabled-Code user to changed:false on upgrade.
+            [PflagKeys.SnykCodeEnabled]           = Settings.SnykSettings.DefaultSnykCodeSecurityEnabled,
             [PflagKeys.SnykIacEnabled]            = true,
             [PflagKeys.SnykSecretsEnabled]        = false,
 

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigDefaults.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigDefaults.cs
@@ -10,21 +10,14 @@ namespace Snyk.VisualStudio.Extension.Language
     // Keys absent from this map are treated as "no default known" — IsDefault returns false.
     internal static class ConfigDefaults
     {
-        // This map holds the default of each key's PROJECTED value — the form produced by
-        // UserOverrideTracker.GetGlobalKeyValues and which BuildSettingsMap sends.
-        //
-        // These might not match the  default of the backing SnykSettings field. For instance:
-        //
-        //   api_endpoint          "" here, but SnykSettings.CustomEndpoint defaults to null
-        //   organization          "" here, but SnykSettings.Organization defaults to null
-        //   additional_parameters "" here (space-joined), but the field is a List<string>
-        //   authentication_method lowercase string here, but the field is an enum
+        // Defaults of each key's PROJECTED value — the form UserOverrideTracker.GetGlobalKeyValues
+        // produces and BuildSettingsMap sends. These need not match the backing SnykSettings field's
+        // default: api_endpoint and organization are "" here but null on the field,
+        // additional_parameters is space-joined from a List<string>, authentication_method is a
+        // lowercase string from an enum.
         private static readonly Dictionary<string, object> Defaults = new Dictionary<string, object>
         {
             // Products — reference the SnykSettings consts rather than duplicating them.
-            // Each must also equal the Language Server's registered default
-            // (snyk-ls internal/types/register_configurations.go), because a user override is
-            // classified by "value != default". 
             [PflagKeys.SnykOssEnabled]            = Settings.SnykSettings.DefaultOssEnabled,
             [PflagKeys.SnykCodeEnabled]           = Settings.SnykSettings.DefaultSnykCodeSecurityEnabled,
             [PflagKeys.SnykIacEnabled]            = Settings.SnykSettings.DefaultIacEnabled,

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigDefaults.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigDefaults.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using Snyk.VisualStudio.Extension.Authentication;
 using Snyk.VisualStudio.Extension.Download;
+using Snyk.VisualStudio.Extension.Settings;
 
 namespace Snyk.VisualStudio.Extension.Language
 {
@@ -18,10 +19,10 @@ namespace Snyk.VisualStudio.Extension.Language
         private static readonly Dictionary<string, object> Defaults = new Dictionary<string, object>
         {
             // Products — reference the SnykSettings consts rather than duplicating them.
-            [PflagKeys.SnykOssEnabled]            = Settings.SnykSettings.DefaultOssEnabled,
-            [PflagKeys.SnykCodeEnabled]           = Settings.SnykSettings.DefaultSnykCodeSecurityEnabled,
-            [PflagKeys.SnykIacEnabled]            = Settings.SnykSettings.DefaultIacEnabled,
-            [PflagKeys.SnykSecretsEnabled]        = Settings.SnykSettings.DefaultSecretsEnabled,
+            [PflagKeys.SnykOssEnabled]            = SnykSettings.DefaultOssEnabled,
+            [PflagKeys.SnykCodeEnabled]           = SnykSettings.DefaultSnykCodeSecurityEnabled,
+            [PflagKeys.SnykIacEnabled]            = SnykSettings.DefaultIacEnabled,
+            [PflagKeys.SnykSecretsEnabled]        = SnykSettings.DefaultSecretsEnabled,
 
             // Scan
             [PflagKeys.ScanAutomatic]             = true,

--- a/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigDefaults.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/V25/ConfigDefaults.cs
@@ -10,24 +10,25 @@ namespace Snyk.VisualStudio.Extension.Language
     // Keys absent from this map are treated as "no default known" — IsDefault returns false.
     internal static class ConfigDefaults
     {
-        // Mirrors SnykSettings field initializers exactly so seed comparison is accurate.
-        // CLI string defaults reference SnykCliDownloader constants (same source as SnykSettings
-        // initializers) so they cannot silently drift. Boolean product/scan/severity/view defaults
-        // are set to the same literal values as SnykSettings field initializers (except
-        // snyk_code_enabled, which references SnykSettings.DefaultSnykCodeSecurityEnabled); the test
-        // ConfigDefaults_BooleanValues_MatchSnykSettingsFieldInitializers (ConfigDefaultsTests.cs)
-        // acts as a drift guard by constructing new SnykSettings() and comparing via GetDefaultForTest.
+        // This map holds the default of each key's PROJECTED value — the form produced by
+        // UserOverrideTracker.GetGlobalKeyValues and which BuildSettingsMap sends.
+        //
+        // These might not match the  default of the backing SnykSettings field. For instance:
+        //
+        //   api_endpoint          "" here, but SnykSettings.CustomEndpoint defaults to null
+        //   organization          "" here, but SnykSettings.Organization defaults to null
+        //   additional_parameters "" here (space-joined), but the field is a List<string>
+        //   authentication_method lowercase string here, but the field is an enum
         private static readonly Dictionary<string, object> Defaults = new Dictionary<string, object>
         {
-            // Products
-            [PflagKeys.SnykOssEnabled]           = true,
-            // References the SnykSettings const rather than repeating the literal: Snyk Code is the
-            // one product whose default must track the Language Server (which does not
-            // default-enable it), and a drift between the two defaults silently downgrades an
-            // enabled-Code user to changed:false on upgrade.
+            // Products — reference the SnykSettings consts rather than duplicating them.
+            // Each must also equal the Language Server's registered default
+            // (snyk-ls internal/types/register_configurations.go), because a user override is
+            // classified by "value != default". 
+            [PflagKeys.SnykOssEnabled]            = Settings.SnykSettings.DefaultOssEnabled,
             [PflagKeys.SnykCodeEnabled]           = Settings.SnykSettings.DefaultSnykCodeSecurityEnabled,
-            [PflagKeys.SnykIacEnabled]            = true,
-            [PflagKeys.SnykSecretsEnabled]        = false,
+            [PflagKeys.SnykIacEnabled]            = Settings.SnykSettings.DefaultIacEnabled,
+            [PflagKeys.SnykSecretsEnabled]        = Settings.SnykSettings.DefaultSecretsEnabled,
 
             // Scan
             [PflagKeys.ScanAutomatic]             = true,

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
@@ -427,10 +427,10 @@ namespace Snyk.VisualStudio.Extension.Settings
         }
 
         // One-shot recovery of Snyk Code enablement for installs created before this migration
-        // existed. Snyk Code is the only product the Language Server does not default-enable — it
-        // requires an explicit changed:true to turn on, whereas OSS and IaC come up enabled from the
-        // LS's own defaults. An upgrading user whose stored preference was "Code on" therefore loses
-        // Code scanning outright unless that preference is carried across as an explicit override.
+        // existed. The Language Server default-enables OSS and IaC but not Code, so Code only turns
+        // on when it receives an explicit changed:true. An upgrading user whose stored preference was
+        // "Code on" therefore loses Code scanning outright unless that preference is carried across
+        // as an explicit override — a value sent changed:false reads to the LS as "no preference".
         //
         // Called from Load() only, already inside persistGate, and AFTER the seed branches — see the
         // ordering note at the call site. Sets the marker in memory only, because Load() must never

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
@@ -94,7 +94,18 @@ namespace Snyk.VisualStudio.Extension.Settings
 
             this.snykSettings = new SnykSettings();
             if (fileWasAbsent)
+            {
+                // Genuine fresh install: stamp the code-enablement marker BEFORE the write, so the
+                // very first settings.json on disk records "nothing to migrate". This is what makes
+                // a missing marker an unambiguous upgrade signal in MigrateCodeEnablement — without
+                // it, a fresh install whose Language Server never started (so no real Save ever
+                // ran) would look identical to an upgrading install on its second launch and get a
+                // phantom Snyk Code override. Deliberately NOT set on the present-but-unreadable
+                // path: that object is blank defaults over a recoverable file, and stamping it here
+                // would burn the one-shot migration for a user whose real settings are still on disk.
+                this.snykSettings.CodeEnablementMigrated = true;
                 SaveSettingsToFile();
+            }
         }
 
         public void SaveSettingsToFile()
@@ -394,6 +405,13 @@ namespace Snyk.VisualStudio.Extension.Settings
                 overrideTracker.MarkSeeded();
             }
 
+            // Recover Snyk Code enablement for installs that predate this migration. MUST run AFTER
+            // the branch chain above: Branch A calls SeedFrom, which Clear()s the changed set, so a
+            // mark applied before it would be silently discarded. (VS Code runs its equivalent
+            // migration BEFORE its seed because it materialises a setting *value* the seed then
+            // reads; here we mark the tracker directly, which inverts the ordering.)
+            MigrateCodeEnablement();
+
             // Rehydrate persisted-but-unconfirmed pending resets (IDE-2152 fix #2) AFTER the changed
             // set has been hydrated by the branch above, so RehydratePendingResets can skip any key
             // that is now a live override mark (a persisted override means the user re-applied the key
@@ -406,6 +424,67 @@ namespace Snyk.VisualStudio.Extension.Settings
             options.ChangedConfigKeys = overrideTracker.Snapshot();
             return options;
             } // release persistGate (returning from inside the lock releases it)
+        }
+
+        // One-shot recovery of Snyk Code enablement for installs created before this migration
+        // existed. Snyk Code is the only product the Language Server does not default-enable — it
+        // requires an explicit changed:true to turn on, whereas OSS and IaC come up enabled from the
+        // LS's own defaults. An upgrading user whose stored preference was "Code on" therefore loses
+        // Code scanning outright unless that preference is carried across as an explicit override.
+        //
+        // Called from Load() only, already inside persistGate, and AFTER the seed branches — see the
+        // ordering note at the call site. Sets the marker in memory only, because Load() must never
+        // write (DEFERRED-PERSIST); the next real Save persists it, exactly as it does for
+        // ChangedConfigKeysSeeded.
+        //
+        // internal for testability (InternalsVisibleTo).
+        internal void MigrateCodeEnablement()
+        {
+            // Already evaluated. Fresh installs are stamped when their settings.json is created, so
+            // reaching here with the marker set means there is nothing to recover — and re-running
+            // would resurrect an override the user may have deliberately reset since.
+            if (snykSettings.CodeEnablementMigrated)
+                return;
+
+            // Present-but-unreadable: snykSettings is blank defaults sitting over a recoverable file,
+            // so its SnykCodeSecurityEnabled says nothing about the user's real preference. Leave the
+            // marker unset too, so the migration is re-evaluated against the real file on the next
+            // process start rather than being burned on blank state (IDE-1483 guard).
+            if (settingsFileWasUnreadable)
+                return;
+
+            // Only "Code was on" needs rescuing. A stored false already resolves correctly: either it
+            // equals the plugin default and the LS leaves Code off, or it is a genuine override that
+            // SeedFrom has already marked.
+            //
+            // The two negative guards keep this from fighting the user: an existing mark means the
+            // state is already carried (the common path after the default flip, where SeedFrom marks
+            // a stored true by itself), and a queued reset means the user explicitly returned Code to
+            // the org/LDX-Sync default — re-marking would silently undo that.
+            if (snykSettings.SnykCodeSecurityEnabled &&
+                !overrideTracker.IsChanged(PflagKeys.SnykCodeEnabled) &&
+                !(snykSettings.PendingResetConfigKeys?.Contains(PflagKeys.SnykCodeEnabled) ?? false))
+            {
+                // Carry the pre-existing enabled state across as explicit user intent so the LS
+                // receives changed:true and starts the Code scanner. This can outrank an org/LDX-Sync
+                // value, which is the same deliberate trade-off the other IDE plugins made: preserving
+                // the security coverage the user already had beats deferring to governance on upgrade.
+                overrideTracker.Mark(PflagKeys.SnykCodeEnabled);
+
+                // Mirror the mark onto snykSettings so the in-memory object stays coherent with the
+                // tracker, exactly as Branch A does for its seeded set. This is load-bearing, not
+                // tidiness: Save(updateOverrideTracker:false) — the LS-originated $/snyk.configuration
+                // echo, and frequently the only Save in a session — serialises snykSettings verbatim
+                // without re-reading the tracker. A mark living only in the tracker would be dropped at
+                // the next restart while CodeEnablementMigrated (whole-object serialised) survived,
+                // so the migration would not re-run and Snyk Code would silently switch off again.
+                var migrated = overrideTracker.Snapshot();
+                snykSettings.ChangedConfigKeys = migrated.Count > 0 ? migrated : null;
+            }
+
+            // Record the evaluation whatever the outcome — the decision is only meaningful against the
+            // pre-upgrade file, and re-running later would undo a subsequent user reset.
+            snykSettings.CodeEnablementMigrated = true;
         }
 
         // Testable seam over the top of Load()'s guarded read region (mirrors the CopyFile seam). A

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykOptionsManager.cs
@@ -95,14 +95,10 @@ namespace Snyk.VisualStudio.Extension.Settings
             this.snykSettings = new SnykSettings();
             if (fileWasAbsent)
             {
-                // Genuine fresh install: stamp the code-enablement marker BEFORE the write, so the
-                // very first settings.json on disk records "nothing to migrate". This is what makes
-                // a missing marker an unambiguous upgrade signal in MigrateCodeEnablement — without
-                // it, a fresh install whose Language Server never started (so no real Save ever
-                // ran) would look identical to an upgrading install on its second launch and get a
-                // phantom Snyk Code override. Deliberately NOT set on the present-but-unreadable
-                // path: that object is blank defaults over a recoverable file, and stamping it here
-                // would burn the one-shot migration for a user whose real settings are still on disk.
+                // Fresh install: stamp the marker before the write so the first settings.json records
+                // "nothing to migrate", making a missing marker an unambiguous upgrade signal. Not
+                // set on the present-but-unreadable path — that would burn the one-shot migration for
+                // a user whose real settings are still on disk.
                 this.snykSettings.CodeEnablementMigrated = true;
                 SaveSettingsToFile();
             }
@@ -405,11 +401,8 @@ namespace Snyk.VisualStudio.Extension.Settings
                 overrideTracker.MarkSeeded();
             }
 
-            // Recover Snyk Code enablement for installs that predate this migration. MUST run AFTER
-            // the branch chain above: Branch A calls SeedFrom, which Clear()s the changed set, so a
-            // mark applied before it would be silently discarded. (VS Code runs its equivalent
-            // migration BEFORE its seed because it materialises a setting *value* the seed then
-            // reads; here we mark the tracker directly, which inverts the ordering.)
+            // MUST run after the branch chain above: Branch A calls SeedFrom, which Clear()s the
+            // changed set, so a mark applied before it would be silently discarded.
             MigrateCodeEnablement();
 
             // Rehydrate persisted-but-unconfirmed pending resets (IDE-2152 fix #2) AFTER the changed
@@ -426,63 +419,44 @@ namespace Snyk.VisualStudio.Extension.Settings
             } // release persistGate (returning from inside the lock releases it)
         }
 
-        // One-shot recovery of Snyk Code enablement for installs created before this migration
-        // existed. The Language Server default-enables OSS and IaC but not Code, so Code only turns
-        // on when it receives an explicit changed:true. An upgrading user whose stored preference was
-        // "Code on" therefore loses Code scanning outright unless that preference is carried across
-        // as an explicit override — a value sent changed:false reads to the LS as "no preference".
+        // One-shot recovery of Snyk Code enablement for installs predating this migration. The LS
+        // default-enables OSS and IaC but not Code, so Code only turns on for an explicit
+        // changed:true — an upgrading user whose stored preference was "Code on" otherwise loses
+        // Code scanning, because changed:false reads to the LS as "no preference".
         //
-        // Called from Load() only, already inside persistGate, and AFTER the seed branches — see the
-        // ordering note at the call site. Sets the marker in memory only, because Load() must never
-        // write (DEFERRED-PERSIST); the next real Save persists it, exactly as it does for
-        // ChangedConfigKeysSeeded.
+        // Marks in memory only; Load() must never write (DEFERRED-PERSIST), so the next real Save
+        // persists it, as it does for ChangedConfigKeysSeeded.
         //
         // internal for testability (InternalsVisibleTo).
         internal void MigrateCodeEnablement()
         {
-            // Already evaluated. Fresh installs are stamped when their settings.json is created, so
-            // reaching here with the marker set means there is nothing to recover — and re-running
-            // would resurrect an override the user may have deliberately reset since.
             if (snykSettings.CodeEnablementMigrated)
                 return;
 
-            // Present-but-unreadable: snykSettings is blank defaults sitting over a recoverable file,
-            // so its SnykCodeSecurityEnabled says nothing about the user's real preference. Leave the
-            // marker unset too, so the migration is re-evaluated against the real file on the next
-            // process start rather than being burned on blank state (IDE-1483 guard).
+            // Blank defaults over a recoverable file say nothing about the user's real preference.
+            // Leave the marker unset so the migration re-runs against the real file (IDE-1483 guard).
             if (settingsFileWasUnreadable)
                 return;
 
-            // Only "Code was on" needs rescuing. A stored false already resolves correctly: either it
-            // equals the plugin default and the LS leaves Code off, or it is a genuine override that
-            // SeedFrom has already marked.
-            //
-            // The two negative guards keep this from fighting the user: an existing mark means the
-            // state is already carried (the common path after the default flip, where SeedFrom marks
-            // a stored true by itself), and a queued reset means the user explicitly returned Code to
-            // the org/LDX-Sync default — re-marking would silently undo that.
+            // Only "Code was on" needs rescuing; a stored false already resolves correctly. The two
+            // negative guards avoid fighting the user — an existing mark means the state is already
+            // carried, and a queued reset means they deliberately returned Code to the org default.
             if (snykSettings.SnykCodeSecurityEnabled &&
                 !overrideTracker.IsChanged(PflagKeys.SnykCodeEnabled) &&
                 !(snykSettings.PendingResetConfigKeys?.Contains(PflagKeys.SnykCodeEnabled) ?? false))
             {
-                // Carry the pre-existing enabled state across as explicit user intent so the LS
-                // receives changed:true and starts the Code scanner. This can outrank an org/LDX-Sync
-                // value, which is the same deliberate trade-off the other IDE plugins made: preserving
-                // the security coverage the user already had beats deferring to governance on upgrade.
                 overrideTracker.Mark(PflagKeys.SnykCodeEnabled);
 
-                // Mirror the mark onto snykSettings so the in-memory object stays coherent with the
-                // tracker, exactly as Branch A does for its seeded set. This is load-bearing, not
-                // tidiness: Save(updateOverrideTracker:false) — the LS-originated $/snyk.configuration
-                // echo, and frequently the only Save in a session — serialises snykSettings verbatim
-                // without re-reading the tracker. A mark living only in the tracker would be dropped at
-                // the next restart while CodeEnablementMigrated (whole-object serialised) survived,
-                // so the migration would not re-run and Snyk Code would silently switch off again.
+                // Load-bearing, not tidiness: Save(updateOverrideTracker:false) — the LS-originated
+                // $/snyk.configuration echo, often the only Save in a session — serialises
+                // snykSettings verbatim without re-reading the tracker. A mark living only in the
+                // tracker would be lost on restart while CodeEnablementMigrated survived, so the
+                // migration would not re-run and Code would silently switch off again.
                 var migrated = overrideTracker.Snapshot();
                 snykSettings.ChangedConfigKeys = migrated.Count > 0 ? migrated : null;
             }
 
-            // Record the evaluation whatever the outcome — the decision is only meaningful against the
+            // Record the evaluation whatever the outcome: it is only meaningful against the
             // pre-upgrade file, and re-running later would undo a subsequent user reset.
             snykSettings.CodeEnablementMigrated = true;
         }

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
@@ -26,13 +26,31 @@ namespace Snyk.VisualStudio.Extension.Settings
         public string CurrentCliVersion { get; set; }
 
         /// <summary>
-        /// Plugin default for <see cref="SnykCodeSecurityEnabled"/>. False to match the Language
-        /// Server, which does not default-enable Snyk Code — enablement otherwise resolves from org
-        /// governance / LDX-Sync. <see cref="Language.ConfigDefaults"/> references this const rather
-        /// than repeating the literal, so the persistence default and the override-comparison
-        /// default cannot drift apart. Matches Eclipse, which derives both from one value.
+        /// Plugin defaults for the four product-enablement settings, each the single owner of its
+        /// default: the properties below initialise from them and
+        /// <see cref="Language.ConfigDefaults"/> references them instead of repeating the literal,
+        /// so the persistence default and the override-comparison default cannot drift apart. This
+        /// mirrors Eclipse and IntelliJ, which each declare a product default exactly once.
+        /// <para>
+        /// Each value must equal the Language Server's registered default (snyk-ls
+        /// <c>internal/types/register_configurations.go</c>). The LS owns the authoritative default;
+        /// the IDE holds a copy because the override seed runs before the first LSP handshake and
+        /// must still work when the language server never starts. A copy that disagrees with the LS
+        /// makes the seed classify overrides against the wrong baseline — for Snyk Code, whose
+        /// product the LS does not default-enable, that silently stops Code scanning on upgrade.
+        /// The agreement is pinned by ConfigDefaultsTests, not enforced at build time.
+        /// </para>
         /// </summary>
         public const bool DefaultSnykCodeSecurityEnabled = false;
+
+        /// <inheritdoc cref="DefaultSnykCodeSecurityEnabled"/>
+        public const bool DefaultOssEnabled = true;
+
+        /// <inheritdoc cref="DefaultSnykCodeSecurityEnabled"/>
+        public const bool DefaultIacEnabled = true;
+
+        /// <inheritdoc cref="DefaultSnykCodeSecurityEnabled"/>
+        public const bool DefaultSecretsEnabled = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether snyk code security enabled.
@@ -42,12 +60,12 @@ namespace Snyk.VisualStudio.Extension.Settings
         /// <summary>
         /// Gets or sets a value indicating whether Secrets scanning is enabled.
         /// </summary>
-        public bool SecretsEnabled { get; set; } = false;
-        
+        public bool SecretsEnabled { get; set; } = DefaultSecretsEnabled;
+
         /// <summary>
         /// Gets or sets a value indicating whether oss enabled.
         /// </summary>
-        public bool OssEnabled { get; set; } = true;
+        public bool OssEnabled { get; set; } = DefaultOssEnabled;
 
         /// <summary>
         /// Gets or sets a value indicating whether binaries auto update is enabled.
@@ -71,7 +89,7 @@ namespace Snyk.VisualStudio.Extension.Settings
 
         public bool AutoScan { get; set; } = true;
         public string Token { get; set; } = string.Empty;
-        public bool IacEnabled { get; set; } = true;
+        public bool IacEnabled { get; set; } = DefaultIacEnabled;
         public string CliReleaseChannel { get; set; } = SnykCliDownloader.DefaultReleaseChannel;
         public string CliBaseDownloadURL { get; set; } = SnykCliDownloader.DefaultBaseDownloadUrl;
         public bool IgnoreUnknownCa { get; set; }

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
@@ -26,9 +26,18 @@ namespace Snyk.VisualStudio.Extension.Settings
         public string CurrentCliVersion { get; set; }
 
         /// <summary>
+        /// Plugin default for <see cref="SnykCodeSecurityEnabled"/>. False to match the Language
+        /// Server, which does not default-enable Snyk Code — enablement otherwise resolves from org
+        /// governance / LDX-Sync. <see cref="Language.ConfigDefaults"/> references this const rather
+        /// than repeating the literal, so the persistence default and the override-comparison
+        /// default cannot drift apart. Matches Eclipse, which derives both from one value.
+        /// </summary>
+        public const bool DefaultSnykCodeSecurityEnabled = false;
+
+        /// <summary>
         /// Gets or sets a value indicating whether snyk code security enabled.
         /// </summary>
-        public bool SnykCodeSecurityEnabled { get; set; } = true;
+        public bool SnykCodeSecurityEnabled { get; set; } = DefaultSnykCodeSecurityEnabled;
 
         /// <summary>
         /// Gets or sets a value indicating whether Secrets scanning is enabled.
@@ -136,5 +145,21 @@ namespace Snyk.VisualStudio.Extension.Settings
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool ChangedConfigKeysSeeded { get; set; }
+
+        /// <summary>
+        /// One-shot marker for the Snyk Code enablement upgrade recovery
+        /// (<see cref="SnykOptionsManager.MigrateCodeEnablement"/>).
+        /// <para>
+        /// Stamped true the moment a fresh install's settings.json is created
+        /// (<see cref="SnykOptionsManager.LoadSettingsFromFile"/>), so its absence is a reliable
+        /// "this file was written by a version that predates the recovery" signal — a fresh install
+        /// can never be mistaken for an upgrade, even if the Language Server never starts.
+        /// </para>
+        /// <see cref="DefaultValueHandling.Ignore"/> keeps the key out of settings.json when false,
+        /// matching <see cref="ChangedConfigKeysSeeded"/>. IDE-only: never added to
+        /// <see cref="ChangedConfigKeys"/> and never sent over the language-server wire.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool CodeEnablementMigrated { get; set; }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
+++ b/Snyk.VisualStudio.Extension.2022/Settings/SnykSettings.cs
@@ -25,31 +25,23 @@ namespace Snyk.VisualStudio.Extension.Settings
         /// </summary>
         public string CurrentCliVersion { get; set; }
 
-        /// <summary>
-        /// Plugin defaults for the four product-enablement settings, each the single owner of its
-        /// default: the properties below initialise from them and
-        /// <see cref="Language.ConfigDefaults"/> references them instead of repeating the literal,
-        /// so the persistence default and the override-comparison default cannot drift apart. This
-        /// mirrors Eclipse and IntelliJ, which each declare a product default exactly once.
-        /// <para>
-        /// Each value must equal the Language Server's registered default (snyk-ls
-        /// <c>internal/types/register_configurations.go</c>). The LS owns the authoritative default;
-        /// the IDE holds a copy because the override seed runs before the first LSP handshake and
-        /// must still work when the language server never starts. A copy that disagrees with the LS
-        /// makes the seed classify overrides against the wrong baseline — for Snyk Code, whose
-        /// product the LS does not default-enable, that silently stops Code scanning on upgrade.
-        /// The agreement is pinned by ConfigDefaultsTests, not enforced at build time.
-        /// </para>
-        /// </summary>
+        // Single owner of each product-enablement default: the properties below initialise from
+        // these and ConfigDefaults references them, so the persistence default and the
+        // override-comparison default cannot drift. Each must equal the Language Server's registered
+        // default (snyk-ls internal/types/register_configurations.go) — ConfigDefaultsTests pins the
+        // agreement. A copy that disagrees makes the override seed classify against the wrong
+        // baseline, which for Snyk Code silently stops Code scanning on upgrade.
+
+        /// <summary>Plugin default for <see cref="SnykCodeSecurityEnabled"/>.</summary>
         public const bool DefaultSnykCodeSecurityEnabled = false;
 
-        /// <inheritdoc cref="DefaultSnykCodeSecurityEnabled"/>
+        /// <summary>Plugin default for <see cref="OssEnabled"/>.</summary>
         public const bool DefaultOssEnabled = true;
 
-        /// <inheritdoc cref="DefaultSnykCodeSecurityEnabled"/>
+        /// <summary>Plugin default for <see cref="IacEnabled"/>.</summary>
         public const bool DefaultIacEnabled = true;
 
-        /// <inheritdoc cref="DefaultSnykCodeSecurityEnabled"/>
+        /// <summary>Plugin default for <see cref="SecretsEnabled"/>.</summary>
         public const bool DefaultSecretsEnabled = false;
 
         /// <summary>
@@ -165,17 +157,10 @@ namespace Snyk.VisualStudio.Extension.Settings
         public bool ChangedConfigKeysSeeded { get; set; }
 
         /// <summary>
-        /// One-shot marker for the Snyk Code enablement upgrade recovery
-        /// (<see cref="SnykOptionsManager.MigrateCodeEnablement"/>).
-        /// <para>
-        /// Stamped true the moment a fresh install's settings.json is created
-        /// (<see cref="SnykOptionsManager.LoadSettingsFromFile"/>), so its absence is a reliable
-        /// "this file was written by a version that predates the recovery" signal — a fresh install
-        /// can never be mistaken for an upgrade, even if the Language Server never starts.
-        /// </para>
-        /// <see cref="DefaultValueHandling.Ignore"/> keeps the key out of settings.json when false,
-        /// matching <see cref="ChangedConfigKeysSeeded"/>. IDE-only: never added to
-        /// <see cref="ChangedConfigKeys"/> and never sent over the language-server wire.
+        /// One-shot marker for <see cref="SnykOptionsManager.MigrateCodeEnablement"/>. Stamped when a
+        /// fresh install's settings.json is created, so its absence reliably means "written by a
+        /// version predating the recovery" and a fresh install is never mistaken for an upgrade.
+        /// IDE-only: never added to <see cref="ChangedConfigKeys"/>, never sent over the wire.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool CodeEnablementMigrated { get; set; }

--- a/Snyk.VisualStudio.Extension.Tests/Language/ConfigDefaultsTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/ConfigDefaultsTests.cs
@@ -136,54 +136,70 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
                 "A non-empty AdditionalParameters string must NOT be the default");
         }
 
-        // PR-REV-3-1: ConfigDefaults boolean values for product-enablement must match
-        // the canonical SnykSettings field initializers. This acts as a drift guard:
-        // if SnykSettings changes a default, the test (which reads the SnykSettings field
-        // via new SnykSettings()) will catch the mismatch.
-        // Note: SnykSettings uses inline field initializers (not named constants), so we compare
-        // by constructing a default instance and reading each field.
+        // PR-REV-3-1: every tracked boolean default, PINNED to a literal expected value and checked
+        // against the SnykSettings field that must agree with it.
+        //
+        // Pinned rather than derived, deliberately. The four product keys now reference
+        // SnykSettings.Default* consts from ConfigDefaults, which is what stops those two sites
+        // drifting apart — but it also makes a bare "map == SnykSettings" comparison tautological for
+        // them: it compares a value to itself and can never fail. The literal below is therefore the
+        // only thing that fails when a default changes, which keeps such a change a deliberate,
+        // reviewable edit instead of a silent one.
+        //
+        // These values must also equal the Language Server's registered defaults (snyk-ls
+        // internal/types/register_configurations.go). The LS owns the authoritative default; the IDE
+        // holds a hard-coded copy because the override seed runs before the first LSP handshake and
+        // must still work when the language server never starts, so no build-time check can enforce
+        // the agreement — it is enforced by this test plus review. A copy that disagrees is exactly
+        // how Snyk Code came to be silently disabled on upgrade: both VS sites agreed on `true` while
+        // the LS said `false`, so the old derived-comparison guard passed while the value was wrong.
         [Fact]
-        public void ConfigDefaults_BooleanValues_MatchSnykSettingsFieldInitializers()
+        public void ConfigDefaults_BooleanValues_ArePinnedAndMatchSnykSettings()
         {
             var defaults = new Snyk.VisualStudio.Extension.Settings.SnykSettings();
 
-            // Product enablement
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SnykOssEnabled) == defaults.OssEnabled,
-                "SnykOssEnabled default must match SnykSettings.OssEnabled initializer");
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SnykCodeEnabled) == defaults.SnykCodeSecurityEnabled,
-                "SnykCodeEnabled default must match SnykSettings.SnykCodeSecurityEnabled initializer");
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SnykIacEnabled) == defaults.IacEnabled,
-                "SnykIacEnabled default must match SnykSettings.IacEnabled initializer");
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SnykSecretsEnabled) == defaults.SecretsEnabled,
-                "SnykSecretsEnabled default must match SnykSettings.SecretsEnabled initializer");
+            // (pflag key, pinned expected default, the SnykSettings value that must agree, its name)
+            var cases = new (string Key, bool Expected, bool FromSettings, string Field)[]
+            {
+                // Product enablement. Code is false to match the LS, which does not default-enable
+                // it; Secrets likewise. OSS and IaC the LS does default-enable.
+                (PflagKeys.SnykOssEnabled,     true,  defaults.OssEnabled,              nameof(defaults.OssEnabled)),
+                (PflagKeys.SnykCodeEnabled,    false, defaults.SnykCodeSecurityEnabled, nameof(defaults.SnykCodeSecurityEnabled)),
+                (PflagKeys.SnykIacEnabled,     true,  defaults.IacEnabled,              nameof(defaults.IacEnabled)),
+                (PflagKeys.SnykSecretsEnabled, false, defaults.SecretsEnabled,          nameof(defaults.SecretsEnabled)),
 
-            // Scan
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.ScanAutomatic) == defaults.AutoScan,
-                "ScanAutomatic default must match SnykSettings.AutoScan initializer");
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.ScanNetNew) == defaults.EnableDeltaFindings,
-                "ScanNetNew default must match SnykSettings.EnableDeltaFindings initializer");
+                // Scan
+                (PflagKeys.ScanAutomatic, true,  defaults.AutoScan,             nameof(defaults.AutoScan)),
+                (PflagKeys.ScanNetNew,    false, defaults.EnableDeltaFindings,  nameof(defaults.EnableDeltaFindings)),
 
-            // Severity filters
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SeverityFilterCritical) == defaults.FilterCritical,
-                "SeverityFilterCritical default must match SnykSettings.FilterCritical initializer");
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SeverityFilterHigh) == defaults.FilterHigh,
-                "SeverityFilterHigh default must match SnykSettings.FilterHigh initializer");
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SeverityFilterMedium) == defaults.FilterMedium,
-                "SeverityFilterMedium default must match SnykSettings.FilterMedium initializer");
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.SeverityFilterLow) == defaults.FilterLow,
-                "SeverityFilterLow default must match SnykSettings.FilterLow initializer");
+                // Severity filters
+                (PflagKeys.SeverityFilterCritical, true, defaults.FilterCritical, nameof(defaults.FilterCritical)),
+                (PflagKeys.SeverityFilterHigh,     true, defaults.FilterHigh,     nameof(defaults.FilterHigh)),
+                (PflagKeys.SeverityFilterMedium,   true, defaults.FilterMedium,   nameof(defaults.FilterMedium)),
+                (PflagKeys.SeverityFilterLow,      true, defaults.FilterLow,      nameof(defaults.FilterLow)),
 
-            // Issue view
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.IssueViewOpenIssues) == defaults.OpenIssuesEnabled,
-                "IssueViewOpenIssues default must match SnykSettings.OpenIssuesEnabled initializer");
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.IssueViewIgnoredIssues) == defaults.IgnoredIssuesEnabled,
-                "IssueViewIgnoredIssues default must match SnykSettings.IgnoredIssuesEnabled initializer");
+                // Issue view
+                (PflagKeys.IssueViewOpenIssues,    true,  defaults.OpenIssuesEnabled,    nameof(defaults.OpenIssuesEnabled)),
+                (PflagKeys.IssueViewIgnoredIssues, false, defaults.IgnoredIssuesEnabled, nameof(defaults.IgnoredIssuesEnabled)),
 
-            // CLI / binary booleans
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.AutomaticDownload) == defaults.BinariesAutoUpdateEnabled,
-                "AutomaticDownload default must match SnykSettings.BinariesAutoUpdateEnabled initializer");
-            Assert.True((bool)ConfigDefaults.GetDefaultForTest(PflagKeys.ProxyInsecure) == defaults.IgnoreUnknownCa,
-                "ProxyInsecure default must match SnykSettings.IgnoreUnknownCa initializer");
+                // CLI / binary booleans
+                (PflagKeys.AutomaticDownload, true,  defaults.BinariesAutoUpdateEnabled, nameof(defaults.BinariesAutoUpdateEnabled)),
+                (PflagKeys.ProxyInsecure,     false, defaults.IgnoreUnknownCa,           nameof(defaults.IgnoreUnknownCa)),
+            };
+
+            foreach (var c in cases)
+            {
+                Assert.True((bool)ConfigDefaults.GetDefaultForTest(c.Key) == c.Expected,
+                    $"ConfigDefaults[{c.Key}] must be {c.Expected}. If this default is changing " +
+                    "deliberately, update the pinned value here and confirm it still equals the " +
+                    "Language Server's registered default in snyk-ls register_configurations.go — " +
+                    "a default that disagrees with the LS makes the override seed classify user " +
+                    "preferences against the wrong baseline.");
+
+                Assert.True(c.FromSettings == c.Expected,
+                    $"SnykSettings.{c.Field} must be {c.Expected} so the persistence default and " +
+                    $"ConfigDefaults[{c.Key}] agree.");
+            }
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.Tests/Language/ConfigDefaultsTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/ConfigDefaultsTests.cs
@@ -16,8 +16,10 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.True(ConfigDefaults.IsDefault(PflagKeys.SnykOssEnabled, true));
             Assert.False(ConfigDefaults.IsDefault(PflagKeys.SnykOssEnabled, false));
 
-            Assert.True(ConfigDefaults.IsDefault(PflagKeys.SnykCodeEnabled, true));
-            Assert.False(ConfigDefaults.IsDefault(PflagKeys.SnykCodeEnabled, false));
+            // Snyk Code defaults to false to match the Language Server, which does not
+            // default-enable it. An enabled-Code value is therefore a genuine override.
+            Assert.True(ConfigDefaults.IsDefault(PflagKeys.SnykCodeEnabled, false));
+            Assert.False(ConfigDefaults.IsDefault(PflagKeys.SnykCodeEnabled, true));
 
             Assert.True(ConfigDefaults.IsDefault(PflagKeys.SnykIacEnabled, true));
             Assert.False(ConfigDefaults.IsDefault(PflagKeys.SnykIacEnabled, false));

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
@@ -35,11 +35,15 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
 
         // Builds a minimal IPersistableOptions at all-plugin-defaults for use with SeedFrom.
         // Used by tests that need a seeded real UserOverrideTracker with no keys marked changed.
-        private static ISnykOptions BuildDefaultOptionsForSeed()
+        // Pass codeEnabled:true to model an upgrading install whose stored preference was "Code on",
+        // which SeedFrom must recognise as an override.
+        private static ISnykOptions BuildDefaultOptionsForSeed(
+            bool codeEnabled = SnykSettings.DefaultSnykCodeSecurityEnabled)
         {
             var o = new Mock<ISnykOptions>();
             o.SetupGet(x => x.OssEnabled).Returns(true);
-            o.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true);
+            // Code's plugin default is false — it matches the LS, which does not default-enable Code.
+            o.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(codeEnabled);
             o.SetupGet(x => x.IacEnabled).Returns(true);
             o.SetupGet(x => x.SecretsEnabled).Returns(false);
             o.SetupGet(x => x.AutoScan).Returns(true);
@@ -916,25 +920,30 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
         // RACC-004 (Acceptance / PR #515 regression): Enabling the global Snyk Code toggle must
         // persist as an explicit user-owned value, not be turned into a reset-to-default signal.
         //
-        // Snyk Code's plugin default is `true` (ConfigDefaults). Under the OLD (buggy) semantics
-        // ApplyUserEdits classified an edited key by value==plugin-default, so a user *enabling*
-        // Code (posting true) hit the Unmark branch → BuildSettingsMap emitted a Reset
-        // ({value:null, changed:true}) → the org/server default won → the enable appeared not to
-        // persist. The fix: any key the form posted (present in editedKeys) is an explicit user
-        // choice and must be Mark'd (changed:true) carrying the user's value, never a reset.
+        // Under the OLD (buggy) semantics ApplyUserEdits classified an edited key by
+        // value==plugin-default, so an edit that happened to land on the default hit the Unmark
+        // branch → BuildSettingsMap emitted a Reset ({value:null, changed:true}) → the org/server
+        // default won → the choice appeared not to persist. The fix: any key the form posted
+        // (present in editedKeys) is an explicit user choice and must be Mark'd (changed:true)
+        // carrying the user's value, never a reset.
+        //
+        // Enabling Code matters doubly because the LS does not default-enable the product: only an
+        // explicit changed:true turns the Code scanner on. See
+        // ApplyUserEdits_EditedKeyEqualToDefault_MarksChanged_NoReset (UserOverrideTrackerTests) for
+        // the value==default half of the invariant.
         [Fact]
         public void EnablingSnykCode_SendsExplicitEnabledValueChangedTrue_NotReset()
         {
-            SetupDefaults(); // SnykCodeSecurityEnabled == true (the plugin default the user just enabled)
+            SetupDefaults(); // SnykCodeSecurityEnabled == true (what the user just enabled)
 
             var realTracker = new UserOverrideTracker();
             realTracker.SeedFrom(BuildDefaultOptionsForSeed()); // clean seeded slate, Code unmarked
 
             // The user enables Snyk Code in the settings form and applies. The form posts
-            // snyk_code_enabled=true and includes it in the edit delta. Even though true equals the
-            // plugin default, the user made an explicit choice — it must be recorded as an override.
+            // snyk_code_enabled=true and includes it in the edit delta, so it must be recorded as an
+            // override rather than inferred to be anything else.
             var optionsAfterSave = new Mock<ISnykOptions>();
-            optionsAfterSave.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true); // user-enabled == plugin default
+            optionsAfterSave.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true);
 
             realTracker.ApplyUserEdits(
                 optionsAfterSave.Object,
@@ -952,6 +961,29 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             Assert.True(map[PflagKeys.SnykCodeEnabled].Changed,
                 "An explicitly enabled Snyk Code toggle must be marked changed so the org default " +
                 "cannot silently override the user's choice");
+        }
+
+        // RACC-005 (wire-level acceptance): an upgrading install whose stored preference was "Code on"
+        // must put snyk_code_enabled on the wire as {value:true, changed:true}. Sent changed:false the
+        // LS reads it as "no user preference" and — unlike OSS and IaC, which it default-enables —
+        // leaves the Code scanner off, so no Code scan runs at all even when the org enables SAST.
+        [Fact]
+        public void UpgradedInstallWithCodeEnabled_SendsCodeAsAnExplicitEnabledOverride()
+        {
+            SetupDefaults(); // the loaded options carry the stored value: Code enabled
+
+            // The tracker state Load() produces for a pre-upgrade settings.json: seeded from
+            // value-vs-default, where a stored Code=true differs from the plugin default (false).
+            var realTracker = new UserOverrideTracker();
+            realTracker.SeedFrom(BuildDefaultOptionsForSeed(codeEnabled: true));
+            optionsManagerMock.Setup(m => m.OverrideTracker).Returns(realTracker);
+
+            var map = cut.BuildSettingsMap(optionsMock.Object);
+
+            Assert.Equal(true, map[PflagKeys.SnykCodeEnabled].Value);
+            Assert.True(map[PflagKeys.SnykCodeEnabled].Changed,
+                "snyk_code_enabled must be sent changed:true, or the Language Server treats the " +
+                "enabled state as absent and skips the Code scanner");
         }
 
         // UNIT-008: ConfigSetting.Of(value, changed) overload sets Changed correctly;

--- a/Snyk.VisualStudio.Extension.Tests/Language/UserOverrideTrackerTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/UserOverrideTrackerTests.cs
@@ -21,7 +21,9 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
         {
             var o = new Mock<ISnykOptions>();
             o.SetupGet(x => x.OssEnabled).Returns(true);
-            o.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true);
+            // Snyk Code's plugin default is false (it matches the Language Server, which does not
+            // default-enable Code) — unlike OSS and IaC, which default to true.
+            o.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(false);
             o.SetupGet(x => x.IacEnabled).Returns(true);
             o.SetupGet(x => x.SecretsEnabled).Returns(false);
             o.SetupGet(x => x.AutoScan).Returns(true);
@@ -317,7 +319,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             // Build options where every value is non-default so every key gets marked.
             var allNonDefault = new Mock<ISnykOptions>();
             allNonDefault.SetupGet(x => x.OssEnabled).Returns(false); // non-default
-            allNonDefault.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(false);
+            // Code's default is false, so true is the non-default here (inverse of OSS/IaC).
+            allNonDefault.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true);
             allNonDefault.SetupGet(x => x.IacEnabled).Returns(false);
             allNonDefault.SetupGet(x => x.SecretsEnabled).Returns(true);
             allNonDefault.SetupGet(x => x.AutoScan).Returns(false);
@@ -531,16 +534,20 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
         // RUNIT-002 (corrected semantics, PR #515): ApplyUserEdits with an edited key whose new
         // value equals the plugin default must MARK it (changed:true) and must NOT enqueue a reset.
         //
-        // This is the core of the "enabling Snyk Code doesn't persist" fix: any key the form posted
-        // (present in editedKeys) is an explicit user choice. Snyk Code's default is `true`, so a
-        // user *enabling* it posts a value equal to the default — the OLD code inferred a reset from
-        // value==default and let the org default win. Reset-to-default is no longer inferred here.
+        // Any key the form posted (present in editedKeys) is an explicit user choice. The OLD code
+        // inferred a reset from value==default and let the org value win, which is how an explicit
+        // choice could silently fail to persist. Reset-to-default is no longer inferred here — it is
+        // an explicit user action only (ApplyUserResets / Unmark).
+        //
+        // Exercised through snyk_code_enabled, whose plugin default is false: a user who explicitly
+        // *disables* Code posts a value equal to the default, and that choice must still reach the LS
+        // as changed:true or an org/LDX-Sync value could re-enable the product behind their back.
         [Fact]
         public void ApplyUserEdits_EditedKeyEqualToDefault_MarksChanged_NoReset()
         {
-            // The user enables Snyk Code (posts true, which equals the plugin default true).
+            // The user disables Snyk Code (posts false, which equals the plugin default false).
             var options = DefaultOptions();
-            options.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(true); // at default
+            options.SetupGet(x => x.SnykCodeSecurityEnabled).Returns(false); // at default
 
             // The user's save included snyk_code_enabled in the edit delta.
             var editedKeys = new List<string> { PflagKeys.SnykCodeEnabled };

--- a/Snyk.VisualStudio.Extension.Tests/Settings/CodeEnablementMigrationTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/CodeEnablementMigrationTests.cs
@@ -171,6 +171,25 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
             Assert.Contains(PflagKeys.SnykOssEnabled, loaded.ChangedConfigKeys);
         }
 
+        // Branch B: the marker is absent but changedConfigKeys is non-empty — the shape of a file
+        // written by a version that recorded overrides before ChangedConfigKeysSeeded existed. Load
+        // hydrates those keys verbatim rather than re-seeding, so the migration is again the only
+        // thing that can recover Code.
+        [Fact]
+        public void Upgrade_UnseededSetWithOtherOverrides_IsRecoveredByTheMigration()
+        {
+            var path = WriteLegacySettings(codeEnabled: true, seeded: false,
+                changedConfigKeys: "[\"snyk_oss_enabled\"]");
+
+            var manager = BuildManager(path);
+            var loaded = manager.Load();
+
+            Assert.True(manager.OverrideTracker.IsChanged(PflagKeys.SnykCodeEnabled),
+                "an unseeded override set that predates the migration must still recover Code");
+            // The verbatim-hydrated override must survive alongside it.
+            Assert.Contains(PflagKeys.SnykOssEnabled, loaded.ChangedConfigKeys);
+        }
+
         // ── Fresh installs must never be seeded ───────────────────────────────────────────────
 
         // A fresh install defers to org governance / LDX-Sync. The marker is stamped when the file is

--- a/Snyk.VisualStudio.Extension.Tests/Settings/CodeEnablementMigrationTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/CodeEnablementMigrationTests.cs
@@ -1,0 +1,371 @@
+// ABOUTME: Tests for the one-shot Snyk Code enablement upgrade recovery in SnykOptionsManager.
+// ABOUTME: Covers the upgrade/fresh-install/one-shot/reset/corrupt paths and the seed-then-migrate ordering.
+//
+// Snyk Code is the only product the Language Server does not default-enable: it needs an explicit
+// changed:true to turn on, whereas OSS and IaC come up enabled from the LS's own defaults. So an
+// upgrading user whose stored preference was "Code on" loses Code scanning entirely unless that
+// preference reaches the LS as an explicit override. Two mechanisms produce that outcome and these
+// tests pin both:
+//   1. The plugin default for Code is false (matching the LS), so SeedFrom recognises a stored
+//      true as a genuine override on any install that has never been seeded.
+//   2. MigrateCodeEnablement covers installs whose override set was ALREADY seeded without
+//      snyk_code_enabled — the state produced by builds that shipped the true default.
+//
+// NOTE: authored on macOS, where this net48 + VSSDK suite cannot be built or run. Verified on
+// Windows/CI (see SnykOptionsManagerCorruptFileTests for the same caveat).
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Moq;
+using Snyk.VisualStudio.Extension.Authentication;
+using Snyk.VisualStudio.Extension.Download;
+using Snyk.VisualStudio.Extension.Language;
+using Snyk.VisualStudio.Extension.Service;
+using Snyk.VisualStudio.Extension.Settings;
+using Snyk.VisualStudio.Extension.Utils;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.Settings
+{
+    public class CodeEnablementMigrationTests : IDisposable
+    {
+        private readonly string tempDir;
+
+        public CodeEnablementMigrationTests()
+        {
+            this.tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(this.tempDir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(this.tempDir, recursive: true); } catch { }
+        }
+
+        // A path inside the temp dir that does NOT exist — the genuine fresh-install signal
+        // (SnykSettingsLoader classifies both a missing file and an empty one as absent).
+        private string NewSettingsPath() => Path.Combine(this.tempDir, "settings.json");
+
+        private static SnykOptionsManager BuildManager(string path)
+        {
+            var spMock = new Mock<ISnykServiceProvider>();
+            spMock.Setup(x => x.Options).Returns(BuildOptions());
+            return new SnykOptionsManager(path, spMock.Object);
+        }
+
+        // A fully-populated options object so Save() cannot null-ref. Product values mirror the
+        // plugin defaults; individual tests override what they care about.
+        private static ISnykOptions BuildOptions()
+        {
+            var optMock = new Mock<ISnykOptions>();
+            optMock.SetupAllProperties();
+            optMock.Object.OssEnabled = true;
+            optMock.Object.SnykCodeSecurityEnabled = SnykSettings.DefaultSnykCodeSecurityEnabled;
+            optMock.Object.IacEnabled = true;
+            optMock.Object.SecretsEnabled = false;
+            optMock.Object.AutoScan = true;
+            optMock.Object.EnableDeltaFindings = false;
+            optMock.Object.FilterCritical = true;
+            optMock.Object.FilterHigh = true;
+            optMock.Object.FilterMedium = true;
+            optMock.Object.FilterLow = true;
+            optMock.Object.OpenIssuesEnabled = true;
+            optMock.Object.IgnoredIssuesEnabled = false;
+            optMock.Object.IgnoreUnknownCA = false;
+            optMock.Object.BinariesAutoUpdate = true;
+            optMock.Object.CliCustomPath = string.Empty;
+            optMock.Object.CliReleaseChannel = SnykCliDownloader.DefaultReleaseChannel;
+            optMock.Object.CliBaseDownloadURL = SnykCliDownloader.DefaultBaseDownloadUrl;
+            optMock.Object.AdditionalEnv = string.Empty;
+            optMock.Object.AdditionalParameters = new List<string>();
+            optMock.Object.TrustedFolders = new HashSet<string>();
+            optMock.Object.DeviceId = "test-device";
+            optMock.Object.ApiToken = new AuthenticationToken(AuthenticationType.OAuth, string.Empty);
+            return optMock.Object;
+        }
+
+        private static SnykSettings ReadSettings(string path) =>
+            Json.Deserialize<SnykSettings>(File.ReadAllText(path, Encoding.UTF8));
+
+        // A settings.json as written by a version that predates this migration: no
+        // codeEnablementMigrated marker. `seeded` / `changedConfigKeys` model how far along the V25
+        // override-tracking lifecycle the file is.
+        private string WriteLegacySettings(bool codeEnabled, bool seeded = false,
+            string changedConfigKeys = null, string pendingResets = null)
+        {
+            var path = NewSettingsPath();
+            var json = "{" +
+                "\"ossEnabled\": true," +
+                "\"iacEnabled\": true," +
+                "\"secretsEnabled\": false," +
+                "\"snykCodeSecurityEnabled\": " + (codeEnabled ? "true" : "false") + "," +
+                "\"autoScan\": true," +
+                "\"openIssuesEnabled\": true," +
+                "\"filterCritical\": true," +
+                "\"filterHigh\": true," +
+                "\"filterMedium\": true," +
+                "\"filterLow\": true," +
+                "\"binariesAutoUpdateEnabled\": true," +
+                "\"trustedFolders\": []," +
+                "\"deviceId\": \"upgrade-test-device\"," +
+                "\"token\": \"\"" +
+                (seeded ? ",\"changedConfigKeysSeeded\": true" : string.Empty) +
+                (changedConfigKeys != null ? ",\"changedConfigKeys\": " + changedConfigKeys : string.Empty) +
+                (pendingResets != null ? ",\"pendingResetConfigKeys\": " + pendingResets : string.Empty) +
+                "}";
+            File.WriteAllText(path, json, Encoding.UTF8);
+            return path;
+        }
+
+        // ── Upgrade from a pre-V25 file (the reported regression) ─────────────────────────────
+
+        // The headline case: released 2.9.0 stored "Code on" and no override set. After upgrading,
+        // Code must reach the LS as an explicit override or the Code scanner is skipped entirely.
+        // Carried by the default flip (stored true != default false → SeedFrom marks it).
+        [Fact]
+        public void Upgrade_CodeEnabled_IsRecoveredAsExplicitOverride()
+        {
+            var path = WriteLegacySettings(codeEnabled: true);
+
+            var manager = BuildManager(path);
+            var loaded = manager.Load();
+
+            Assert.True(manager.OverrideTracker.IsChanged(PflagKeys.SnykCodeEnabled),
+                "an upgrading user's enabled Snyk Code must be carried across as an explicit " +
+                "override, otherwise it is sent changed:false and the LS leaves Code disabled");
+            Assert.Contains(PflagKeys.SnykCodeEnabled, loaded.ChangedConfigKeys);
+        }
+
+        // The mirror case: Code was off. Nothing to rescue — the stored value equals the plugin
+        // default, and the LS also defaults Code off, so changed:false resolves correctly.
+        [Fact]
+        public void Upgrade_CodeDisabled_IsNotMarked()
+        {
+            var path = WriteLegacySettings(codeEnabled: false);
+
+            var manager = BuildManager(path);
+            var loaded = manager.Load();
+
+            Assert.False(manager.OverrideTracker.IsChanged(PflagKeys.SnykCodeEnabled),
+                "a stored Code=false equals the plugin default and must not become an override");
+            Assert.DoesNotContain(PflagKeys.SnykCodeEnabled,
+                loaded.ChangedConfigKeys ?? new HashSet<string>());
+        }
+
+        // The case only the migration can fix: an install whose override set was already seeded by a
+        // build that shipped the true default, so snyk_code_enabled was never recorded. SeedFrom does
+        // not re-run for these files (Branch C hydrates verbatim), so without MigrateCodeEnablement
+        // the enabled state stays lost forever.
+        [Fact]
+        public void Upgrade_AlreadySeededSetOmittingCode_IsRecoveredByTheMigration()
+        {
+            var path = WriteLegacySettings(codeEnabled: true, seeded: true,
+                changedConfigKeys: "[\"snyk_oss_enabled\"]");
+
+            var manager = BuildManager(path);
+            var loaded = manager.Load();
+
+            Assert.True(manager.OverrideTracker.IsChanged(PflagKeys.SnykCodeEnabled),
+                "a seeded override set that predates the migration must still recover Code");
+            // The pre-existing override must survive alongside it.
+            Assert.Contains(PflagKeys.SnykOssEnabled, loaded.ChangedConfigKeys);
+        }
+
+        // ── Fresh installs must never be seeded ───────────────────────────────────────────────
+
+        // A fresh install defers to org governance / LDX-Sync. The marker is stamped when the file is
+        // created so the migration can never mistake a later launch for an upgrade.
+        [Fact]
+        public void FreshInstall_StampsMarkerAndLeavesCodeToTheServer()
+        {
+            var path = NewSettingsPath();
+            Assert.False(File.Exists(path));
+
+            var manager = BuildManager(path);
+            var loaded = manager.Load();
+
+            var onDisk = ReadSettings(path);
+            Assert.True(onDisk.CodeEnablementMigrated,
+                "a fresh install must record the migration as evaluated at file-creation time");
+            Assert.False(onDisk.SnykCodeSecurityEnabled);
+            Assert.False(manager.OverrideTracker.IsChanged(PflagKeys.SnykCodeEnabled),
+                "a fresh install must not force Snyk Code on — org/LDX-Sync decides");
+            Assert.DoesNotContain(PflagKeys.SnykCodeEnabled,
+                loaded.ChangedConfigKeys ?? new HashSet<string>());
+        }
+
+        // The failure mode the file-creation stamp exists to prevent: if the Language Server later
+        // enables Code and echoes it back (an LS-originated save, which does NOT record user
+        // overrides), the next launch sees a stored Code=true on a file with no override set. Without
+        // the marker that is indistinguishable from an upgrade, and the org's value would be frozen
+        // into a permanent user override.
+        [Fact]
+        public void FreshInstall_ThenServerEnablesCode_DoesNotBecomeAUserOverride()
+        {
+            var path = NewSettingsPath();
+            var manager = BuildManager(path);
+            manager.Load();
+
+            // The LS pushes Code=true via $/snyk.configuration; the plugin persists it without
+            // recording a user override.
+            var pushed = BuildOptions();
+            pushed.SnykCodeSecurityEnabled = true;
+            manager.Save(pushed, triggerSettingsChangedEvent: false, updateOverrideTracker: false);
+            Assert.True(ReadSettings(path).SnykCodeSecurityEnabled);
+
+            // Restart over the same file.
+            var manager2 = BuildManager(path);
+            var loaded = manager2.Load();
+
+            Assert.False(manager2.OverrideTracker.IsChanged(PflagKeys.SnykCodeEnabled),
+                "an org-pushed Code value must not be frozen into a user override on restart");
+            Assert.DoesNotContain(PflagKeys.SnykCodeEnabled,
+                loaded.ChangedConfigKeys ?? new HashSet<string>());
+        }
+
+        // ── One-shot semantics ───────────────────────────────────────────────────────────────
+
+        // Once evaluated, the migration must never run again: the user may have deliberately reset
+        // Code to the org default since, and re-marking would silently undo that.
+        [Fact]
+        public void Migration_IsOneShot_DoesNotResurrectAResetOverride()
+        {
+            var path = NewSettingsPath();
+            // Post-migration steady state: marker set, Code stored on, but the user has since reset
+            // the key so it is absent from the override set.
+            var json = "{" +
+                "\"snykCodeSecurityEnabled\": true," +
+                "\"trustedFolders\": []," +
+                "\"token\": \"\"," +
+                "\"changedConfigKeysSeeded\": true," +
+                "\"codeEnablementMigrated\": true" +
+                "}";
+            File.WriteAllText(path, json, Encoding.UTF8);
+
+            var manager = BuildManager(path);
+            var loaded = manager.Load();
+
+            Assert.False(manager.OverrideTracker.IsChanged(PflagKeys.SnykCodeEnabled),
+                "the migration must not re-run and resurrect a reset override");
+            Assert.DoesNotContain(PflagKeys.SnykCodeEnabled,
+                loaded.ChangedConfigKeys ?? new HashSet<string>());
+        }
+
+        // A reset queued but not yet confirmed-delivered to the LS is an explicit user action in
+        // flight. Even on a file that predates the marker, the migration must not fight it.
+        [Fact]
+        public void Upgrade_WithQueuedResetForCode_DoesNotReMark()
+        {
+            var path = WriteLegacySettings(codeEnabled: true, seeded: true,
+                changedConfigKeys: "[]", pendingResets: "[\"snyk_code_enabled\"]");
+
+            var manager = BuildManager(path);
+            manager.Load();
+
+            Assert.False(manager.OverrideTracker.IsChanged(PflagKeys.SnykCodeEnabled),
+                "a queued reset means the user explicitly returned Code to the org default; " +
+                "the migration must not undo it");
+            Assert.Contains(PflagKeys.SnykCodeEnabled, manager.OverrideTracker.PeekPendingResets());
+        }
+
+        // ── Corrupt file ─────────────────────────────────────────────────────────────────────
+
+        // After a present-but-unreadable read the in-memory settings are blank defaults over a
+        // recoverable file, so they say nothing about the user's real preference. The migration must
+        // neither mark anything nor burn its one shot, and must not touch the file (IDE-1483).
+        [Fact]
+        public void CorruptFile_DoesNotMigrateAndLeavesTheFileIntact()
+        {
+            var path = NewSettingsPath();
+            File.WriteAllText(path, "{ \"snykCodeSecurityEnabled\": true, ", Encoding.UTF8);
+            var originalBytes = File.ReadAllBytes(path);
+
+            var manager = BuildManager(path);
+            var loaded = manager.Load();
+
+            Assert.True(manager.SettingsFileWasUnreadableForTest,
+                "the truncated file must be classified as present-but-unreadable, not absent");
+            Assert.False(manager.OverrideTracker.IsChanged(PflagKeys.SnykCodeEnabled),
+                "blank post-corrupt state must not produce a phantom Code override");
+            Assert.DoesNotContain(PflagKeys.SnykCodeEnabled,
+                loaded.ChangedConfigKeys ?? new HashSet<string>());
+            Assert.Equal(originalBytes, File.ReadAllBytes(path));
+        }
+
+        // ── Persistence of the recovered mark ────────────────────────────────────────────────
+
+        // Regression guard for a subtle loss path: Save(updateOverrideTracker:false) — the
+        // LS-originated echo, often the only save in a session — serialises snykSettings verbatim
+        // without re-reading the tracker. If the recovered mark lived only in the tracker it would be
+        // dropped at the next restart, while codeEnablementMigrated (whole-object serialised) would
+        // survive and stop the migration re-running. Code would silently switch off again.
+        [Fact]
+        public void RecoveredMark_SurvivesAnLsOriginatedSaveAndRestart()
+        {
+            var path = WriteLegacySettings(codeEnabled: true, seeded: true,
+                changedConfigKeys: "[\"snyk_oss_enabled\"]");
+
+            var manager = BuildManager(path);
+            manager.Load();
+            Assert.True(manager.OverrideTracker.IsChanged(PflagKeys.SnykCodeEnabled));
+
+            // An LS-originated save: persists values, deliberately does not record user overrides.
+            var pushed = BuildOptions();
+            pushed.SnykCodeSecurityEnabled = true;
+            manager.Save(pushed, triggerSettingsChangedEvent: false, updateOverrideTracker: false);
+
+            var onDisk = ReadSettings(path);
+            Assert.True(onDisk.CodeEnablementMigrated);
+            Assert.NotNull(onDisk.ChangedConfigKeys);
+            Assert.Contains(PflagKeys.SnykCodeEnabled, onDisk.ChangedConfigKeys);
+
+            // Restart: the recovered override must still be there, even though the migration is done.
+            var manager2 = BuildManager(path);
+            var loaded = manager2.Load();
+            Assert.True(manager2.OverrideTracker.IsChanged(PflagKeys.SnykCodeEnabled),
+                "the recovered override must survive a restart after an LS-originated save");
+            Assert.Contains(PflagKeys.SnykCodeEnabled, loaded.ChangedConfigKeys);
+        }
+
+        // ── Ordering guard ───────────────────────────────────────────────────────────────────
+
+        // The migration MUST run after the seed branches. SeedFrom performs a full Clear() of the
+        // changed set, so a mark applied first is silently discarded. This proves the ordering is
+        // load-bearing rather than incidental — the same guard PR #783 added for the VS Code fix
+        // (which runs its migration BEFORE its seed, because there the migration writes a setting
+        // value the seed then reads).
+        [Fact]
+        public void SeedThenMark_IsLoadBearing_MarkThenSeedLosesTheOverride()
+        {
+            var atDefaults = BuildOptionsAtDefaultsForSeed();
+
+            // Production order: seed, then carry the pre-existing enabled state across.
+            var correct = new UserOverrideTracker();
+            correct.SeedFrom(atDefaults);
+            correct.Mark(PflagKeys.SnykCodeEnabled);
+            Assert.True(correct.IsChanged(PflagKeys.SnykCodeEnabled),
+                "marking after the seed must survive");
+
+            // Inverted order: the seed wipes the mark and the recovery is lost.
+            var inverted = new UserOverrideTracker();
+            inverted.Mark(PflagKeys.SnykCodeEnabled);
+            inverted.SeedFrom(atDefaults);
+            Assert.False(inverted.IsChanged(PflagKeys.SnykCodeEnabled),
+                "SeedFrom clears the changed set, so a mark applied before it is discarded — " +
+                "this is why MigrateCodeEnablement runs after the seed branches in Load()");
+        }
+
+        // Every global key at its plugin default, so SeedFrom marks nothing by itself and the
+        // ordering test isolates the effect of the explicit Mark.
+        private static ISnykOptions BuildOptionsAtDefaultsForSeed()
+        {
+            var o = BuildOptions();
+            o.CustomEndpoint = string.Empty;
+            o.Organization = string.Empty;
+            o.RiskScoreThreshold = null;
+            o.AuthenticationMethod = default(AuthenticationType);
+            return o;
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/Settings/CodeEnablementMigrationTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/CodeEnablementMigrationTests.cs
@@ -1,11 +1,10 @@
 // ABOUTME: Tests for the one-shot Snyk Code enablement upgrade recovery in SnykOptionsManager.
 // ABOUTME: Covers the upgrade/fresh-install/one-shot/reset/corrupt paths and the seed-then-migrate ordering.
 //
-// Snyk Code is the only product the Language Server does not default-enable: it needs an explicit
-// changed:true to turn on, whereas OSS and IaC come up enabled from the LS's own defaults. So an
-// upgrading user whose stored preference was "Code on" loses Code scanning entirely unless that
-// preference reaches the LS as an explicit override. Two mechanisms produce that outcome and these
-// tests pin both:
+// The Language Server default-enables OSS and IaC but not Code, so Code only turns on when it
+// receives an explicit changed:true. An upgrading user whose stored preference was "Code on"
+// therefore loses Code scanning entirely unless that preference reaches the LS as an explicit
+// override. Two mechanisms produce that outcome and these tests pin both:
 //   1. The plugin default for Code is false (matching the LS), so SeedFrom recognises a stored
 //      true as a genuine override on any install that has never been seeded.
 //   2. MigrateCodeEnablement covers installs whose override set was ALREADY seeded without

--- a/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
@@ -26,7 +26,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
 
             // Seed reasonable defaults so Save() doesn't null-ref on Token or TrustedFolders.
             optMock.Object.OssEnabled = true;
-            optMock.Object.SnykCodeSecurityEnabled = true;
+            // false is Code's plugin default (it matches the LS, which does not default-enable Code).
+            optMock.Object.SnykCodeSecurityEnabled = false;
             optMock.Object.IacEnabled = true;
             optMock.Object.SecretsEnabled = false;
             optMock.Object.AutoScan = true;
@@ -348,8 +349,12 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
 
                 // OssEnabled = false is non-default, so it must be in ChangedConfigKeys.
                 Assert.Contains(PflagKeys.SnykOssEnabled, loaded.ChangedConfigKeys);
-                // SnykCodeEnabled = true is the default, so it must NOT be in ChangedConfigKeys.
-                Assert.DoesNotContain(PflagKeys.SnykCodeEnabled, loaded.ChangedConfigKeys);
+                // SnykCodeEnabled = true is non-default (Code's plugin default is false, matching the
+                // LS), so an upgrading user's enabled Code must be recognised as an override. Sending
+                // it as changed:false is what silently disabled Code for migrating users.
+                Assert.Contains(PflagKeys.SnykCodeEnabled, loaded.ChangedConfigKeys);
+                // IacEnabled = true IS the default, so it must NOT be in ChangedConfigKeys.
+                Assert.DoesNotContain(PflagKeys.SnykIacEnabled, loaded.ChangedConfigKeys);
             }
             finally
             {

--- a/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Settings/UserOverridePersistenceTests.cs
@@ -460,6 +460,9 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
         {
             // Write a settings.json with the seeded marker present but ChangedConfigKeys absent.
             // This models the steady state after a fresh install: user has zero overrides, marker is set.
+            // codeEnablementMigrated is set too — a fresh install stamps it when settings.json is
+            // created, and leaving it out would make this an upgrade file, so MigrateCodeEnablement
+            // would mark snyk_code_enabled and mask the re-seed behaviour under test.
             var path = Path.GetTempFileName();
             try
             {
@@ -477,7 +480,8 @@ namespace Snyk.VisualStudio.Extension.Tests.Settings
   ""autoScan"": true,
   ""deviceId"": ""sint001-device"",
   ""token"": """",
-  ""changedConfigKeysSeeded"": true
+  ""changedConfigKeysSeeded"": true,
+  ""codeEnablementMigrated"": true
 }";
                 File.WriteAllText(path, rawJson);
 


### PR DESCRIPTION
### **User description**
### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix Snyk Code enablement for upgrades.

- Align product enablement defaults.

- Enhance settings migration and loading logic.

- Add comprehensive tests for new migration.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[User Settings File] --> B(SnykOptionsManager.Load);
  B --> C{Default Configuration};
  B --> D{Code Enablement Migration};
  C --> E(OverrideTracker);
  D --> E;
  E --> F[Language Server];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ConfigDefaults.cs</strong><dd><code>Use SnykSettings constants for product defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/533/changes#diff-ef76604714a96630ddeaebc748510bc8c2296959914b91b9563c29ea036f5480">+17/-11</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>SnykOptionsManager.cs</strong><dd><code>Implement Snyk Code enablement migration logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/533/changes#diff-9719f1759d69640780fac0222473c9ab8233003553897a17b6b2bb2d77c768ae">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>SnykSettings.cs</strong><dd><code>Define Snyk Code default and migration marker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/533/changes#diff-66df776dbc99ed39a16e4ce974d885f78348445f17bebf3bffe177c51573ec57">+48/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>ConfigDefaultsTests.cs</strong><dd><code>Update tests for Snyk Code default and pinning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/533/changes#diff-f939316304f7bf511f87528590a76bbcbeb96e04f533cacd50fad78f5df1b031">+64/-46</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>LsSettingsV25Tests.cs</strong><dd><code>Adjust tests for Snyk Code default and migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/533/changes#diff-df5c7ba10f6ff233a9cddbc98511c075645dd0dcb65930deb4f03b08aba519ae">+44/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>UserOverrideTrackerTests.cs</strong><dd><code>Update tests for Snyk Code default and seeding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/533/changes#diff-e56312274b6c6342d390227842ee8e1ac4102e60f62e0c441ab0b41a554e0be5">+15/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CodeEnablementMigrationTests.cs</strong><dd><code>Add new tests for Snyk Code enablement migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/533/changes#diff-b43b3068bb15d1a6185437299e33f4f6377677f36953479732d516ca27b4bfd5">+370/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>UserOverridePersistenceTests.cs</strong><dd><code>Update persistence tests for Snyk Code default/migration</code>&nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-visual-studio-plugin/pull/533/changes#diff-f352c857a3750c68bf5b6a632de97b1c316905194aea6d5ac721dda57c914ef8">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

