### PR TITLE
feat: run 412 unit tests on Linux and macOS via a Core test project

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -72,6 +72,13 @@ jobs:
       with:
         vs-version: '[17.0, )'
 
+    # Snyk.VisualStudio.Extension.Core.Tests targets net8.0, so the solution build needs a
+    # .NET 8 SDK for MSBuild's SDK resolver. Pinned rather than relying on the runner image.
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
     - name: Restore NuGet packages
       run: nuget restore ${{ inputs.solution-file-path }}
 

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -29,7 +29,7 @@ jobs:
             command: test
             args: 
               --all-projects
-              --exclude=Snyk.VisualStudio.Extension.Tests,Snyk.Common.Tests,Snyk.Code.Library.Tests,Tests
+              --exclude=Snyk.VisualStudio.Extension.Tests,Snyk.VisualStudio.Extension.Core.Tests,Snyk.Common.Tests,Snyk.Code.Library.Tests,Tests
               --severity-threshold=high
   security-code-scan:
       runs-on: ubuntu-latest

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -44,6 +44,19 @@ jobs:
             command: code test
             args:
               --severity-threshold=high
+  cross-platform-unit-tests:
+    name: Run Cross-Platform Unit-Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      # No Visual Studio, MSBuild or VSIX tooling involved: this project compiles the
+      # platform-neutral subset of the extension. See docs/cross-platform-testing.md.
+      - name: Cross-platform unit tests
+        run: dotnet test Snyk.VisualStudio.Extension.Core.Tests --configuration Release
   build-project:
     uses: snyk/snyk-visual-studio-plugin/.github/workflows/build-project.yml@main
     with:

--- a/.github/workflows/security-scan-upload.yml
+++ b/.github/workflows/security-scan-upload.yml
@@ -24,7 +24,7 @@ jobs:
           command: monitor
           args: 
             --all-projects
-            --exclude=Snyk.VisualStudio.Extension.Tests,Snyk.Common.Tests,Snyk.Code.Library.Tests,Tests
+            --exclude=Snyk.VisualStudio.Extension.Tests,Snyk.VisualStudio.Extension.Core.Tests,Snyk.Common.Tests,Snyk.Code.Library.Tests,Tests
   security-code-monitor:
     runs-on: ubuntu-latest
     environment: snyk-msbuild-envs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,19 @@ If you do not have access to our content management system (you are not a Snyk e
 
 ## Setup development environment
 
+Most unit tests do not need Visual Studio, or even Windows. If your change is to the extension's
+logic rather than its IDE surface, you can develop and verify it with just the .NET SDK on Linux,
+macOS or Windows:
+
+```bash
+dotnet test Snyk.VisualStudio.Extension.Core.Tests
+```
+
+See [docs/cross-platform-testing.md](docs/cross-platform-testing.md) for what that covers, how to
+bring more tests into it, and what still needs a Windows machine.
+
+Building the VSIX and running the IDE-bound tests does need the full setup below.
+
 Download and install Visual Studio 2022 from [official website](https://visualstudio.microsoft.com/vs/).
 
 Install the Visual Studio SDK as part of a Visual Studio installation. For details, please, see [this page](https://docs.microsoft.com/en-us/visualstudio/extensibility/installing-the-visual-studio-sdk?view=vs-2022).

--- a/Snyk.VisualStudio.Extension.2022/Download/SnykCliDownloader.Vs.cs
+++ b/Snyk.VisualStudio.Extension.2022/Download/SnykCliDownloader.Vs.cs
@@ -1,0 +1,15 @@
+using Snyk.VisualStudio.Extension.UI.Notifications;
+
+namespace Snyk.VisualStudio.Extension.Download
+{
+    /// <summary>
+    /// The Visual Studio bound half of <see cref="SnykCliDownloader"/>: reporting a failed CLI
+    /// update needs the IDE info bar. Excluded from the cross-platform build (see
+    /// docs/cross-platform-testing.md).
+    /// </summary>
+    public partial class SnykCliDownloader
+    {
+        static partial void ShowCliUpdateErrorInfoBar(string message) =>
+            NotificationService.Instance.ShowErrorInfoBar(message);
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/Download/SnykCliDownloader.cs
+++ b/Snyk.VisualStudio.Extension.2022/Download/SnykCliDownloader.cs
@@ -8,14 +8,13 @@ using Snyk.VisualStudio.Extension.CLI;
 using Snyk.VisualStudio.Extension.Language;
 using Snyk.VisualStudio.Extension.Service;
 using Snyk.VisualStudio.Extension.Settings;
-using Snyk.VisualStudio.Extension.UI.Notifications;
 
 namespace Snyk.VisualStudio.Extension.Download
 {
     /// <summary>
     /// Donwnload last Snyk CLI version.
     /// </summary>
-    public class SnykCliDownloader
+    public partial class SnykCliDownloader
     {
         public const string DefaultBaseDownloadUrl = "https://downloads.snyk.io";
         public const string DefaultReleaseChannel = "stable";
@@ -326,7 +325,7 @@ namespace Snyk.VisualStudio.Extension.Download
                 }
                 catch (Exception e)
                 {
-                    NotificationService.Instance.ShowErrorInfoBar($"CLI could not be updated. Please check if another process is using the CLI binary at {cliFileDestinationPath}");
+                    ShowCliUpdateErrorInfoBar($"CLI could not be updated. Please check if another process is using the CLI binary at {cliFileDestinationPath}");
                     Logger.Error(e, "Error on CLI copy from temp file");
                 }
                 finally
@@ -335,6 +334,13 @@ namespace Snyk.VisualStudio.Extension.Download
                 }
             }
         }
+
+        /// <summary>
+        /// Surfaces a CLI update failure to the user. Implemented by the VSIX in
+        /// SnykCliDownloader.Vs.cs, which raises a Visual Studio info bar. There is nothing to
+        /// notify outside the IDE, so the call is compiled away in the cross-platform build.
+        /// </summary>
+        static partial void ShowCliUpdateErrorInfoBar(string message);
 
         private void FinishDownload(ISnykProgressWorker progressWorker, List<CliDownloadFinishedCallback> downloadFinishedCallbacks)
         {

--- a/Snyk.VisualStudio.Extension.2022/LogManager.Vs.cs
+++ b/Snyk.VisualStudio.Extension.2022/LogManager.Vs.cs
@@ -1,0 +1,16 @@
+using Microsoft.VisualStudio.Shell;
+
+namespace Snyk.VisualStudio.Extension
+{
+    /// <summary>
+    /// The Visual Studio bound half of <see cref="ThreadContextEnricher"/>. Excluded from the
+    /// cross-platform build (see docs/cross-platform-testing.md).
+    /// </summary>
+    public partial class ThreadContextEnricher
+    {
+        static partial void ResolveIdeThreadContext(ref string threadContext)
+        {
+            threadContext = ThreadHelper.CheckAccess() ? "UI Thread" : "Background Thread";
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/LogManager.cs
+++ b/Snyk.VisualStudio.Extension.2022/LogManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using Microsoft.VisualStudio.Shell;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -86,13 +85,22 @@ namespace Snyk.VisualStudio.Extension
     /// <summary>
     /// Custom thread context enricher to dynamically determine if the thread is a UI thread or a background thread.
     /// </summary>
-    public class ThreadContextEnricher : ILogEventEnricher
+    public partial class ThreadContextEnricher : ILogEventEnricher
     {
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
-            var threadContext = ThreadHelper.CheckAccess() ? "UI Thread" : "Background Thread";
+            var threadContext = "Background Thread";
+            ResolveIdeThreadContext(ref threadContext);
+
             var threadContextProperty = propertyFactory.CreateProperty("ThreadContext", threadContext);
             logEvent.AddPropertyIfAbsent(threadContextProperty);
         }
+
+        /// <summary>
+        /// Asks the IDE whether the calling thread is the UI thread. Implemented by the VSIX in
+        /// LogManager.Vs.cs; outside Visual Studio there is no UI thread to report, so the call is
+        /// compiled away and every event is attributed to a background thread.
+        /// </summary>
+        static partial void ResolveIdeThreadContext(ref string threadContext);
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/Service/ISnykServiceProvider.Vs.cs
+++ b/Snyk.VisualStudio.Extension.2022/Service/ISnykServiceProvider.Vs.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.Tasks;
+using EnvDTE80;
+using Microsoft.VisualStudio.Settings;
+using Microsoft.VisualStudio.Shell;
+using Snyk.VisualStudio.Extension.Theme;
+using Snyk.VisualStudio.Extension.UI.Toolwindow;
+
+namespace Snyk.VisualStudio.Extension.Service
+{
+    /// <summary>
+    /// The Visual Studio bound half of <see cref="ISnykServiceProvider"/>. Everything here needs
+    /// the VS SDK, so this part is excluded from the cross-platform build (see
+    /// docs/cross-platform-testing.md).
+    /// </summary>
+    public partial interface ISnykServiceProvider
+    {
+        /// <summary>
+        /// Gets VisualStudio DTE object instance.
+        /// </summary>
+        DTE2 DTE { get; }
+
+        /// <summary>
+        /// Gets Snyk package instance.
+        /// </summary>
+        SnykVSPackage Package { get; }
+
+        /// <summary>
+        /// Gets IAsyncServiceProvider implementation.
+        /// </summary>
+        IAsyncServiceProvider AsyncServiceProvider { get; }
+
+        /// <summary>
+        /// Gets Visual Studio Settiings Manager instance.
+        /// </summary>
+        SettingsManager SettingsManager { get; }
+
+        /// <summary>
+        /// Gets Theme service instance.
+        /// </summary>
+        SnykVsThemeService VsThemeService { get; }
+
+        /// <summary>
+        /// Gets the tool window seam (implemented by <see cref="SnykToolWindowControl"/>).
+        /// </summary>
+        ISnykToolWindow ToolWindow { get; }
+
+        /// <summary>
+        /// Get Visual Studio service (async).
+        /// </summary>
+        /// <param name="serviceType">Service type.</param>
+        /// <returns>VS service instance.</returns>
+        Task<object> GetServiceAsync(Type serviceType);
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/Service/ISnykServiceProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/Service/ISnykServiceProvider.cs
@@ -1,43 +1,22 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using EnvDTE80;
-using Microsoft.VisualStudio.Settings;
-using Microsoft.VisualStudio.Shell;
+﻿using System.Threading;
 using Snyk.VisualStudio.Extension.Authentication;
 using Snyk.VisualStudio.Extension.Language;
 using Snyk.VisualStudio.Extension.Settings;
-using Snyk.VisualStudio.Extension.Theme;
-using Snyk.VisualStudio.Extension.UI.Toolwindow;
 
 namespace Snyk.VisualStudio.Extension.Service
 {
     /// <summary>
     /// ServiceProvider interface for Snyk extension. Provide all needed services for this extension.
+    /// The Visual Studio specific members live in ISnykServiceProvider.Vs.cs.
     /// </summary>
-    public interface ISnykServiceProvider
+    public partial interface ISnykServiceProvider
     {
         /// <summary>
-        /// Gets VisualStudio DTE object instance.
-        /// </summary>
-        DTE2 DTE { get; }
-
-        /// <summary>
-        /// Gets Snyk package instance.
-        /// </summary>
-        SnykVSPackage Package { get; }
-
-        /// <summary>
         /// Gets the package disposal token, cancelled when the extension shuts down. Exposed here
-        /// (rather than reaching through <see cref="SnykVSPackage"/>.Instance) so consumers stay
+        /// (rather than reaching through <c>SnykVSPackage.Instance</c>) so consumers stay
         /// constructor-injectable and testable.
         /// </summary>
         CancellationToken DisposalToken { get; }
-
-        /// <summary>
-        /// Gets IAsyncServiceProvider implementation.
-        /// </summary>
-        IAsyncServiceProvider AsyncServiceProvider { get; }
 
         /// <summary>
         /// Gets Solution service instance.
@@ -61,28 +40,7 @@ namespace Snyk.VisualStudio.Extension.Service
         /// Orchestrates IDE-side auth flow (login/logout, modal auth dialog).
         /// </summary>
         IAuthenticationFlowService AuthenticationFlowService { get; }
-        /// <summary>
-        /// Gets Visual Studio Settiings Manager instance.
-        /// </summary>
-        SettingsManager SettingsManager { get; }
 
-        /// <summary>
-        /// Gets Theme service instance.
-        /// </summary>
-        SnykVsThemeService VsThemeService { get; }
-
-        /// <summary>
-        /// Gets the tool window seam (implemented by <see cref="SnykToolWindowControl"/>).
-        /// </summary>
-        ISnykToolWindow ToolWindow { get; }
-
-        /// <summary>
-        /// Get Visual Studio service (async).
-        /// </summary>
-        /// <param name="serviceType">Service type.</param>
-        /// <returns>VS service instance.</returns>
-        Task<object> GetServiceAsync(Type serviceType);
-        
         /// <summary>
         /// Get Feature Flag Service
         /// </summary>

--- a/Snyk.VisualStudio.Extension.2022/Service/ISolutionService.Vs.cs
+++ b/Snyk.VisualStudio.Extension.2022/Service/ISolutionService.Vs.cs
@@ -1,0 +1,16 @@
+namespace Snyk.VisualStudio.Extension.Service
+{
+    /// <summary>
+    /// The Visual Studio bound half of <see cref="ISolutionService"/>. Excluded from the
+    /// cross-platform build (see docs/cross-platform-testing.md).
+    /// </summary>
+    public partial interface ISolutionService
+    {
+        /// <summary>
+        /// Gets the VS solution-load event source (null until the service is initialized).
+        /// Exposed on the interface so that LanguageClient and other consumers can subscribe to
+        /// solution-lifecycle events without downcasting to the concrete SnykSolutionService.
+        /// </summary>
+        SnykVsSolutionLoadEvents SolutionEvents { get; }
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/Service/ISolutionService.cs
+++ b/Snyk.VisualStudio.Extension.2022/Service/ISolutionService.cs
@@ -4,17 +4,11 @@ using System.Threading.Tasks;
 namespace Snyk.VisualStudio.Extension.Service
 {
     /// <summary>
-    /// Service for solution related functionality.
+    /// Service for solution related functionality. The Visual Studio specific members live in
+    /// ISolutionService.Vs.cs.
     /// </summary>
-    public interface ISolutionService
+    public partial interface ISolutionService
     {
-        /// <summary>
-        /// Gets the VS solution-load event source (null until the service is initialized).
-        /// Exposed on the interface so that LanguageClient and other consumers can subscribe to
-        /// solution-lifecycle events without downcasting to the concrete SnykSolutionService.
-        /// </summary>
-        SnykVsSolutionLoadEvents SolutionEvents { get; }
-
         /// <summary>
         /// Get solution folder path.
         /// </summary>

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -241,6 +241,7 @@
     <Compile Include="UI\Html\WebView2BridgeBindings.cs" />
     <Compile Include="UI\Html\WebView2EnvironmentCache.cs" />
     <Compile Include="UI\Html\WebView2Host.cs" />
+    <Compile Include="UI\Html\WebView2Host.Paths.cs" />
     <Compile Include="UI\Html\WebView2MessageDispatcher.cs" />
     <Compile Include="UI\Html\WebView2NavigationPreparer.cs" />
     <Compile Include="UI\Notifications\NotificationService.cs" />

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -217,6 +217,7 @@
       <DependentUpon>TextField.xaml</DependentUpon>
     </Compile>
     <Compile Include="UI\Html\BaseHtmlProvider.cs" />
+    <Compile Include="UI\Html\BaseHtmlProvider.Vs.cs" />
     <Compile Include="UI\Html\ColorExtension.cs" />
     <Compile Include="UI\Html\ExecuteCommandBridge.cs" />
     <Compile Include="UI\Html\HtmlSettingsScriptingBridge.cs" />
@@ -225,12 +226,17 @@
     <Compile Include="UI\Html\HtmlResourceLoader.cs" />
     <Compile Include="UI\Html\IacHtmlProvider.cs" />
     <Compile Include="UI\Html\IHtmlProvider.cs" />
+    <Compile Include="UI\Html\HtmlThemePalette.cs" />
     <Compile Include="UI\Html\IWebView2Host.cs" />
     <Compile Include="UI\Html\StaticHtmlProvider.cs" />
+    <Compile Include="UI\Html\StaticHtmlProvider.Vs.cs" />
     <Compile Include="UI\Html\SummaryHtmlProvider.cs" />
     <Compile Include="UI\Html\OssHtmlProvider.cs" />
+    <Compile Include="UI\Html\OssHtmlProvider.Vs.cs" />
     <Compile Include="UI\Html\CodeHtmlProvider.cs" />
+    <Compile Include="UI\Html\CodeHtmlProvider.Vs.cs" />
     <Compile Include="UI\Html\SecretsHtmlProvider.cs" />
+    <Compile Include="UI\Html\SecretsHtmlProvider.Vs.cs" />
     <Compile Include="UI\Html\HtmlProviderFactory.cs" />
     <Compile Include="UI\Html\WebView2BridgeBindings.cs" />
     <Compile Include="UI\Html\WebView2EnvironmentCache.cs" />

--- a/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
+++ b/Snyk.VisualStudio.Extension.2022/Snyk.VisualStudio.Extension.2022.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Download\ChecksumVerificationException.cs" />
     <Compile Include="Download\LatestReleaseInfo.cs" />
     <Compile Include="Download\SnykCliDownloader.cs" />
+    <Compile Include="Download\SnykCliDownloader.Vs.cs" />
     <Compile Include="CLI\ICli.cs" />
     <Compile Include="CLI\InvalidTokenException.cs" />
     <Compile Include="CLI\SnykCli.cs" />
@@ -128,6 +129,7 @@
     <Compile Include="Language\SnykLanguageServerEventArgs.cs" />
     <Compile Include="LocalCodeEngine.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogManager.Vs.cs" />
     <Compile Include="ManualAssemblyResolver.cs" />
     <Compile Include="Model\Severity.cs" />
     <Compile Include="Product.cs" />
@@ -157,8 +159,10 @@
     <Compile Include="Service\ISnykProgressWorker.cs" />
     <Compile Include="Service\ISnykService.cs" />
     <Compile Include="Service\ISnykServiceProvider.cs" />
+    <Compile Include="Service\ISnykServiceProvider.Vs.cs" />
     <Compile Include="Service\ISnykTasksService.cs" />
     <Compile Include="Service\ISolutionService.cs" />
+    <Compile Include="Service\ISolutionService.Vs.cs" />
     <Compile Include="Service\IWorkspaceTrustService.cs" />
     <Compile Include="Service\OssScanException.cs" />
     <Compile Include="Service\SnykCliDownloadEventArgs.cs" />

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.Vs.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.Vs.cs
@@ -1,0 +1,50 @@
+using Microsoft.VisualStudio.PlatformUI;
+using Snyk.VisualStudio.Extension.Theme;
+
+namespace Snyk.VisualStudio.Extension.UI.Html
+{
+    /// <summary>
+    /// The Visual Studio bound half of <see cref="BaseHtmlProvider"/>: reading the active IDE
+    /// colour theme. Excluded from the cross-platform build (see
+    /// docs/cross-platform-testing.md).
+    /// </summary>
+    public partial class BaseHtmlProvider
+    {
+        static partial void ResolveIdeThemePalette(ref HtmlThemePalette palette)
+        {
+            palette = new HtmlThemePalette
+            {
+                // Use proper tool window colors for consistent theming
+                BackgroundColor = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey).ToHex(),
+                TextColor = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowTextColorKey).ToHex(),
+                BorderColor = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBorderColorKey).ToHex(),
+
+                // Links should use the standard hyperlink color
+                LinkColor = VSColorTheme.GetThemedColor(EnvironmentColors.PanelHyperlinkBrushKey).ToHex(),
+
+                // Input fields - use ComboBox colors as they're designed for input controls
+                InputBackground = VSColorTheme.GetThemedColor(EnvironmentColors.ComboBoxBackgroundColorKey).ToHex(),
+                InputBorder = VSColorTheme.GetThemedColor(EnvironmentColors.ComboBoxBorderColorKey).ToHex(),
+
+                // Legacy vscode- prefixed button variables (kept for compatibility)
+                ButtonBackground = VSColorTheme.GetThemedColor(EnvironmentColors.CommandBarMenuBackgroundGradientBeginColorKey).ToHex(),
+                ButtonHoverBackground = VSColorTheme.GetThemedColor(EnvironmentColors.CommandBarMouseOverBackgroundBeginColorKey).ToHex(),
+
+                // Disabled and error states
+                DisabledForeground = VSColorTheme.GetThemedColor(EnvironmentColors.SystemGrayTextColorKey).ToHex(),
+                ErrorForeground = VSColorTheme.GetThemedColor(EnvironmentColors.VizSurfaceRedMediumBrushKey).ToHex(),
+
+                // Section backgrounds - use grid colors which are designed for content separation
+                InactiveSelectionBackground = VSColorTheme.GetThemedColor(EnvironmentColors.GridHeadingBackgroundColorKey).ToHex(),
+
+                // Hover and interaction states
+                ListHoverBackground = VSColorTheme.GetThemedColor(EnvironmentColors.ComboBoxMouseOverBackgroundBeginColorKey).ToHex(),
+
+                // Scrollbar colors
+                ScrollbarBackground = VSColorTheme.GetThemedColor(EnvironmentColors.ScrollBarBackgroundColorKey).ToHex(),
+                ScrollbarThumb = VSColorTheme.GetThemedColor(EnvironmentColors.ScrollBarThumbBackgroundColorKey).ToHex(),
+                ScrollbarThumbHover = VSColorTheme.GetThemedColor(EnvironmentColors.ScrollBarThumbMouseOverBackgroundColorKey).ToHex(),
+            };
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.Vs.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.Vs.cs
@@ -1,5 +1,4 @@
 using Microsoft.VisualStudio.PlatformUI;
-using Snyk.VisualStudio.Extension.Theme;
 
 namespace Snyk.VisualStudio.Extension.UI.Html
 {

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/BaseHtmlProvider.cs
@@ -1,12 +1,10 @@
 using System.Linq;
 using System;
 using System.Text.RegularExpressions;
-using Microsoft.VisualStudio.PlatformUI;
-using Snyk.VisualStudio.Extension.Theme;
 
 namespace Snyk.VisualStudio.Extension.UI.Html
 {
-    public class BaseHtmlProvider : IHtmlProvider
+    public partial class BaseHtmlProvider : IHtmlProvider
     {
         private readonly bool forceLight;
 
@@ -114,77 +112,36 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             return new string(chars);
         }
 
+        /// <summary>
+        /// Replaces <paramref name="palette"/> with the active Visual Studio colour theme.
+        /// Implemented in BaseHtmlProvider.Vs.cs; where there is no IDE theme to read the call is
+        /// compiled away and the light palette stands (see docs/cross-platform-testing.md).
+        /// </summary>
+        static partial void ResolveIdeThemePalette(ref HtmlThemePalette palette);
+
         public virtual string ReplaceCssVariables(string html)
         {
-            string backgroundColor;
-            string textColor;
-            string borderColor;
-            string linkColor;
-            string inputBackground;
-            string inputBorder;
-            string buttonBackground;
-            string buttonHoverBackground;
-            string disabledForeground;
-            string errorForeground;
-            string inactiveSelectionBackground;
-            string listHoverBackground;
-            string scrollbarBackground;
-            string scrollbarThumb;
-            string scrollbarThumbHover;
-
-            if (forceLight)
+            var palette = HtmlThemePalette.Light;
+            if (!forceLight)
             {
-                // Hardcoded light palette — approximates VS's Light theme so the settings
-                // dialog reads cleanly regardless of the user's active VS theme.
-                backgroundColor = "#FFFFFF";
-                textColor = "#1F1F1F";
-                borderColor = "#D4D4D4";
-                linkColor = "#0066CC";
-                inputBackground = "#FFFFFF";
-                inputBorder = "#CECECE";
-                buttonBackground = "#E1E1E1";
-                buttonHoverBackground = "#CECECE";
-                disabledForeground = "#A0A0A0";
-                errorForeground = "#A1260D";
-                inactiveSelectionBackground = "#E5EBF1";
-                listHoverBackground = "#F0F0F0";
-                scrollbarBackground = "#F0F0F0";
-                scrollbarThumb = "#C1C1C1";
-                scrollbarThumbHover = "#A8A8A8";
+                ResolveIdeThemePalette(ref palette);
             }
-            else
-            {
-                // Use proper tool window colors for consistent theming
-                backgroundColor = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey).ToHex();
-                textColor = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowTextColorKey).ToHex();
-                borderColor = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBorderColorKey).ToHex();
 
-                // Links should use the standard hyperlink color
-                linkColor = VSColorTheme.GetThemedColor(EnvironmentColors.PanelHyperlinkBrushKey).ToHex();
-
-                // Input fields - use ComboBox colors as they're designed for input controls
-                inputBackground = VSColorTheme.GetThemedColor(EnvironmentColors.ComboBoxBackgroundColorKey).ToHex();
-                inputBorder = VSColorTheme.GetThemedColor(EnvironmentColors.ComboBoxBorderColorKey).ToHex();
-
-                // Legacy vscode- prefixed button variables (kept for compatibility)
-                buttonBackground = VSColorTheme.GetThemedColor(EnvironmentColors.CommandBarMenuBackgroundGradientBeginColorKey).ToHex();
-                buttonHoverBackground = VSColorTheme.GetThemedColor(EnvironmentColors.CommandBarMouseOverBackgroundBeginColorKey).ToHex();
-
-                // Disabled and error states
-                disabledForeground = VSColorTheme.GetThemedColor(EnvironmentColors.SystemGrayTextColorKey).ToHex();
-                errorForeground = VSColorTheme.GetThemedColor(EnvironmentColors.VizSurfaceRedMediumBrushKey).ToHex();
-
-                // Section backgrounds - use grid colors which are designed for content separation
-                inactiveSelectionBackground = VSColorTheme.GetThemedColor(EnvironmentColors.GridHeadingBackgroundColorKey).ToHex();
-
-                // Hover and interaction states
-                listHoverBackground = VSColorTheme.GetThemedColor(EnvironmentColors.ComboBoxMouseOverBackgroundBeginColorKey).ToHex();
-
-                // Scrollbar colors
-                scrollbarBackground = VSColorTheme.GetThemedColor(EnvironmentColors.ScrollBarBackgroundColorKey).ToHex();
-                scrollbarThumb = VSColorTheme.GetThemedColor(EnvironmentColors.ScrollBarThumbBackgroundColorKey).ToHex();
-                scrollbarThumbHover = VSColorTheme.GetThemedColor(EnvironmentColors.ScrollBarThumbMouseOverBackgroundColorKey).ToHex();
-            }
+            var backgroundColor = palette.BackgroundColor;
+            var textColor = palette.TextColor;
+            var borderColor = palette.BorderColor;
+            var linkColor = palette.LinkColor;
+            var inputBackground = palette.InputBackground;
+            var inputBorder = palette.InputBorder;
+            var buttonBackground = palette.ButtonBackground;
+            var buttonHoverBackground = palette.ButtonHoverBackground;
+            var disabledForeground = palette.DisabledForeground;
+            var errorForeground = palette.ErrorForeground;
+            var inactiveSelectionBackground = palette.InactiveSelectionBackground;
+            var listHoverBackground = palette.ListHoverBackground;
+            var scrollbarBackground = palette.ScrollbarBackground;
+            var scrollbarThumb = palette.ScrollbarThumb;
+            var scrollbarThumbHover = palette.ScrollbarThumbHover;
 
             // Editor/main content area
             var editorBackground = backgroundColor;

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/CodeHtmlProvider.Vs.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/CodeHtmlProvider.Vs.cs
@@ -1,0 +1,30 @@
+using Microsoft.VisualStudio.PlatformUI;
+using Snyk.VisualStudio.Extension.Theme;
+
+namespace Snyk.VisualStudio.Extension.UI.Html
+{
+    /// <summary>
+    /// The Visual Studio bound half of <see cref="CodeHtmlProvider"/>: the themed colours and
+    /// theme flags the Code description panel needs. Excluded from the cross-platform build (see
+    /// docs/cross-platform-testing.md).
+    /// </summary>
+    public partial class CodeHtmlProvider
+    {
+        static partial void ResolveIdeThemeFlags(ref bool isDarkTheme, ref bool isHighContrast)
+        {
+            isDarkTheme = ThemeInfo.IsDarkTheme();
+            isHighContrast = ThemeInfo.IsHighContrast();
+        }
+
+        static partial void ApplyIdeThemeColors(ref string html)
+        {
+            html = html.Replace("var(--example-line-removed-color)", VSColorTheme.GetThemedColor(EnvironmentColors.VizSurfaceRedDarkBrushKey).ToHex());
+            html = html.Replace("var(--example-line-added-color)", VSColorTheme.GetThemedColor(EnvironmentColors.VizSurfaceGreenDarkBrushKey).ToHex());
+            html = html.Replace("var(--button-background-color)", VSColorTheme.GetThemedColor(EnvironmentColors.StartPageButtonPinHoverColorKey).ToHex());
+            html = html.Replace("var(--button-text-color)", VSColorTheme.GetThemedColor(EnvironmentColors.BrandedUITextBrushKey).ToHex());
+            html = html.Replace("var(--circle-color)", VSColorTheme.GetThemedColor(EnvironmentColors.StartPageButtonPinHoverColorKey).ToHex());
+            html = html.Replace("var(--warning-background)", VSColorTheme.GetThemedColor(EnvironmentColors.SmartTagHoverFillBrushKey).ToHex());
+            html = html.Replace("var(--warning-text)", VSColorTheme.GetThemedColor(EnvironmentColors.SmartTagHoverTextBrushKey).ToHex());
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/CodeHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/CodeHtmlProvider.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using Microsoft.VisualStudio.PlatformUI;
-using Snyk.VisualStudio.Extension.Theme;
 
 namespace Snyk.VisualStudio.Extension.UI.Html
 {
-    public class CodeHtmlProvider : BaseHtmlProvider
+    public partial class CodeHtmlProvider : BaseHtmlProvider
     {
         private static CodeHtmlProvider _instance;
 
@@ -61,13 +59,26 @@ namespace Snyk.VisualStudio.Extension.UI.Html
 
         private string GetThemeScript()
         {
-            var isDarkTheme = ThemeInfo.IsDarkTheme();
-            var isHighContrast = ThemeInfo.IsHighContrast();
+            var isDarkTheme = false;
+            var isHighContrast = false;
+            ResolveIdeThemeFlags(ref isDarkTheme, ref isHighContrast);
+
             var themeScript = $"var isDarkTheme = {isDarkTheme.ToString().ToLowerInvariant()};\n" +
                               $"var isHighContrast = {isHighContrast.ToString().ToLowerInvariant()};\n" +
                               "document.body.classList.add(isHighContrast ? 'high-contrast' : (isDarkTheme ? 'dark' : 'light'));";
             return themeScript;
         }
+
+        /// <summary>
+        /// Reports the IDE's dark / high-contrast state. Implemented in CodeHtmlProvider.Vs.cs.
+        /// </summary>
+        static partial void ResolveIdeThemeFlags(ref bool isDarkTheme, ref bool isHighContrast);
+
+        /// <summary>
+        /// Substitutes the Code panel's themed colour variables. Implemented in
+        /// CodeHtmlProvider.Vs.cs; the variables are left in place where there is no IDE theme.
+        /// </summary>
+        static partial void ApplyIdeThemeColors(ref string html);
 
         public override string ReplaceCssVariables(string html)
         {
@@ -76,13 +87,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
 
             html = base.ReplaceCssVariables(html);
 
-            html = html.Replace("var(--example-line-removed-color)", VSColorTheme.GetThemedColor(EnvironmentColors.VizSurfaceRedDarkBrushKey).ToHex());
-            html = html.Replace("var(--example-line-added-color)", VSColorTheme.GetThemedColor(EnvironmentColors.VizSurfaceGreenDarkBrushKey).ToHex());
-            html = html.Replace("var(--button-background-color)", VSColorTheme.GetThemedColor(EnvironmentColors.StartPageButtonPinHoverColorKey).ToHex());
-            html = html.Replace("var(--button-text-color)", VSColorTheme.GetThemedColor(EnvironmentColors.BrandedUITextBrushKey).ToHex());
-            html = html.Replace("var(--circle-color)", VSColorTheme.GetThemedColor(EnvironmentColors.StartPageButtonPinHoverColorKey).ToHex());
-            html = html.Replace("var(--warning-background)", VSColorTheme.GetThemedColor(EnvironmentColors.SmartTagHoverFillBrushKey).ToHex());
-            html = html.Replace("var(--warning-text)", VSColorTheme.GetThemedColor(EnvironmentColors.SmartTagHoverTextBrushKey).ToHex());
+            ApplyIdeThemeColors(ref html);
 
             html = html.Replace("${ideGenerateAIFix}", "window.GenerateFixes(issueId)");
             html = html.Replace("${ideApplyAIFix}", "window.ApplyFixDiff(fixId)");

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlThemePalette.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/HtmlThemePalette.cs
@@ -1,0 +1,68 @@
+namespace Snyk.VisualStudio.Extension.UI.Html
+{
+    /// <summary>
+    /// The colours <see cref="BaseHtmlProvider.ReplaceCssVariables"/> maps onto the CSS custom
+    /// properties of every HTML surface, as CSS hex strings.
+    /// </summary>
+    /// <remarks>
+    /// Holding the palette in one object keeps the mapping (here and in
+    /// <c>BaseHtmlProvider</c>) separate from where the colours come from: the active Visual
+    /// Studio theme, read in <c>BaseHtmlProvider.Vs.cs</c>, or <see cref="Light"/>.
+    /// </remarks>
+    internal sealed class HtmlThemePalette
+    {
+        public string BackgroundColor { get; set; }
+
+        public string TextColor { get; set; }
+
+        public string BorderColor { get; set; }
+
+        public string LinkColor { get; set; }
+
+        public string InputBackground { get; set; }
+
+        public string InputBorder { get; set; }
+
+        public string ButtonBackground { get; set; }
+
+        public string ButtonHoverBackground { get; set; }
+
+        public string DisabledForeground { get; set; }
+
+        public string ErrorForeground { get; set; }
+
+        public string InactiveSelectionBackground { get; set; }
+
+        public string ListHoverBackground { get; set; }
+
+        public string ScrollbarBackground { get; set; }
+
+        public string ScrollbarThumb { get; set; }
+
+        public string ScrollbarThumbHover { get; set; }
+
+        /// <summary>
+        /// Hardcoded light palette — approximates VS's Light theme so the settings
+        /// dialog reads cleanly regardless of the user's active VS theme. Also the palette used
+        /// wherever there is no Visual Studio theme to read.
+        /// </summary>
+        public static HtmlThemePalette Light => new HtmlThemePalette
+        {
+            BackgroundColor = "#FFFFFF",
+            TextColor = "#1F1F1F",
+            BorderColor = "#D4D4D4",
+            LinkColor = "#0066CC",
+            InputBackground = "#FFFFFF",
+            InputBorder = "#CECECE",
+            ButtonBackground = "#E1E1E1",
+            ButtonHoverBackground = "#CECECE",
+            DisabledForeground = "#A0A0A0",
+            ErrorForeground = "#A1260D",
+            InactiveSelectionBackground = "#E5EBF1",
+            ListHoverBackground = "#F0F0F0",
+            ScrollbarBackground = "#F0F0F0",
+            ScrollbarThumb = "#C1C1C1",
+            ScrollbarThumbHover = "#A8A8A8",
+        };
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/OssHtmlProvider.Vs.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/OssHtmlProvider.Vs.cs
@@ -1,5 +1,4 @@
 using Microsoft.VisualStudio.PlatformUI;
-using Snyk.VisualStudio.Extension.Theme;
 
 namespace Snyk.VisualStudio.Extension.UI.Html
 {

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/OssHtmlProvider.Vs.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/OssHtmlProvider.Vs.cs
@@ -1,0 +1,15 @@
+using Microsoft.VisualStudio.PlatformUI;
+using Snyk.VisualStudio.Extension.Theme;
+
+namespace Snyk.VisualStudio.Extension.UI.Html
+{
+    /// <summary>
+    /// The Visual Studio bound half of <see cref="OssHtmlProvider"/>. Excluded from the
+    /// cross-platform build (see docs/cross-platform-testing.md).
+    /// </summary>
+    public partial class OssHtmlProvider
+    {
+        static partial void ApplyIdeThemeColors(ref string html) =>
+            html = html.Replace("var(--container-background-color)", VSColorTheme.GetThemedColor(EnvironmentColors.EditorExpansionFillBrushKey).ToHex());
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/OssHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/OssHtmlProvider.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.VisualStudio.PlatformUI;
-using System;
+﻿using System;
 
 namespace Snyk.VisualStudio.Extension.UI.Html
 {
-    public class OssHtmlProvider : BaseHtmlProvider
+    public partial class OssHtmlProvider : BaseHtmlProvider
     {
         private static OssHtmlProvider _instance;
 
@@ -19,6 +18,12 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             }
         }
 
+        /// <summary>
+        /// Substitutes the Open Source panel's themed container colour. Implemented in
+        /// OssHtmlProvider.Vs.cs; the variable is left in place where there is no IDE theme.
+        /// </summary>
+        static partial void ApplyIdeThemeColors(ref string html);
+
         public override string ReplaceCssVariables(string html)
         {
             var css = "<style nonce=\"${nonce}\">";
@@ -26,7 +31,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             css += "</style>"; 
             html = html.Replace("${ideStyle}", css);
             html =  base.ReplaceCssVariables(html);
-            html = html.Replace("var(--container-background-color)", VSColorTheme.GetThemedColor(EnvironmentColors.EditorExpansionFillBrushKey).ToHex());
+            ApplyIdeThemeColors(ref html);
 
             return html;
         }

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/SecretsHtmlProvider.Vs.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/SecretsHtmlProvider.Vs.cs
@@ -1,0 +1,28 @@
+using Microsoft.VisualStudio.PlatformUI;
+using Snyk.VisualStudio.Extension.Theme;
+
+namespace Snyk.VisualStudio.Extension.UI.Html
+{
+    /// <summary>
+    /// The Visual Studio bound half of <see cref="SecretsHtmlProvider"/>: the themed colours and
+    /// theme flags the Secrets description panel needs. Excluded from the cross-platform build
+    /// (see docs/cross-platform-testing.md).
+    /// </summary>
+    public partial class SecretsHtmlProvider
+    {
+        static partial void ResolveIdeThemeFlags(ref bool isDarkTheme, ref bool isHighContrast)
+        {
+            isDarkTheme = ThemeInfo.IsDarkTheme();
+            isHighContrast = ThemeInfo.IsHighContrast();
+        }
+
+        static partial void ApplyIdeThemeColors(ref string html)
+        {
+            html = html.Replace("var(--button-background-color)", VSColorTheme.GetThemedColor(EnvironmentColors.StartPageButtonPinHoverColorKey).ToHex());
+            html = html.Replace("var(--button-text-color)", VSColorTheme.GetThemedColor(EnvironmentColors.BrandedUITextBrushKey).ToHex());
+            html = html.Replace("var(--circle-color)", VSColorTheme.GetThemedColor(EnvironmentColors.StartPageButtonPinHoverColorKey).ToHex());
+            html = html.Replace("var(--warning-background)", VSColorTheme.GetThemedColor(EnvironmentColors.SmartTagHoverFillBrushKey).ToHex());
+            html = html.Replace("var(--warning-text)", VSColorTheme.GetThemedColor(EnvironmentColors.SmartTagHoverTextBrushKey).ToHex());
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/SecretsHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/SecretsHtmlProvider.cs
@@ -1,6 +1,4 @@
 using System;
-using Microsoft.VisualStudio.PlatformUI;
-using Snyk.VisualStudio.Extension.Theme;
 
 namespace Snyk.VisualStudio.Extension.UI.Html
 {
@@ -9,7 +7,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
     // internal/html/ignore templates) emits only: ${ideStyle}, ${ideScript}, the ignore form's
     // ${ideSubmitIgnoreRequest}, and theme classes. It does NOT emit ${ideGenerateAIFix},
     // ${ideApplyAIFix}, or data-flow-clickable-row rows — so we wire neither here.
-    public class SecretsHtmlProvider : BaseHtmlProvider
+    public partial class SecretsHtmlProvider : BaseHtmlProvider
     {
         private static SecretsHtmlProvider _instance;
 
@@ -41,13 +39,26 @@ namespace Snyk.VisualStudio.Extension.UI.Html
 
         private string GetThemeScript()
         {
-            var isDarkTheme = ThemeInfo.IsDarkTheme();
-            var isHighContrast = ThemeInfo.IsHighContrast();
+            var isDarkTheme = false;
+            var isHighContrast = false;
+            ResolveIdeThemeFlags(ref isDarkTheme, ref isHighContrast);
+
             var themeScript = $"var isDarkTheme = {isDarkTheme.ToString().ToLowerInvariant()};\n" +
                               $"var isHighContrast = {isHighContrast.ToString().ToLowerInvariant()};\n" +
                               "document.body.classList.add(isHighContrast ? 'high-contrast' : (isDarkTheme ? 'dark' : 'light'));";
             return themeScript;
         }
+
+        /// <summary>
+        /// Reports the IDE's dark / high-contrast state. Implemented in SecretsHtmlProvider.Vs.cs.
+        /// </summary>
+        static partial void ResolveIdeThemeFlags(ref bool isDarkTheme, ref bool isHighContrast);
+
+        /// <summary>
+        /// Substitutes the Secrets panel's themed colour variables. Implemented in
+        /// SecretsHtmlProvider.Vs.cs; the variables are left in place where there is no IDE theme.
+        /// </summary>
+        static partial void ApplyIdeThemeColors(ref string html);
 
         public override string ReplaceCssVariables(string html)
         {
@@ -56,11 +67,7 @@ namespace Snyk.VisualStudio.Extension.UI.Html
 
             html = base.ReplaceCssVariables(html);
 
-            html = html.Replace("var(--button-background-color)", VSColorTheme.GetThemedColor(EnvironmentColors.StartPageButtonPinHoverColorKey).ToHex());
-            html = html.Replace("var(--button-text-color)", VSColorTheme.GetThemedColor(EnvironmentColors.BrandedUITextBrushKey).ToHex());
-            html = html.Replace("var(--circle-color)", VSColorTheme.GetThemedColor(EnvironmentColors.StartPageButtonPinHoverColorKey).ToHex());
-            html = html.Replace("var(--warning-background)", VSColorTheme.GetThemedColor(EnvironmentColors.SmartTagHoverFillBrushKey).ToHex());
-            html = html.Replace("var(--warning-text)", VSColorTheme.GetThemedColor(EnvironmentColors.SmartTagHoverTextBrushKey).ToHex());
+            ApplyIdeThemeColors(ref html);
 
             html = html.Replace("${ideSubmitIgnoreRequest}", "window.SubmitIgnoreRequest(issueId, ignoreType, ignoreReason, ignoreExpirationDate)");
             return html;

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.Vs.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.Vs.cs
@@ -1,0 +1,29 @@
+using Microsoft.VisualStudio.Shell;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Snyk.VisualStudio.Extension.UI.Html
+{
+    /// <summary>
+    /// The Visual Studio bound half of <see cref="StaticHtmlProvider"/>: loading the loading-state
+    /// HTML has to be marshalled through the IDE's joinable task factory. Excluded from the
+    /// cross-platform build (see docs/cross-platform-testing.md).
+    /// </summary>
+    public partial class StaticHtmlProvider
+    {
+        public async Task<string> GetInitHtmlAsync()
+        {
+            return await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                var assemblyLocation = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+                if (assemblyLocation == null) return string.Empty;
+                var path = Path.Combine(assemblyLocation, "Resources", "ScanSummaryInit.html");
+                using (var stream = new StreamReader(path))
+                {
+                    var html = await stream.ReadToEndAsync();
+                    return html;
+                }
+            });
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/StaticHtmlProvider.cs
@@ -1,10 +1,6 @@
-﻿using Microsoft.VisualStudio.Shell;
-using System.IO;
-using System.Threading.Tasks;
-
-namespace Snyk.VisualStudio.Extension.UI.Html
+﻿namespace Snyk.VisualStudio.Extension.UI.Html
 {
-    public class StaticHtmlProvider : BaseHtmlProvider
+    public partial class StaticHtmlProvider : BaseHtmlProvider
     {
         private static StaticHtmlProvider _instance;
 
@@ -40,21 +36,6 @@ namespace Snyk.VisualStudio.Extension.UI.Html
                 "<style nonce=\"ideNonce\">:root { --main-font-size: 10px; }" + GetScrollbarCss() + "</style>";
             html = html.Replace("${ideStyle}", ideStyleOverride);
             return base.ReplaceCssVariables(html);
-        }
-
-        public async Task<string> GetInitHtmlAsync()
-        {
-            return await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                var assemblyLocation = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-                if (assemblyLocation == null) return string.Empty;
-                var path = Path.Combine(assemblyLocation, "Resources", "ScanSummaryInit.html");
-                using (var stream = new StreamReader(path))
-                {
-                    var html = await stream.ReadToEndAsync();
-                    return html;
-                }
-            });
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/SummaryHtmlProvider.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/SummaryHtmlProvider.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualStudio.PlatformUI;
-using System;
+﻿using System;
 
 namespace Snyk.VisualStudio.Extension.UI.Html
 {

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/WebView2Host.Paths.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/WebView2Host.Paths.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using Serilog;
+
+namespace Snyk.VisualStudio.Extension.UI.Html
+{
+    /// <summary>
+    /// The path and URI rules of <see cref="WebView2Host"/>: where a host's Chromium user-data
+    /// folder lives, when a stale one may be swept, and which documents the control is allowed to
+    /// navigate to. None of this needs the WebView2 control or WPF, so it is separated from the
+    /// host itself and covered by the cross-platform test suite.
+    /// </summary>
+    public sealed partial class WebView2Host
+    {
+        private static readonly ILogger Logger = LogManager.ForContext<WebView2Host>();
+
+        /// <summary>
+        /// Builds a per-context + per-VS-process user-data folder path under
+        /// <c>%LOCALAPPDATA%\Snyk\WebView2\&lt;pid&gt;\&lt;contextKey&gt;</c>. Production
+        /// uses two keys: <c>"toolwindow"</c> (shared by the description and summary
+        /// panels) and <c>"settings"</c> (the modal dialog, see class-level remarks for
+        /// why it's isolated). The per-process root is essential because WebView2 takes
+        /// an exclusive lock on the user-data folder — two VS instances running
+        /// concurrently would otherwise contend. Sibling <c>&lt;pid&gt;</c> folders whose
+        /// process has exited are swept on first call so they don't accumulate across
+        /// crashed sessions.
+        /// </summary>
+        public static string BuildUserDataFolder(string contextKey)
+        {
+            if (string.IsNullOrEmpty(contextKey)) throw new ArgumentException("Context key is required", nameof(contextKey));
+
+            _ = OrphanCleanupOnce.Value;
+
+            var pid = Process.GetCurrentProcess().Id;
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Snyk", "WebView2", pid.ToString(), contextKey);
+        }
+
+        private static readonly Lazy<bool> OrphanCleanupOnce = new Lazy<bool>(() =>
+        {
+            TryCleanupOrphanFolders();
+            return true;
+        });
+
+        private static void TryCleanupOrphanFolders()
+        {
+            var root = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Snyk", "WebView2");
+
+            if (!Directory.Exists(root)) return;
+
+            var currentPid = Process.GetCurrentProcess().Id;
+            foreach (var dir in Directory.GetDirectories(root))
+            {
+                var name = Path.GetFileName(dir);
+                if (!int.TryParse(name, out var pid)) continue;
+                if (pid == currentPid) continue;
+                if (IsProcessAlive(pid)) continue;
+
+                try
+                {
+                    Directory.Delete(dir, recursive: true);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning(ex, "Failed to clean up orphan WebView2 folder {Path}", dir);
+                }
+            }
+        }
+
+        private static bool IsProcessAlive(int pid)
+        {
+            try
+            {
+                using (var process = Process.GetProcessById(pid))
+                {
+                    return !process.HasExited;
+                }
+            }
+            catch (ArgumentException)
+            {
+                // GetProcessById throws when the PID does not refer to a running process.
+                return false;
+            }
+            catch (InvalidOperationException)
+            {
+                // Process has exited between GetProcessById and the HasExited check.
+                return false;
+            }
+        }
+
+        // internal static for testability (InternalsVisibleTo test project): pure allowlist logic
+        // with the user-data folder passed in rather than read from instance state.
+        internal static bool IsAllowedDocumentUri(string uri, string userDataFolder)
+        {
+            if (string.IsNullOrEmpty(uri))
+                return true; // initial / empty document
+
+            // NavigateToString surfaces as about:blank or a data: document depending on size.
+            if (uri.StartsWith("about:", StringComparison.OrdinalIgnoreCase)
+                || uri.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            // Oversized HTML is spilled to a scratch file and loaded via file://; only allow files
+            // under this host's own user-data folder.
+            if (uri.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    var path = Path.GetFullPath(new Uri(uri).LocalPath);
+                    var root = Path.GetFullPath(userDataFolder).TrimEnd(
+                        Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+                    return path.StartsWith(root, StringComparison.OrdinalIgnoreCase);
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/WebView2Host.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/WebView2Host.cs
@@ -39,10 +39,10 @@ namespace Snyk.VisualStudio.Extension.UI.Html
     /// context. See <a href="https://github.com/MicrosoftEdge/WebView2Feedback/issues/2323">
     /// WebView2Feedback#2323</a>.
     /// </para>
-    /// </remarks>
-    /// <remarks>
+    /// <para>
     /// The user-data folder layout and the navigation allowlist live in
     /// WebView2Host.Paths.cs, which needs neither WebView2 nor WPF.
+    /// </para>
     /// </remarks>
     public sealed partial class WebView2Host : IWebView2Host
     {

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/WebView2Host.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/WebView2Host.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.Wpf;
-using Serilog;
 using Snyk.VisualStudio.Extension.Extension;
 #if DEBUG
 using Newtonsoft.Json.Linq;
@@ -41,10 +40,12 @@ namespace Snyk.VisualStudio.Extension.UI.Html
     /// WebView2Feedback#2323</a>.
     /// </para>
     /// </remarks>
-    public sealed class WebView2Host : IWebView2Host
+    /// <remarks>
+    /// The user-data folder layout and the navigation allowlist live in
+    /// WebView2Host.Paths.cs, which needs neither WebView2 nor WPF.
+    /// </remarks>
+    public sealed partial class WebView2Host : IWebView2Host
     {
-        private static readonly ILogger Logger = LogManager.ForContext<WebView2Host>();
-
         private readonly WebView2 _webView;
         private readonly WebView2MessageDispatcher _dispatcher;
         private readonly WebView2NavigationPreparer _preparer;
@@ -120,35 +121,6 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             }
         }
 
-        /// <summary>
-        /// Builds a per-context + per-VS-process user-data folder path under
-        /// <c>%LOCALAPPDATA%\Snyk\WebView2\&lt;pid&gt;\&lt;contextKey&gt;</c>. Production
-        /// uses two keys: <c>"toolwindow"</c> (shared by the description and summary
-        /// panels) and <c>"settings"</c> (the modal dialog, see class-level remarks for
-        /// why it's isolated). The per-process root is essential because WebView2 takes
-        /// an exclusive lock on the user-data folder — two VS instances running
-        /// concurrently would otherwise contend. Sibling <c>&lt;pid&gt;</c> folders whose
-        /// process has exited are swept on first call so they don't accumulate across
-        /// crashed sessions.
-        /// </summary>
-        public static string BuildUserDataFolder(string contextKey)
-        {
-            if (string.IsNullOrEmpty(contextKey)) throw new ArgumentException("Context key is required", nameof(contextKey));
-
-            _ = OrphanCleanupOnce.Value;
-
-            var pid = Process.GetCurrentProcess().Id;
-            return Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Snyk", "WebView2", pid.ToString(), contextKey);
-        }
-
-        private static readonly Lazy<bool> OrphanCleanupOnce = new Lazy<bool>(() =>
-        {
-            TryCleanupOrphanFolders();
-            return true;
-        });
-
         // Per-folder environment cache so multiple WebView2 controls sharing the same
         // user-data folder share the same env instance — which is what WebView2 requires
         // for safe shared-folder operation (see WebView2Feedback#2323 + class-level remarks).
@@ -174,54 +146,6 @@ namespace Snyk.VisualStudio.Extension.UI.Html
 
         private static Task<CoreWebView2Environment> GetOrCreateEnvironmentAsync(string userDataFolder) =>
             EnvironmentCache.GetOrCreate(userDataFolder);
-
-        private static void TryCleanupOrphanFolders()
-        {
-            var root = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Snyk", "WebView2");
-
-            if (!Directory.Exists(root)) return;
-
-            var currentPid = Process.GetCurrentProcess().Id;
-            foreach (var dir in Directory.GetDirectories(root))
-            {
-                var name = Path.GetFileName(dir);
-                if (!int.TryParse(name, out var pid)) continue;
-                if (pid == currentPid) continue;
-                if (IsProcessAlive(pid)) continue;
-
-                try
-                {
-                    Directory.Delete(dir, recursive: true);
-                }
-                catch (Exception ex)
-                {
-                    Logger.Warning(ex, "Failed to clean up orphan WebView2 folder {Path}", dir);
-                }
-            }
-        }
-
-        private static bool IsProcessAlive(int pid)
-        {
-            try
-            {
-                using (var process = Process.GetProcessById(pid))
-                {
-                    return !process.HasExited;
-                }
-            }
-            catch (ArgumentException)
-            {
-                // GetProcessById throws when the PID does not refer to a running process.
-                return false;
-            }
-            catch (InvalidOperationException)
-            {
-                // Process has exited between GetProcessById and the HasExited check.
-                return false;
-            }
-        }
 
         public async Task InitializeAsync()
         {
@@ -339,38 +263,6 @@ namespace Snyk.VisualStudio.Extension.UI.Html
             {
                 Logger.Warning("Blocking WebView2 new-window request for disallowed URI: {Uri}", e.Uri);
             }
-        }
-
-        // internal static for testability (InternalsVisibleTo test project): pure allowlist logic
-        // with the user-data folder passed in rather than read from instance state.
-        internal static bool IsAllowedDocumentUri(string uri, string userDataFolder)
-        {
-            if (string.IsNullOrEmpty(uri))
-                return true; // initial / empty document
-
-            // NavigateToString surfaces as about:blank or a data: document depending on size.
-            if (uri.StartsWith("about:", StringComparison.OrdinalIgnoreCase)
-                || uri.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
-                return true;
-
-            // Oversized HTML is spilled to a scratch file and loaded via file://; only allow files
-            // under this host's own user-data folder.
-            if (uri.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
-            {
-                try
-                {
-                    var path = Path.GetFullPath(new Uri(uri).LocalPath);
-                    var root = Path.GetFullPath(userDataFolder).TrimEnd(
-                        Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
-                    return path.StartsWith(root, StringComparison.OrdinalIgnoreCase);
-                }
-                catch
-                {
-                    return false;
-                }
-            }
-
-            return false;
         }
 
         private static void TryOpenExternally(string url)

--- a/Snyk.VisualStudio.Extension.Core.Tests/ProjectFileIntegrityTests.cs
+++ b/Snyk.VisualStudio.Extension.Core.Tests/ProjectFileIntegrityTests.cs
@@ -1,0 +1,142 @@
+// ABOUTME: Guards the hand-maintained project file lists that the Windows build depends on.
+// Snyk.VisualStudio.Extension.2022.csproj is a legacy (non-SDK) project: every source file has to
+// be listed explicitly, and a file that is added to disk but not to the csproj compiles fine
+// locally in some editors yet silently disappears from the VSIX. The cross-platform test project
+// has the same exposure through its two .props file lists. These checks run on Linux, so the
+// mistake is caught long before a Windows-only build.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests
+{
+    public class ProjectFileIntegrityTests
+    {
+        private const string ExtensionProject = "Snyk.VisualStudio.Extension.2022";
+        private const string WindowsTestProject = "Snyk.VisualStudio.Extension.Tests";
+        private const string CoreTestProject = "Snyk.VisualStudio.Extension.Core.Tests";
+
+        private static readonly Regex IncludeAttribute = new Regex(
+            @"<(?:Compile|Page|EmbeddedResource|Content|None|Resource|VSCTCompile|ApplicationDefinition)\s+[^>]*Include=""(?<path>[^""]+)""",
+            RegexOptions.Compiled);
+
+        [Fact]
+        public void ExtensionCsproj_ListsEverySourceFileOnDisk()
+        {
+            var projectDir = Path.Combine(RepositoryRoot(), ExtensionProject);
+            var listed = IncludedPaths(Path.Combine(projectDir, ExtensionProject + ".csproj"));
+
+            var missing = SourceFilesUnder(projectDir)
+                .Where(relativePath => !listed.Contains(relativePath))
+                .OrderBy(relativePath => relativePath, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            Assert.True(
+                missing.Count == 0,
+                $"{ExtensionProject}.csproj is a legacy project and must list every source file. " +
+                $"Add <Compile Include=\"...\"/> (or <Page .../> for XAML) entries for: {string.Join(", ", missing)}");
+        }
+
+        [Fact]
+        public void ExtensionCsproj_DoesNotReferenceDeletedFiles()
+        {
+            var projectDir = Path.Combine(RepositoryRoot(), ExtensionProject);
+
+            var absent = IncludedPaths(Path.Combine(projectDir, ExtensionProject + ".csproj"))
+                .Where(relativePath => relativePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+                                       || relativePath.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase))
+                .Where(relativePath => !File.Exists(Path.Combine(projectDir, relativePath.Replace('/', Path.DirectorySeparatorChar))))
+                .OrderBy(relativePath => relativePath, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            Assert.True(
+                absent.Count == 0,
+                $"{ExtensionProject}.csproj references files that no longer exist: {string.Join(", ", absent)}");
+        }
+
+        [Theory]
+        [InlineData("Snyk.VisualStudio.Extension.Core.props", ExtensionProject)]
+        [InlineData("Snyk.VisualStudio.Extension.Core.Tests.props", WindowsTestProject)]
+        public void CoreSourceList_OnlyReferencesFilesThatExist(string propsFileName, string sourceProject)
+        {
+            var sourceDir = Path.Combine(RepositoryRoot(), sourceProject);
+
+            var absent = IncludedPaths(Path.Combine(RepositoryRoot(), CoreTestProject, propsFileName))
+                .Select(relativePath => Regex.Replace(relativePath, @"^\$\([A-Za-z]+\)", string.Empty))
+                .Where(relativePath => !File.Exists(Path.Combine(sourceDir, relativePath.Replace('/', Path.DirectorySeparatorChar))))
+                .OrderBy(relativePath => relativePath, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            Assert.True(
+                absent.Count == 0,
+                $"{propsFileName} lists files that no longer exist under {sourceProject}: {string.Join(", ", absent)}");
+        }
+
+        [Fact]
+        public void CoreSourceList_DoesNotIncludeVisualStudioOnlyParts()
+        {
+            // *.Vs.cs is the convention for the Visual Studio bound half of a partial type. Linking
+            // one into the cross-platform build would drag the VS SDK in with it.
+            var offenders = IncludedPaths(Path.Combine(RepositoryRoot(), CoreTestProject, "Snyk.VisualStudio.Extension.Core.props"))
+                .Where(relativePath => relativePath.EndsWith(".Vs.cs", StringComparison.Ordinal)
+                                       || relativePath.EndsWith(".xaml.cs", StringComparison.Ordinal))
+                .OrderBy(relativePath => relativePath, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            Assert.True(
+                offenders.Count == 0,
+                $"Visual Studio only sources must stay out of the cross-platform build: {string.Join(", ", offenders)}");
+        }
+
+        private static ISet<string> IncludedPaths(string projectFilePath)
+        {
+            var contents = File.ReadAllText(projectFilePath);
+
+            return new HashSet<string>(
+                IncludeAttribute.Matches(contents)
+                    .Cast<Match>()
+                    .Select(match => match.Groups["path"].Value.Replace('\\', '/')),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static IEnumerable<string> SourceFilesUnder(string projectDir)
+        {
+            return Directory
+                .EnumerateFiles(projectDir, "*.*", SearchOption.AllDirectories)
+                .Where(path => path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+                               || path.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase))
+                .Where(path => !IsBuildOutput(path, projectDir))
+                .Select(path => GetRelativePath(projectDir, path));
+        }
+
+        private static bool IsBuildOutput(string path, string projectDir)
+        {
+            var relative = GetRelativePath(projectDir, path);
+            return relative.StartsWith("bin/", StringComparison.OrdinalIgnoreCase)
+                   || relative.StartsWith("obj/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetRelativePath(string basePath, string fullPath) =>
+            fullPath.Substring(basePath.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                .Replace('\\', '/');
+
+        /// <summary>
+        /// Walks up from the test assembly to the directory holding the solution file, so the
+        /// checks work from any working directory and on any platform.
+        /// </summary>
+        private static string RepositoryRoot()
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "snyk-visual-studio-plugin.sln")))
+            {
+                directory = directory.Parent;
+            }
+
+            Assert.NotNull(directory);
+            return directory.FullName;
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.Tests.csproj
+++ b/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.Tests.csproj
@@ -1,0 +1,87 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Cross-platform unit tests for the Snyk Visual Studio extension.
+
+    This project runs on Linux, macOS and Windows with nothing but the .NET SDK:
+
+        dotnet test Snyk.VisualStudio.Extension.Core.Tests
+
+    It contains no sources of its own beyond a handful of host shims. Instead it compiles
+    the platform-neutral subset of the extension and of the net48 test project, both listed
+    in the .props files imported below. See docs/cross-platform-testing.md.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>Snyk.VisualStudio.Extension.Core.Tests</AssemblyName>
+    <!-- Matches the net48 test project so `dotnet test` and vstest resolve the same
+         embedded-resource logical names as the Windows run. -->
+    <RootNamespace>Snyk.VisualStudio.Extension.Tests</RootNamespace>
+    <EnableDefaultItems>true</EnableDefaultItems>
+    <!--
+      The shared sources are authored for net48 and their warnings are owned by the net48 build,
+      so this project stays quiet about differences the .NET 8 SDK reports on the same code:
+        SYSLIB0012/0014/0021 - Assembly.CodeBase, WebClient and SHA256Managed are the correct
+                               net48 APIs; changing them belongs in the extension, not here.
+        VSTHRD002/VSTHRD110  - vs-threading analyzer findings that pre-date this project.
+        xUnit1031            - blocking waits in existing concurrency tests.
+    -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);CS1591;SYSLIB0012;SYSLIB0014;SYSLIB0021;NU1701;VSTHRD002;VSTHRD110;xUnit1031</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SnykExtensionSourceRoot>$(MSBuildThisFileDirectory)..\Snyk.VisualStudio.Extension.2022\</SnykExtensionSourceRoot>
+    <SnykExtensionTestSourceRoot>$(MSBuildThisFileDirectory)..\Snyk.VisualStudio.Extension.Tests\</SnykExtensionTestSourceRoot>
+  </PropertyGroup>
+
+  <Import Project="Snyk.VisualStudio.Extension.Core.props" />
+  <Import Project="Snyk.VisualStudio.Extension.Core.Tests.props" />
+
+  <ItemGroup>
+    <!-- Test harness -->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      Runtime dependencies of the Core source subset. Every one of these is
+      cross-platform; nothing here requires Visual Studio to be installed.
+      Versions are kept in step with Snyk.VisualStudio.Extension.2022.csproj.
+    -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.6.40" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.8" />
+    <PackageReference Include="StreamJsonRpc" Version="2.14.24" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Test fixtures shared with the net48 test project. -->
+    <EmbeddedResource Include="$(SnykExtensionTestSourceRoot)Resources\*.json"
+                      Link="Tests\Resources\%(Filename)%(Extension)"
+                      LogicalName="Snyk.VisualStudio.Extension.Tests.Resources.%(Filename)%(Extension)">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
+
+</Project>

--- a/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.Tests.csproj
+++ b/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.Tests.csproj
@@ -27,10 +27,10 @@
         SYSLIB0012/0014/0021 - Assembly.CodeBase, WebClient and SHA256Managed are the correct
                                net48 APIs; changing them belongs in the extension, not here.
         VSTHRD002/VSTHRD110  - vs-threading analyzer findings that pre-date this project.
-        xUnit1031            - blocking waits in existing concurrency tests.
+        xUnit1031/xUnit2004  - blocking waits and Assert.Equal-on-bool in existing tests.
     -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS1591;SYSLIB0012;SYSLIB0014;SYSLIB0021;NU1701;VSTHRD002;VSTHRD110;xUnit1031</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;SYSLIB0012;SYSLIB0014;SYSLIB0021;NU1701;VSTHRD002;VSTHRD110;xUnit1031;xUnit2004</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -67,12 +67,12 @@
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <!-- Despite the names, both of these ship as plain netstandard2.0 libraries and need
+         no Visual Studio: AsyncEventHandler on ILanguageClientManager, and StreamJsonRpc's
+         RemoteInvocationException in the settings persistence code. -->
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.6.40" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.8" />
     <PackageReference Include="StreamJsonRpc" Version="2.14.24" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.Tests.props
+++ b/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.Tests.props
@@ -41,6 +41,7 @@
     <Compile Include="$(SnykExtensionTestSourceRoot)Settings\SnykOptionsManagerSecretsTests.cs" Link="Tests\Settings\SnykOptionsManagerSecretsTests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)Settings\UserOverridePersistenceTests.cs" Link="Tests\Settings\UserOverridePersistenceTests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)SnykCliDownloaderTest.cs" Link="Tests\SnykCliDownloaderTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)SnykOptionsTest.cs" Link="Tests\SnykOptionsTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)SnykUserStorageSettingsServiceTest.cs" Link="Tests\SnykUserStorageSettingsServiceTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)TestUtils.cs" Link="Tests\TestUtils.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\BaseHtmlProviderTest.cs" Link="Tests\UI\Html\BaseHtmlProviderTest.cs" />
@@ -50,6 +51,7 @@
     <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\TreeHtmlProviderTest.cs" Link="Tests\UI\Html\TreeHtmlProviderTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\WebView2BridgeBindingsTest.cs" Link="Tests\UI\Html\WebView2BridgeBindingsTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\WebView2EnvironmentCacheTests.cs" Link="Tests\UI\Html\WebView2EnvironmentCacheTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\WebView2HostTest.cs" Link="Tests\UI\Html\WebView2HostTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\WebView2MessageDispatcherTest.cs" Link="Tests\UI\Html\WebView2MessageDispatcherTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\WebView2NavigationPreparerTest.cs" Link="Tests\UI\Html\WebView2NavigationPreparerTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)Utils\SnykDirectoryTests.cs" Link="Tests\Utils\SnykDirectoryTests.cs" />

--- a/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.Tests.props
+++ b/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.Tests.props
@@ -43,8 +43,11 @@
     <Compile Include="$(SnykExtensionTestSourceRoot)SnykCliDownloaderTest.cs" Link="Tests\SnykCliDownloaderTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)SnykUserStorageSettingsServiceTest.cs" Link="Tests\SnykUserStorageSettingsServiceTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)TestUtils.cs" Link="Tests\TestUtils.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\BaseHtmlProviderTest.cs" Link="Tests\UI\Html\BaseHtmlProviderTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\ExecuteCommandBridgeTest.cs" Link="Tests\UI\Html\ExecuteCommandBridgeTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\HtmlProviderFactoryTest.cs" Link="Tests\UI\Html\HtmlProviderFactoryTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\IdeConfigContractTests.cs" Link="Tests\UI\Html\IdeConfigContractTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\TreeHtmlProviderTest.cs" Link="Tests\UI\Html\TreeHtmlProviderTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\WebView2BridgeBindingsTest.cs" Link="Tests\UI\Html\WebView2BridgeBindingsTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\WebView2EnvironmentCacheTests.cs" Link="Tests\UI\Html\WebView2EnvironmentCacheTests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\WebView2MessageDispatcherTest.cs" Link="Tests\UI\Html\WebView2MessageDispatcherTest.cs" />

--- a/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.Tests.props
+++ b/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.Tests.props
@@ -1,0 +1,52 @@
+<Project>
+
+  <!--
+    Snyk.VisualStudio.Extension.Core.Tests.props
+    ===========================================
+    The platform-neutral subset of Snyk.VisualStudio.Extension.Tests. These test files
+    are compiled twice: once by the Windows-only net48 test project (against the VSIX
+    assembly) and once by Snyk.VisualStudio.Extension.Core.Tests (against the Core
+    source subset) so they also run on Linux and macOS.
+
+    Tests are shared rather than moved deliberately: coverage on Windows is unchanged
+    and there is exactly one copy of every test.
+
+    Import it and set $(SnykExtensionTestSourceRoot) to the net48 test project directory.
+
+    See docs/cross-platform-testing.md.
+  -->
+
+  <ItemGroup>
+    <Compile Include="$(SnykExtensionTestSourceRoot)AuthDialogStateTests.cs" Link="Tests\AuthDialogStateTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Extension\UriExtensionsTest.cs" Link="Tests\Extension\UriExtensionsTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Language\ConfigDefaultsTests.cs" Link="Tests\Language\ConfigDefaultsTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Language\FolderConfigApplierTests.cs" Link="Tests\Language\FolderConfigApplierTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Language\GlobalSettingsApplierTests.cs" Link="Tests\Language\GlobalSettingsApplierTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Language\LsConstantsTest.cs" Link="Tests\Language\LsConstantsTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Language\UserOverrideTrackerTests.cs" Link="Tests\Language\UserOverrideTrackerTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)LogManagerGracefulDegradationTests.cs" Link="Tests\LogManagerGracefulDegradationTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Service\FeatureFlagServiceTest.cs" Link="Tests\Service\FeatureFlagServiceTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Service\WorkspaceTrustServiceTest.cs" Link="Tests\Service\WorkspaceTrustServiceTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Settings\LegacySolutionSettingsMigratorTests.cs" Link="Tests\Settings\LegacySolutionSettingsMigratorTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Settings\LoadReadUnderPersistGateTests.cs" Link="Tests\Settings\LoadReadUnderPersistGateTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Settings\PendingAuthTokenSlotTests.cs" Link="Tests\Settings\PendingAuthTokenSlotTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Settings\SettingsLocationMigratorTests.cs" Link="Tests\Settings\SettingsLocationMigratorTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Settings\SettingsPersistenceConcurrencyTests.cs" Link="Tests\Settings\SettingsPersistenceConcurrencyTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Settings\SnykOptionsManagerAutoOrgTests.cs" Link="Tests\Settings\SnykOptionsManagerAutoOrgTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Settings\SnykOptionsManagerCorruptFileTests.cs" Link="Tests\Settings\SnykOptionsManagerCorruptFileTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Settings\SnykOptionsManagerLegacyMigrationTests.cs" Link="Tests\Settings\SnykOptionsManagerLegacyMigrationTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Settings\SnykOptionsManagerSecretsTests.cs" Link="Tests\Settings\SnykOptionsManagerSecretsTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Settings\UserOverridePersistenceTests.cs" Link="Tests\Settings\UserOverridePersistenceTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)SnykCliDownloaderTest.cs" Link="Tests\SnykCliDownloaderTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)SnykUserStorageSettingsServiceTest.cs" Link="Tests\SnykUserStorageSettingsServiceTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)TestUtils.cs" Link="Tests\TestUtils.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\ExecuteCommandBridgeTest.cs" Link="Tests\UI\Html\ExecuteCommandBridgeTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\IdeConfigContractTests.cs" Link="Tests\UI\Html\IdeConfigContractTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\WebView2BridgeBindingsTest.cs" Link="Tests\UI\Html\WebView2BridgeBindingsTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\WebView2EnvironmentCacheTests.cs" Link="Tests\UI\Html\WebView2EnvironmentCacheTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\WebView2MessageDispatcherTest.cs" Link="Tests\UI\Html\WebView2MessageDispatcherTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)UI\Html\WebView2NavigationPreparerTest.cs" Link="Tests\UI\Html\WebView2NavigationPreparerTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Utils\SnykDirectoryTests.cs" Link="Tests\Utils\SnykDirectoryTests.cs" />
+  </ItemGroup>
+
+</Project>

--- a/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.Tests.props
+++ b/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.Tests.props
@@ -22,7 +22,9 @@
     <Compile Include="$(SnykExtensionTestSourceRoot)Language\ConfigDefaultsTests.cs" Link="Tests\Language\ConfigDefaultsTests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)Language\FolderConfigApplierTests.cs" Link="Tests\Language\FolderConfigApplierTests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)Language\GlobalSettingsApplierTests.cs" Link="Tests\Language\GlobalSettingsApplierTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Language\LsAnalysisResultTest.cs" Link="Tests\Language\LsAnalysisResultTest.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)Language\LsConstantsTest.cs" Link="Tests\Language\LsConstantsTest.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Language\LsSettingsV25Tests.cs" Link="Tests\Language\LsSettingsV25Tests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)Language\UserOverrideTrackerTests.cs" Link="Tests\Language\UserOverrideTrackerTests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)LogManagerGracefulDegradationTests.cs" Link="Tests\LogManagerGracefulDegradationTests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)Service\FeatureFlagServiceTest.cs" Link="Tests\Service\FeatureFlagServiceTest.cs" />
@@ -31,6 +33,7 @@
     <Compile Include="$(SnykExtensionTestSourceRoot)Settings\LoadReadUnderPersistGateTests.cs" Link="Tests\Settings\LoadReadUnderPersistGateTests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)Settings\PendingAuthTokenSlotTests.cs" Link="Tests\Settings\PendingAuthTokenSlotTests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)Settings\SettingsLocationMigratorTests.cs" Link="Tests\Settings\SettingsLocationMigratorTests.cs" />
+    <Compile Include="$(SnykExtensionTestSourceRoot)Settings\SettingsPersistenceAcceptanceTests.cs" Link="Tests\Settings\SettingsPersistenceAcceptanceTests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)Settings\SettingsPersistenceConcurrencyTests.cs" Link="Tests\Settings\SettingsPersistenceConcurrencyTests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)Settings\SnykOptionsManagerAutoOrgTests.cs" Link="Tests\Settings\SnykOptionsManagerAutoOrgTests.cs" />
     <Compile Include="$(SnykExtensionTestSourceRoot)Settings\SnykOptionsManagerCorruptFileTests.cs" Link="Tests\Settings\SnykOptionsManagerCorruptFileTests.cs" />

--- a/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.props
+++ b/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.props
@@ -1,0 +1,115 @@
+<Project>
+
+  <!--
+    Snyk.VisualStudio.Extension.Core.props
+    =====================================
+    The platform-neutral ("Core") subset of the Visual Studio extension's production
+    source. Every file listed here compiles without Visual Studio, WPF or WebView2 and
+    is therefore reusable outside the net48 VSIX - most importantly by the
+    Snyk.VisualStudio.Extension.Core.Tests project, which runs on Linux and macOS.
+
+    This file is the single source of truth for that subset. It is intentionally an
+    explicit list rather than a glob: adding a file here is a deliberate statement that
+    the file is platform-neutral, and the cross-platform build fails loudly if it is not.
+
+    Import it and set $(SnykExtensionSourceRoot) to the extension project directory.
+
+    See docs/cross-platform-testing.md.
+  -->
+
+  <ItemGroup>
+    <Compile Include="$(SnykExtensionSourceRoot)Analytics\AbstractAnalyticsEvent.cs" Link="Core\Analytics\AbstractAnalyticsEvent.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Analytics\AnalyticsEvent.cs" Link="Core\Analytics\AnalyticsEvent.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)AuthDialogState.cs" Link="Core\AuthDialogState.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Authentication\AuthenticationToken.cs" Link="Core\Authentication\AuthenticationToken.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Authentication\AuthenticationType.cs" Link="Core\Authentication\AuthenticationType.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Authentication\IAuthDialog.cs" Link="Core\Authentication\IAuthDialog.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Authentication\IAuthenticationFlowService.cs" Link="Core\Authentication\IAuthenticationFlowService.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Authentication\OAuthToken.cs" Link="Core\Authentication\OAuthToken.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)CLI\ICli.cs" Link="Core\CLI\ICli.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)CLI\InvalidTokenException.cs" Link="Core\CLI\InvalidTokenException.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)CLI\OssError.cs" Link="Core\CLI\OssError.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)CLI\SnykCli.cs" Link="Core\CLI\SnykCli.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Download\ChecksumVerificationException.cs" Link="Core\Download\ChecksumVerificationException.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Download\LatestReleaseInfo.cs" Link="Core\Download\LatestReleaseInfo.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Download\Sha256.cs" Link="Core\Download\Sha256.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Download\SnykCliDownloader.cs" Link="Core\Download\SnykCliDownloader.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Extension\CollectionExtensions.cs" Link="Core\Extension\CollectionExtensions.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Extension\JTokenExtension.cs" Link="Core\Extension\JTokenExtension.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Extension\StringExtensions.cs" Link="Core\Extension\StringExtensions.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Extension\UriExtensions.cs" Link="Core\Extension\UriExtensions.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\CustomInitializationOptions.cs" Link="Core\Language\CustomInitializationOptions.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\FeatureFlagResponse.cs" Link="Core\Language\FeatureFlagResponse.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\IJsonRpc.cs" Link="Core\Language\IJsonRpc.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\ILanguageClientManager.cs" Link="Core\Language\ILanguageClientManager.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\InvalidProductTypeException.cs" Link="Core\Language\InvalidProductTypeException.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\JsonRpcWrapper.cs" Link="Core\Language\JsonRpcWrapper.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\LsAnalysisResult.cs" Link="Core\Language\LsAnalysisResult.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\LsConstants.cs" Link="Core\Language\LsConstants.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\SnykLanguageServerEventArgs.cs" Link="Core\Language\SnykLanguageServerEventArgs.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\ConfigDefaults.cs" Link="Core\Language\V25\ConfigDefaults.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\ConfigSetting.cs" Link="Core\Language\V25\ConfigSetting.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\FolderConfigApplier.cs" Link="Core\Language\V25\FolderConfigApplier.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\GlobalSettingsApplier.cs" Link="Core\Language\V25\GlobalSettingsApplier.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\InitializationOptionsV25.cs" Link="Core\Language\V25\InitializationOptionsV25.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\IUserOverrideTracker.cs" Link="Core\Language\V25\IUserOverrideTracker.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\LspConfigurationParam.cs" Link="Core\Language\V25\LspConfigurationParam.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\LspFolderConfig.cs" Link="Core\Language\V25\LspFolderConfig.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\LsSettingsV25.cs" Link="Core\Language\V25\LsSettingsV25.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\PflagKeys.cs" Link="Core\Language\V25\PflagKeys.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\UserOverrideTracker.cs" Link="Core\Language\V25\UserOverrideTracker.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)LocalCodeEngine.cs" Link="Core\LocalCodeEngine.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)LogManager.cs" Link="Core\LogManager.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)ManualAssemblyResolver.cs" Link="Core\ManualAssemblyResolver.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Model\Severity.cs" Link="Core\Model\Severity.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Product.cs" Link="Core\Product.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Resources\SnykLsInit.cs" Link="Core\Resources\SnykLsInit.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)SastSettings.cs" Link="Core\SastSettings.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\ApiEndpointResolver.cs" Link="Core\Service\ApiEndpointResolver.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\Domain\FeaturesSettings.cs" Link="Core\Service\Domain\FeaturesSettings.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\IFeatureFlagService.cs" Link="Core\Service\IFeatureFlagService.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\ISnykProgressWorker.cs" Link="Core\Service\ISnykProgressWorker.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\ISnykService.cs" Link="Core\Service\ISnykService.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\ISnykServiceProvider.cs" Link="Core\Service\ISnykServiceProvider.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\ISnykTasksService.cs" Link="Core\Service\ISnykTasksService.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\ISolutionService.cs" Link="Core\Service\ISolutionService.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\IWorkspaceTrustService.cs" Link="Core\Service\IWorkspaceTrustService.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\OssScanException.cs" Link="Core\Service\OssScanException.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\SnykCliDownloadEventArgs.cs" Link="Core\Service\SnykCliDownloadEventArgs.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\SnykCodeScanEventArgs.cs" Link="Core\Service\SnykCodeScanEventArgs.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\SnykFeatureFlagService.cs" Link="Core\Service\SnykFeatureFlagService.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\SnykOssScanEventArgs.cs" Link="Core\Service\SnykOssScanEventArgs.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\SolutionType.cs" Link="Core\Service\SolutionType.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\WorkspaceTrustService.cs" Link="Core\Service\WorkspaceTrustService.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\IPersistableOption.cs" Link="Core\Settings\IPersistableOption.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\ISnykOptions.cs" Link="Core\Settings\ISnykOptions.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\ISnykOptionsManager.cs" Link="Core\Settings\ISnykOptionsManager.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\LegacySolutionSettings.cs" Link="Core\Settings\LegacySolutionSettings.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\LegacySolutionSettingsMigrator.cs" Link="Core\Settings\LegacySolutionSettingsMigrator.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\PendingAuthTokenSlot.cs" Link="Core\Settings\PendingAuthTokenSlot.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\SettingsLocationMigrator.cs" Link="Core\Settings\SettingsLocationMigrator.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykOptions.cs" Link="Core\Settings\SnykOptions.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykOptionsManager.cs" Link="Core\Settings\SnykOptionsManager.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykSettingsChangedEventArgs.cs" Link="Core\Settings\SnykSettingsChangedEventArgs.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykSettings.cs" Link="Core\Settings\SnykSettings.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykSettingsLoader.cs" Link="Core\Settings\SnykSettingsLoader.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)SnykIcons.Designer.cs" Link="Core\SnykIcons.Designer.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)SnykWebClient.cs" Link="Core\SnykWebClient.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\ExecuteCommandBridge.cs" Link="Core\UI\Html\ExecuteCommandBridge.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IdeConfigContract.cs" Link="Core\UI\Html\IdeConfigContract.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IdeConfigData.cs" Link="Core\UI\Html\IdeConfigData.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IHtmlProvider.cs" Link="Core\UI\Html\IHtmlProvider.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IWebView2Host.cs" Link="Core\UI\Html\IWebView2Host.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2BridgeBindings.cs" Link="Core\UI\Html\WebView2BridgeBindings.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2EnvironmentCache.cs" Link="Core\UI\Html\WebView2EnvironmentCache.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2MessageDispatcher.cs" Link="Core\UI\Html\WebView2MessageDispatcher.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2NavigationPreparer.cs" Link="Core\UI\Html\WebView2NavigationPreparer.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Toolwindow\IHtmlPanel.cs" Link="Core\UI\Toolwindow\IHtmlPanel.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Toolwindow\ISnykToolWindow.cs" Link="Core\UI\Toolwindow\ISnykToolWindow.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Toolwindow\ITreeHtmlPanel.cs" Link="Core\UI\Toolwindow\ITreeHtmlPanel.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Utils\Json.cs" Link="Core\Utils\Json.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Utils\SnykDirectory.cs" Link="Core\Utils\SnykDirectory.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Utils\SnykExtension.cs" Link="Core\Utils\SnykExtension.cs" />
+  </ItemGroup>
+
+</Project>

--- a/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.props
+++ b/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.props
@@ -44,11 +44,22 @@
     <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykSettings.cs" Link="Core\Settings\SnykSettings.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykSettingsChangedEventArgs.cs" Link="Core\Settings\SnykSettingsChangedEventArgs.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykSettingsLoader.cs" Link="Core\Settings\SnykSettingsLoader.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\BaseHtmlProvider.cs" Link="Core\UI\Html\BaseHtmlProvider.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\CodeHtmlProvider.cs" Link="Core\UI\Html\CodeHtmlProvider.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\ExecuteCommandBridge.cs" Link="Core\UI\Html\ExecuteCommandBridge.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\HtmlProviderFactory.cs" Link="Core\UI\Html\HtmlProviderFactory.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\HtmlResourceLoader.cs" Link="Core\UI\Html\HtmlResourceLoader.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\HtmlThemePalette.cs" Link="Core\UI\Html\HtmlThemePalette.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IHtmlProvider.cs" Link="Core\UI\Html\IHtmlProvider.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IWebView2Host.cs" Link="Core\UI\Html\IWebView2Host.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IacHtmlProvider.cs" Link="Core\UI\Html\IacHtmlProvider.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IdeConfigContract.cs" Link="Core\UI\Html\IdeConfigContract.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IdeConfigData.cs" Link="Core\UI\Html\IdeConfigData.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\OssHtmlProvider.cs" Link="Core\UI\Html\OssHtmlProvider.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\SecretsHtmlProvider.cs" Link="Core\UI\Html\SecretsHtmlProvider.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\StaticHtmlProvider.cs" Link="Core\UI\Html\StaticHtmlProvider.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\SummaryHtmlProvider.cs" Link="Core\UI\Html\SummaryHtmlProvider.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\TreeHtmlProvider.cs" Link="Core\UI\Html\TreeHtmlProvider.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2BridgeBindings.cs" Link="Core\UI\Html\WebView2BridgeBindings.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2EnvironmentCache.cs" Link="Core\UI\Html\WebView2EnvironmentCache.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2MessageDispatcher.cs" Link="Core\UI\Html\WebView2MessageDispatcher.cs" />

--- a/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.props
+++ b/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.props
@@ -18,18 +18,48 @@
   -->
 
   <ItemGroup>
+    <Compile Include="$(SnykExtensionSourceRoot)AuthDialogState.cs" Link="Core\AuthDialogState.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)LocalCodeEngine.cs" Link="Core\LocalCodeEngine.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)LogManager.cs" Link="Core\LogManager.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)ManualAssemblyResolver.cs" Link="Core\ManualAssemblyResolver.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Product.cs" Link="Core\Product.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)SastSettings.cs" Link="Core\SastSettings.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)SnykIcons.Designer.cs" Link="Core\SnykIcons.Designer.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)SnykWebClient.cs" Link="Core\SnykWebClient.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Analytics\AbstractAnalyticsEvent.cs" Link="Core\Analytics\AbstractAnalyticsEvent.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Analytics\AnalyticsEvent.cs" Link="Core\Analytics\AnalyticsEvent.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)AuthDialogState.cs" Link="Core\AuthDialogState.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Authentication\AuthenticationToken.cs" Link="Core\Authentication\AuthenticationToken.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Authentication\AuthenticationType.cs" Link="Core\Authentication\AuthenticationType.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Authentication\IAuthDialog.cs" Link="Core\Authentication\IAuthDialog.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Authentication\IAuthenticationFlowService.cs" Link="Core\Authentication\IAuthenticationFlowService.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Authentication\OAuthToken.cs" Link="Core\Authentication\OAuthToken.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)CLI\ICli.cs" Link="Core\CLI\ICli.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)CLI\InvalidTokenException.cs" Link="Core\CLI\InvalidTokenException.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)CLI\OssError.cs" Link="Core\CLI\OssError.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)CLI\SnykCli.cs" Link="Core\CLI\SnykCli.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\IPersistableOption.cs" Link="Core\Settings\IPersistableOption.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\ISnykOptions.cs" Link="Core\Settings\ISnykOptions.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\ISnykOptionsManager.cs" Link="Core\Settings\ISnykOptionsManager.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\LegacySolutionSettings.cs" Link="Core\Settings\LegacySolutionSettings.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\LegacySolutionSettingsMigrator.cs" Link="Core\Settings\LegacySolutionSettingsMigrator.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\PendingAuthTokenSlot.cs" Link="Core\Settings\PendingAuthTokenSlot.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\SettingsLocationMigrator.cs" Link="Core\Settings\SettingsLocationMigrator.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykOptions.cs" Link="Core\Settings\SnykOptions.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykOptionsManager.cs" Link="Core\Settings\SnykOptionsManager.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykSettings.cs" Link="Core\Settings\SnykSettings.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykSettingsChangedEventArgs.cs" Link="Core\Settings\SnykSettingsChangedEventArgs.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykSettingsLoader.cs" Link="Core\Settings\SnykSettingsLoader.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\ExecuteCommandBridge.cs" Link="Core\UI\Html\ExecuteCommandBridge.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IHtmlProvider.cs" Link="Core\UI\Html\IHtmlProvider.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IWebView2Host.cs" Link="Core\UI\Html\IWebView2Host.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IdeConfigContract.cs" Link="Core\UI\Html\IdeConfigContract.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IdeConfigData.cs" Link="Core\UI\Html\IdeConfigData.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2BridgeBindings.cs" Link="Core\UI\Html\WebView2BridgeBindings.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2EnvironmentCache.cs" Link="Core\UI\Html\WebView2EnvironmentCache.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2MessageDispatcher.cs" Link="Core\UI\Html\WebView2MessageDispatcher.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2NavigationPreparer.cs" Link="Core\UI\Html\WebView2NavigationPreparer.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Toolwindow\IHtmlPanel.cs" Link="Core\UI\Toolwindow\IHtmlPanel.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Toolwindow\ISnykToolWindow.cs" Link="Core\UI\Toolwindow\ISnykToolWindow.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Toolwindow\ITreeHtmlPanel.cs" Link="Core\UI\Toolwindow\ITreeHtmlPanel.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Utils\Json.cs" Link="Core\Utils\Json.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Utils\SnykDirectory.cs" Link="Core\Utils\SnykDirectory.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Utils\SnykExtension.cs" Link="Core\Utils\SnykExtension.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Resources\SnykLsInit.cs" Link="Core\Resources\SnykLsInit.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Download\ChecksumVerificationException.cs" Link="Core\Download\ChecksumVerificationException.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Download\LatestReleaseInfo.cs" Link="Core\Download\LatestReleaseInfo.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Download\Sha256.cs" Link="Core\Download\Sha256.cs" />
@@ -38,35 +68,8 @@
     <Compile Include="$(SnykExtensionSourceRoot)Extension\JTokenExtension.cs" Link="Core\Extension\JTokenExtension.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Extension\StringExtensions.cs" Link="Core\Extension\StringExtensions.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Extension\UriExtensions.cs" Link="Core\Extension\UriExtensions.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\CustomInitializationOptions.cs" Link="Core\Language\CustomInitializationOptions.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\FeatureFlagResponse.cs" Link="Core\Language\FeatureFlagResponse.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\IJsonRpc.cs" Link="Core\Language\IJsonRpc.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\ILanguageClientManager.cs" Link="Core\Language\ILanguageClientManager.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\InvalidProductTypeException.cs" Link="Core\Language\InvalidProductTypeException.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\JsonRpcWrapper.cs" Link="Core\Language\JsonRpcWrapper.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\LsAnalysisResult.cs" Link="Core\Language\LsAnalysisResult.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\LsConstants.cs" Link="Core\Language\LsConstants.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\SnykLanguageServerEventArgs.cs" Link="Core\Language\SnykLanguageServerEventArgs.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\ConfigDefaults.cs" Link="Core\Language\V25\ConfigDefaults.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\ConfigSetting.cs" Link="Core\Language\V25\ConfigSetting.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\FolderConfigApplier.cs" Link="Core\Language\V25\FolderConfigApplier.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\GlobalSettingsApplier.cs" Link="Core\Language\V25\GlobalSettingsApplier.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\InitializationOptionsV25.cs" Link="Core\Language\V25\InitializationOptionsV25.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\IUserOverrideTracker.cs" Link="Core\Language\V25\IUserOverrideTracker.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\LspConfigurationParam.cs" Link="Core\Language\V25\LspConfigurationParam.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\LspFolderConfig.cs" Link="Core\Language\V25\LspFolderConfig.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\LsSettingsV25.cs" Link="Core\Language\V25\LsSettingsV25.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\PflagKeys.cs" Link="Core\Language\V25\PflagKeys.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\UserOverrideTracker.cs" Link="Core\Language\V25\UserOverrideTracker.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)LocalCodeEngine.cs" Link="Core\LocalCodeEngine.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)LogManager.cs" Link="Core\LogManager.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)ManualAssemblyResolver.cs" Link="Core\ManualAssemblyResolver.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Model\Severity.cs" Link="Core\Model\Severity.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Product.cs" Link="Core\Product.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Resources\SnykLsInit.cs" Link="Core\Resources\SnykLsInit.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)SastSettings.cs" Link="Core\SastSettings.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Service\ApiEndpointResolver.cs" Link="Core\Service\ApiEndpointResolver.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Service\Domain\FeaturesSettings.cs" Link="Core\Service\Domain\FeaturesSettings.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Service\IFeatureFlagService.cs" Link="Core\Service\IFeatureFlagService.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Service\ISnykProgressWorker.cs" Link="Core\Service\ISnykProgressWorker.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Service\ISnykService.cs" Link="Core\Service\ISnykService.cs" />
@@ -81,35 +84,32 @@
     <Compile Include="$(SnykExtensionSourceRoot)Service\SnykOssScanEventArgs.cs" Link="Core\Service\SnykOssScanEventArgs.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Service\SolutionType.cs" Link="Core\Service\SolutionType.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)Service\WorkspaceTrustService.cs" Link="Core\Service\WorkspaceTrustService.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Settings\IPersistableOption.cs" Link="Core\Settings\IPersistableOption.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Settings\ISnykOptions.cs" Link="Core\Settings\ISnykOptions.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Settings\ISnykOptionsManager.cs" Link="Core\Settings\ISnykOptionsManager.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Settings\LegacySolutionSettings.cs" Link="Core\Settings\LegacySolutionSettings.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Settings\LegacySolutionSettingsMigrator.cs" Link="Core\Settings\LegacySolutionSettingsMigrator.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Settings\PendingAuthTokenSlot.cs" Link="Core\Settings\PendingAuthTokenSlot.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Settings\SettingsLocationMigrator.cs" Link="Core\Settings\SettingsLocationMigrator.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykOptions.cs" Link="Core\Settings\SnykOptions.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykOptionsManager.cs" Link="Core\Settings\SnykOptionsManager.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykSettingsChangedEventArgs.cs" Link="Core\Settings\SnykSettingsChangedEventArgs.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykSettings.cs" Link="Core\Settings\SnykSettings.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Settings\SnykSettingsLoader.cs" Link="Core\Settings\SnykSettingsLoader.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)SnykIcons.Designer.cs" Link="Core\SnykIcons.Designer.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)SnykWebClient.cs" Link="Core\SnykWebClient.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\ExecuteCommandBridge.cs" Link="Core\UI\Html\ExecuteCommandBridge.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IdeConfigContract.cs" Link="Core\UI\Html\IdeConfigContract.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IdeConfigData.cs" Link="Core\UI\Html\IdeConfigData.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IHtmlProvider.cs" Link="Core\UI\Html\IHtmlProvider.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\IWebView2Host.cs" Link="Core\UI\Html\IWebView2Host.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2BridgeBindings.cs" Link="Core\UI\Html\WebView2BridgeBindings.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2EnvironmentCache.cs" Link="Core\UI\Html\WebView2EnvironmentCache.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2MessageDispatcher.cs" Link="Core\UI\Html\WebView2MessageDispatcher.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2NavigationPreparer.cs" Link="Core\UI\Html\WebView2NavigationPreparer.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)UI\Toolwindow\IHtmlPanel.cs" Link="Core\UI\Toolwindow\IHtmlPanel.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)UI\Toolwindow\ISnykToolWindow.cs" Link="Core\UI\Toolwindow\ISnykToolWindow.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)UI\Toolwindow\ITreeHtmlPanel.cs" Link="Core\UI\Toolwindow\ITreeHtmlPanel.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Utils\Json.cs" Link="Core\Utils\Json.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Utils\SnykDirectory.cs" Link="Core\Utils\SnykDirectory.cs" />
-    <Compile Include="$(SnykExtensionSourceRoot)Utils\SnykExtension.cs" Link="Core\Utils\SnykExtension.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Service\Domain\FeaturesSettings.cs" Link="Core\Service\Domain\FeaturesSettings.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Authentication\AuthenticationToken.cs" Link="Core\Authentication\AuthenticationToken.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Authentication\AuthenticationType.cs" Link="Core\Authentication\AuthenticationType.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Authentication\IAuthDialog.cs" Link="Core\Authentication\IAuthDialog.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Authentication\IAuthenticationFlowService.cs" Link="Core\Authentication\IAuthenticationFlowService.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Authentication\OAuthToken.cs" Link="Core\Authentication\OAuthToken.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\CustomInitializationOptions.cs" Link="Core\Language\CustomInitializationOptions.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\FeatureFlagResponse.cs" Link="Core\Language\FeatureFlagResponse.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\IJsonRpc.cs" Link="Core\Language\IJsonRpc.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\ILanguageClientManager.cs" Link="Core\Language\ILanguageClientManager.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\InvalidProductTypeException.cs" Link="Core\Language\InvalidProductTypeException.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\JsonRpcWrapper.cs" Link="Core\Language\JsonRpcWrapper.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\LsAnalysisResult.cs" Link="Core\Language\LsAnalysisResult.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\LsConstants.cs" Link="Core\Language\LsConstants.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\SnykLanguageServerEventArgs.cs" Link="Core\Language\SnykLanguageServerEventArgs.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\ConfigDefaults.cs" Link="Core\Language\V25\ConfigDefaults.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\ConfigSetting.cs" Link="Core\Language\V25\ConfigSetting.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\FolderConfigApplier.cs" Link="Core\Language\V25\FolderConfigApplier.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\GlobalSettingsApplier.cs" Link="Core\Language\V25\GlobalSettingsApplier.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\IUserOverrideTracker.cs" Link="Core\Language\V25\IUserOverrideTracker.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\InitializationOptionsV25.cs" Link="Core\Language\V25\InitializationOptionsV25.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\LsSettingsV25.cs" Link="Core\Language\V25\LsSettingsV25.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\LspConfigurationParam.cs" Link="Core\Language\V25\LspConfigurationParam.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\LspFolderConfig.cs" Link="Core\Language\V25\LspFolderConfig.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\PflagKeys.cs" Link="Core\Language\V25\PflagKeys.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)Language\V25\UserOverrideTracker.cs" Link="Core\Language\V25\UserOverrideTracker.cs" />
   </ItemGroup>
 
 </Project>

--- a/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.props
+++ b/Snyk.VisualStudio.Extension.Core.Tests/Snyk.VisualStudio.Extension.Core.props
@@ -62,6 +62,7 @@
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\TreeHtmlProvider.cs" Link="Core\UI\Html\TreeHtmlProvider.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2BridgeBindings.cs" Link="Core\UI\Html\WebView2BridgeBindings.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2EnvironmentCache.cs" Link="Core\UI\Html\WebView2EnvironmentCache.cs" />
+    <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2Host.Paths.cs" Link="Core\UI\Html\WebView2Host.Paths.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2MessageDispatcher.cs" Link="Core\UI\Html\WebView2MessageDispatcher.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Html\WebView2NavigationPreparer.cs" Link="Core\UI\Html\WebView2NavigationPreparer.cs" />
     <Compile Include="$(SnykExtensionSourceRoot)UI\Toolwindow\IHtmlPanel.cs" Link="Core\UI\Toolwindow\IHtmlPanel.cs" />

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsAnalysisResultTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsAnalysisResultTest.cs
@@ -2,6 +2,10 @@ using System;
 using Snyk.VisualStudio.Extension.Language;
 using Xunit;
 
+// System.Range exists on .NET Core but not on net48, so an unqualified `Range` is ambiguous
+// only in the cross-platform build. Alias it so the file compiles the same on both.
+using Range = Snyk.VisualStudio.Extension.Language.Range;
+
 namespace Snyk.VisualStudio.Extension.Tests.Language
 {
     public class LsAnalysisResultTest

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.Vs.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.Vs.cs
@@ -1,0 +1,16 @@
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests.Language
+{
+    /// <summary>
+    /// Keeps <see cref="LsSettingsV25Tests"/> in the MockedVS collection when running under the
+    /// Visual Studio SDK test framework, so it stays serialized alongside the other VS-dependent
+    /// tests exactly as before. The tests themselves use only local mocks, which is why the rest of
+    /// the class compiles in the cross-platform build (see docs/cross-platform-testing.md).
+    /// </summary>
+    [Collection(MockedVS.Collection)]
+    public partial class LsSettingsV25Tests
+    {
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/LsSettingsV25Tests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using Microsoft.VisualStudio.Sdk.TestFramework;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -14,16 +13,17 @@ using Xunit;
 
 namespace Snyk.VisualStudio.Extension.Tests.Language
 {
-    [Collection(MockedVS.Collection)]
-    public class LsSettingsV25Tests
+    // The [Collection(MockedVS.Collection)] attribute lives in LsSettingsV25Tests.Vs.cs: none of
+    // these tests touch Visual Studio services, so the fixture only needs to keep them in the same
+    // serialized collection on Windows.
+    public partial class LsSettingsV25Tests
     {
         private LsSettingsV25 cut;
         private readonly Mock<ISnykOptions> optionsMock;
         private readonly Mock<ISnykOptionsManager> optionsManagerMock;
 
-        public LsSettingsV25Tests(GlobalServiceProvider sp)
+        public LsSettingsV25Tests()
         {
-            sp.Reset();
             optionsMock = new Mock<ISnykOptions>();
             optionsManagerMock = new Mock<ISnykOptionsManager>();
             var serviceProviderMock = new Mock<ISnykServiceProvider>();

--- a/Snyk.VisualStudio.Extension.Tests/SnykOptionsTest.Vs.cs
+++ b/Snyk.VisualStudio.Extension.Tests/SnykOptionsTest.Vs.cs
@@ -1,0 +1,15 @@
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests
+{
+    /// <summary>
+    /// Keeps <see cref="SnykOptionsTest"/> in the MockedVS collection when running under the Visual
+    /// Studio SDK test framework, so it stays serialized alongside the other VS-dependent tests
+    /// exactly as before (see docs/cross-platform-testing.md).
+    /// </summary>
+    [Collection(MockedVS.Collection)]
+    public partial class SnykOptionsTest
+    {
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/SnykOptionsTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/SnykOptionsTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using Microsoft.VisualStudio.Sdk.TestFramework;
 using Moq;
 using Snyk.VisualStudio.Extension.Service;
 using Snyk.VisualStudio.Extension.Settings;
@@ -8,18 +7,20 @@ using Xunit;
 
 namespace Snyk.VisualStudio.Extension.Tests
 {
-    [Collection(MockedVS.Collection)]
-    public class SnykOptionsTest : IDisposable
+    // The [Collection(MockedVS.Collection)] attribute lives in SnykOptionsTest.Vs.cs: these tests
+    // only exercise endpoint derivation on SnykOptions and touch no Visual Studio service, so the
+    // fixture only needs to keep them in the same serialized collection on Windows.
+    public partial class SnykOptionsTest : IDisposable
     {
         private readonly SnykOptions cut;
         private readonly string settingsFilePath;
 
-        public SnykOptionsTest(GlobalServiceProvider sp)
+        public SnykOptionsTest()
         {
-            sp.Reset();
             var serviceProviderMock = new Mock<ISnykServiceProvider>();
-            var snykSolutionService = new SnykSolutionService();
-            serviceProviderMock.Setup(x => x.SolutionService).Returns(snykSolutionService);
+            // A mock rather than SnykSolutionService: nothing under test reads the solution, and
+            // the concrete service needs Visual Studio's DTE.
+            serviceProviderMock.Setup(x => x.SolutionService).Returns(new Mock<ISolutionService>().Object);
             var serviceProvider = serviceProviderMock.Object;
             // IDE-1483: use a non-pre-created unique path so the file does not exist at
             // construction time (avoids the JSON-parse error that Path.GetTempFileName()'s

--- a/docs/cross-platform-testing.md
+++ b/docs/cross-platform-testing.md
@@ -67,6 +67,9 @@ Current examples:
 | `ISolutionService` | `SolutionEvents` (`SnykVsSolutionLoadEvents`) |
 | `ThreadContextEnricher` | resolving the IDE UI thread via `ThreadHelper.CheckAccess()` |
 | `SnykCliDownloader` | raising the VS info bar when a CLI update fails |
+| `BaseHtmlProvider` | reading the active VS colour theme into an `HtmlThemePalette` |
+| `CodeHtmlProvider`, `OssHtmlProvider`, `SecretsHtmlProvider` | their product-specific themed colour substitutions, and dark / high-contrast detection |
+| `StaticHtmlProvider` | `GetInitHtmlAsync`, which marshals through the IDE joinable task factory |
 
 Where the VS half is an implementation detail rather than API, it is expressed as a
 [classic partial method](https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/partial-method)

--- a/docs/cross-platform-testing.md
+++ b/docs/cross-platform-testing.md
@@ -1,0 +1,118 @@
+# Cross-platform unit testing
+
+Most of this extension's unit tests now run on Linux, macOS and Windows with nothing but the
+.NET SDK:
+
+```bash
+dotnet test Snyk.VisualStudio.Extension.Core.Tests
+```
+
+No Visual Studio, no MSBuild, no VSIX tooling, no `nuget.config` VSSDK feeds. This means you can
+develop and verify most changes to the extension's logic without a Windows machine, and the
+`Run Cross-Platform Unit-Tests` job in `pr-workflow.yml` gates every pull request on Linux.
+
+## How it works
+
+`Snyk.VisualStudio.Extension.2022` is a legacy net48 VSIX project: referencing it pulls in the
+Visual Studio SDK, WPF and WebView2, none of which exist off Windows. A large part of the
+extension, though, is ordinary .NET code — settings persistence, language-server configuration,
+CLI download logic, HTML/CSS string manipulation, URI handling.
+
+`Snyk.VisualStudio.Extension.Core.Tests` is a `net8.0` xUnit project that has almost no sources of
+its own. Instead it **compiles the platform-neutral subset of the existing sources** as linked
+files:
+
+| File | Contains |
+| --- | --- |
+| `Snyk.VisualStudio.Extension.Core.props` | the platform-neutral production sources, from `Snyk.VisualStudio.Extension.2022/` |
+| `Snyk.VisualStudio.Extension.Core.Tests.props` | the platform-neutral test sources, from `Snyk.VisualStudio.Extension.Tests/` |
+
+```
+Snyk.VisualStudio.Extension.2022        (net48 VSIX, Windows only)  ─┐
+                                                                     ├─ same source files
+Snyk.VisualStudio.Extension.Core.Tests  (net8.0, any OS)  ──────────┘
+
+Snyk.VisualStudio.Extension.Tests       (net48, Windows only)  ─┐
+                                                                ├─ same test files
+Snyk.VisualStudio.Extension.Core.Tests  (net8.0, any OS)  ──────┘
+```
+
+Nothing was moved or duplicated. Every shared test still runs on Windows against the real net48
+VSIX assembly exactly as before; the cross-platform project runs the same test code a second time
+against the same source compiled for .NET 8. Two consequences worth knowing:
+
+- Windows coverage never regressed as a side effect of this work.
+- Occasionally the two target frameworks disagree (`Snyk.VisualStudio.Extension.Language.Range`
+  vs `System.Range`, for instance). That is a real finding about the code, not an artefact.
+
+## The `.Vs.cs` convention
+
+Some types are *mostly* platform-neutral with a small Visual Studio dependency. Rather than
+introducing runtime indirection, those types are `partial` and split across two files:
+
+| File | Compiled by | Contains |
+| --- | --- | --- |
+| `Foo.cs` | both projects | everything that does not need the IDE |
+| `Foo.Vs.cs` | the VSIX only | the members that need the VS SDK |
+
+Both `partial class` and `partial interface` are used. The split is resolved entirely at compile
+time, so **the Windows build and the shipped VSIX behave exactly as before** — there is no
+registration step to forget and no runtime fallback to get wrong.
+
+Current examples:
+
+| Type | What lives in `.Vs.cs` |
+| --- | --- |
+| `ISnykServiceProvider` | `DTE`, `Package`, `AsyncServiceProvider`, `SettingsManager`, `VsThemeService`, `ToolWindow`, `GetServiceAsync` |
+| `ISolutionService` | `SolutionEvents` (`SnykVsSolutionLoadEvents`) |
+| `ThreadContextEnricher` | resolving the IDE UI thread via `ThreadHelper.CheckAccess()` |
+| `SnykCliDownloader` | raising the VS info bar when a CLI update fails |
+
+Where the VS half is an implementation detail rather than API, it is expressed as a
+[classic partial method](https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/partial-method)
+(`static partial void Xxx(...)`): if no implementing declaration is compiled, the call is removed
+by the compiler. That is why the cross-platform build needs no stub files at all.
+
+## Adding a test to the cross-platform run
+
+1. Add the test file to `Snyk.VisualStudio.Extension.Core.Tests.props`.
+2. Add any production file it needs to `Snyk.VisualStudio.Extension.Core.props`, plus that file's
+   own dependencies.
+3. `dotnet test Snyk.VisualStudio.Extension.Core.Tests`.
+
+If the build fails on a Visual Studio type, you have three options, in order of preference:
+
+1. **Split the type** using the `.Vs.cs` convention above. Best when the VS dependency is a small
+   part of an otherwise neutral type. Remember to add the new `.Vs.cs` file to
+   `Snyk.VisualStudio.Extension.2022.csproj`.
+2. **Narrow the dependency** — for example, depend on an interface the tests already mock instead
+   of a concrete VS-bound service.
+3. **Leave it Windows-only.** Genuinely IDE-bound code (tool windows, WPF panels, the VS language
+   client, the WebView2 control host) belongs in `Snyk.VisualStudio.Extension.Tests`.
+
+## What stays Windows-only
+
+| | Why |
+| --- | --- |
+| Building the VSIX (`Snyk.VisualStudio.Extension.2022`) | needs MSBuild plus the Visual Studio SDK |
+| `Snyk.VisualStudio.Extension.Tests` (net48) | references the VSIX and `Microsoft.VisualStudio.Sdk.TestFramework` / MockedVS |
+| `Tests/Integration.Tests` | launches a real Visual Studio instance |
+
+Tests that stay in the Windows-only project are the ones using `[Collection(MockedVS.Collection)]`,
+deriving from `PackageBaseTest`, or touching WPF, WebView2 or the VS language client directly.
+
+Do not try to `msbuild` the solution on Linux — the VSSDK targets are Windows-only. Build the
+cross-platform project directly, by path, as shown at the top of this document.
+
+## Guard rails
+
+`ProjectFileIntegrityTests` runs as part of the cross-platform suite and fails if:
+
+- a source file exists under `Snyk.VisualStudio.Extension.2022/` but is missing from its legacy
+  csproj (which would silently drop it from the VSIX),
+- the csproj references a file that has been deleted,
+- either `.props` list points at a file that no longer exists,
+- a `.Vs.cs` or `.xaml.cs` file leaks into the cross-platform source list.
+
+Because those checks run on Linux, the most common way to break the Windows-only build gets caught
+before anyone starts a Windows machine.

--- a/docs/cross-platform-testing.md
+++ b/docs/cross-platform-testing.md
@@ -1,7 +1,7 @@
 # Cross-platform unit testing
 
-Most of this extension's unit tests now run on Linux, macOS and Windows with nothing but the
-.NET SDK:
+Most of this extension's unit tests — 412 of them at the time of writing — run on Linux, macOS and
+Windows with nothing but the .NET SDK:
 
 ```bash
 dotnet test Snyk.VisualStudio.Extension.Core.Tests
@@ -71,6 +71,10 @@ Current examples:
 | `CodeHtmlProvider`, `OssHtmlProvider`, `SecretsHtmlProvider` | their product-specific themed colour substitutions, and dark / high-contrast detection |
 | `StaticHtmlProvider` | `GetInitHtmlAsync`, which marshals through the IDE joinable task factory |
 
+`WebView2Host` uses a plain partial split rather than the `.Vs.cs` convention, because the shared
+half is the smaller one: `WebView2Host.Paths.cs` holds the user-data folder layout and the
+navigation allowlist, while `WebView2Host.cs` remains the WPF/WebView2 control host.
+
 Where the VS half is an implementation detail rather than API, it is expressed as a
 [classic partial method](https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/partial-method)
 (`static partial void Xxx(...)`): if no implementing declaration is compiled, the call is removed
@@ -98,14 +102,34 @@ If the build fails on a Visual Studio type, you have three options, in order of 
 | | Why |
 | --- | --- |
 | Building the VSIX (`Snyk.VisualStudio.Extension.2022`) | needs MSBuild plus the Visual Studio SDK |
-| `Snyk.VisualStudio.Extension.Tests` (net48) | references the VSIX and `Microsoft.VisualStudio.Sdk.TestFramework` / MockedVS |
 | `Tests/Integration.Tests` | launches a real Visual Studio instance |
 
-Tests that stay in the Windows-only project are the ones using `[Collection(MockedVS.Collection)]`,
-deriving from `PackageBaseTest`, or touching WPF, WebView2 or the VS language client directly.
+Do not try to `msbuild` the solution on Linux: the VSSDK targets are Windows-only, and the VS SDK
+NuGet feeds are Azure DevOps hosted. Build the cross-platform project directly, by path, as shown at
+the top of this document.
 
-Do not try to `msbuild` the solution on Linux — the VSSDK targets are Windows-only. Build the
-cross-platform project directly, by path, as shown at the top of this document.
+These test classes are genuinely IDE-bound and only run on Windows:
+
+| Test class | Why |
+| --- | --- |
+| `PackageBaseTest` and its subclasses (`SnykVSPackageNotInitializedHandlerTests`, `SnykLanguageClientTest`, `SnykLanguageClientCustomTargetTests`, `HtmlSettingsScriptingBridgeTest`) | construct `SnykVSPackage` against MockedVS |
+| `UI/ResourceLoaderTest` | resolves `pack://application:` WPF resource URIs |
+| `UI/Toolwindow/PanelDisposalContractTest` | `ToolWindowPane` and the WPF panels |
+| `UI/Html/WebView2PackageSmokeTest` | loads WebView2 runtime types |
+| `Settings/GlobalResetPropagationTests` | `HtmlSettingsScriptingBridge` schedules work on the IDE joinable task factory |
+| `Authentication/AuthenticationFlowServiceTests` | `AuthenticationFlowService` is built around `ThreadHelper` and the modal auth dialog |
+| `SnykSolutionServiceTest` | `SnykSolutionService` is DTE / `IVsSolution` based throughout |
+
+## Network access
+
+`SnykCliDownloaderTest` downloads real CLI release metadata and binaries from
+`downloads.snyk.io`, exactly as it does in the Windows run. The cross-platform suite therefore needs
+outbound HTTPS; behind a restrictive proxy, filter it out:
+
+```bash
+dotnet test Snyk.VisualStudio.Extension.Core.Tests \
+  --filter 'FullyQualifiedName!~SnykCliDownloaderTest'
+```
 
 ## Guard rails
 

--- a/snyk-visual-studio-plugin.sln
+++ b/snyk-visual-studio-plugin.sln
@@ -37,6 +37,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{ADBE502B
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Integration.Tests", "Tests\Integration.Tests\Integration.Tests.csproj", "{10CB14D3-CB55-461C-B100-70E803198A7D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snyk.VisualStudio.Extension.Core.Tests", "Snyk.VisualStudio.Extension.Core.Tests\Snyk.VisualStudio.Extension.Core.Tests.csproj", "{4E1D5C90-5A2B-4C7F-9E63-2B7C1A4F8D31}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,10 @@ Global
 		{10CB14D3-CB55-461C-B100-70E803198A7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{10CB14D3-CB55-461C-B100-70E803198A7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{10CB14D3-CB55-461C-B100-70E803198A7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E1D5C90-5A2B-4C7F-9E63-2B7C1A4F8D31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E1D5C90-5A2B-4C7F-9E63-2B7C1A4F8D31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E1D5C90-5A2B-4C7F-9E63-2B7C1A4F8D31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E1D5C90-5A2B-4C7F-9E63-2B7C1A4F8D31}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Every unit test in this repo requires Windows today, because both test projects reference the net48 VSIX and therefore the Visual Studio SDK, WPF and WebView2. That makes Windows CI the bottleneck for any change to the extension's logic, even when the logic itself is ordinary .NET code.

## What

Adds `Snyk.VisualStudio.Extension.Core.Tests`, a `net8.0` xUnit project that runs **412 of the extension's unit tests** on Linux, macOS and Windows with nothing but the .NET SDK:

```bash
dotnet test Snyk.VisualStudio.Extension.Core.Tests
```

A new `Run Cross-Platform Unit-Tests` job in `pr-workflow.yml` gates pull requests on `ubuntu-latest`. Only nine test classes still need Windows, all of them genuinely IDE-bound (listed in the docs).

### Approach: shared sources, not a new library

The obvious design — extract a `netstandard2.0` Core library and move files into it — means editing 160+ explicit `<Compile Include>` entries in the legacy VSIX csproj, relocating files that XAML markup resolves by `clr-namespace`, and changing which assembly types live in. None of that is verifiable on Linux (the VS SDK feeds are Azure DevOps hosted and unreachable from a Linux agent), and a mistake breaks the release pipeline.

Instead, this project **compiles the platform-neutral subset of the existing sources as linked files**. Two lists define the subset:

- `Snyk.VisualStudio.Extension.Core.props` — 104 production sources from `Snyk.VisualStudio.Extension.2022/`
- `Snyk.VisualStudio.Extension.Core.Tests.props` — 38 test sources from `Snyk.VisualStudio.Extension.Tests/`

Nothing moved and nothing was duplicated, so:

- **Windows coverage is unchanged** — every shared test still runs on `windows-2022` against the real net48 assembly exactly as before.
- Shared tests now run against **both** net48 and net8.0, which already surfaced a genuine cross-target ambiguity between `Snyk.VisualStudio.Extension.Language.Range` and `System.Range`.
- Converting to a real Core library later is easy: the same `.props` list is the manifest.

### The `.Vs.cs` convention

Several types were *mostly* platform-neutral with a small IDE dependency. Each is now `partial`, with its Visual Studio members in a sibling `*.Vs.cs` file that only the VSIX compiles. The split is resolved entirely at compile time — there is no registration step to forget and no runtime fallback to get wrong, so the shipped VSIX behaves exactly as before.

| Type | Moved to `.Vs.cs` |
| --- | --- |
| `ISnykServiceProvider` | `DTE`, `Package`, `AsyncServiceProvider`, `SettingsManager`, `VsThemeService`, `ToolWindow`, `GetServiceAsync` |
| `ISolutionService` | `SolutionEvents` (`SnykVsSolutionLoadEvents`) |
| `ThreadContextEnricher` | UI-thread detection via `ThreadHelper.CheckAccess()` |
| `SnykCliDownloader` | the VS info bar raised when a CLI update fails |
| `BaseHtmlProvider` | reading the active VS colour theme into an `HtmlThemePalette` |
| `CodeHtmlProvider`, `OssHtmlProvider`, `SecretsHtmlProvider` | product-specific themed colour substitutions and dark / high-contrast detection |
| `StaticHtmlProvider` | `GetInitHtmlAsync`, which marshals through the IDE joinable task factory |

Both `partial interface` and `partial class` are used. Where the VS half is an implementation detail it is a classic `static partial void` method, which the compiler removes entirely when no implementation is compiled — that is why the cross-platform build needs no stub files.

Two related refactors that stand on their own merit:

- **`HtmlThemePalette`** separates *which* CSS custom properties the HTML surfaces get from *where* the colours come from. The existing forced-light colours become `HtmlThemePalette.Light`, which is also what applies with no IDE theme to read. Colour values and substitution order are unchanged.
- **`WebView2Host.Paths.cs`** splits the user-data folder layout and the navigation allowlist away from the WPF control host. `WebView2HostTest` only ever exercised that logic, yet needed the WebView2 runtime to compile.

Two test classes had purely incidental VS coupling, now removed: `LsSettingsV25Tests` took a `GlobalServiceProvider` fixture solely to call `sp.Reset()` while using local mocks throughout, and `SnykOptionsTest` constructed a real `SnykSolutionService` to satisfy a mock setup nothing under test reads. Both keep `[Collection(MockedVS.Collection)]` in a `.Vs.cs` part, so they stay in the same serialized collection on Windows.

### Guard rails

`ProjectFileIntegrityTests` runs in the cross-platform suite and fails if a source file is missing from the legacy VSIX csproj, if the csproj references a deleted file, if either `.props` list is stale, or if a `.Vs.cs` file leaks into the cross-platform source list. Adding a file to disk but not to the legacy csproj silently drops it from the VSIX; that mistake is now caught on Linux.

## Test evidence

```
$ dotnet test Snyk.VisualStudio.Extension.Core.Tests --configuration Release
Test run for .../bin/Release/net8.0/Snyk.VisualStudio.Extension.Core.Tests.dll (.NETCoreApp,Version=v8.0)

Test Run Successful.
Total tests: 412
     Passed: 412
 Total time: 12.6399 Seconds
```

The VSIX itself cannot be built on a Linux agent, so as a substitute for the net48 compile I compiled every extension and test source together with Roslyn and asserted that no partial-split diagnostic appears — `CS0759` (implementation with no matching defining declaration), `CS0758`/`CS0761` (signature mismatch), `CS0111`/`CS0102` (duplicate member across parts), `CS0263`/`CS0261`/`CS0262` (conflicting partial declarations) and any parse error. The set is empty; only the expected unresolved-VS-type errors remain. `msbuild` on `windows-2022` is still the authority.

## Notes for review

- `build-project.yml` gains an explicit `actions/setup-dotnet@v4` step: the solution now contains a `net8.0` project, so MSBuild's SDK resolver needs a .NET 8 SDK rather than relying on the runner image.
- The new project is a full member of the solution, so Windows will also build and run it. That is deliberate (it is how the cross-target `Range` ambiguity was found), but if you would rather keep the Windows pipeline untouched, dropping the `Build.0` lines for `{4E1D5C90-…}` from the `.sln` is a one-line change.
- `SnykCliDownloaderTest` downloads real CLI artefacts from `downloads.snyk.io`, exactly as it does on Windows today, so the Linux job needs outbound HTTPS. The docs give the filter to skip it behind a proxy.
- The new test project is excluded from the Snyk open-source scans alongside the existing test projects.
- `docs/cross-platform-testing.md` documents the model, how to bring more tests across, and what stays Windows-only. `CONTRIBUTING.md` now leads with the no-Windows-required path.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1cf4c42-8833-429b-98ce-b360e719ba46?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1cf4c42-8833-429b-98ce-b360e719ba46&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

