### PR TITLE
fix: ensure the Snyk tool window exists before any InfoBar [IDE-2454]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
+++ b/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
@@ -181,7 +181,15 @@ namespace Snyk.VisualStudio.Extension
                 // instead of re-running Activator.CreateInstance or constructing a new
                 // SnykToolWindowControl/WebView2 host. Resetting ToolWindow here only clears this
                 // package's own field, not that cache.
+                //
+                // Reset ToolWindowControl alongside it: SnykToolWindow.OnToolWindowCreated can assign
+                // both ToolWindow and ToolWindowControl as part of the same tool-window creation the
+                // Frame check above is validating. Resetting only ToolWindow would leave ToolWindowControl
+                // pointing at that pane's control while ToolWindow reads null - and SnykService.ToolWindow
+                // reaches through ToolWindowControl specifically, so the LS message handlers and the auth
+                // flow would keep driving a pane this method has just declared unusable.
                 ToolWindow = null;
+                ToolWindowControl = null;
 
                 throw new NotSupportedException("Cannot find Snyk tool window.");
             }

--- a/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
+++ b/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
@@ -173,6 +173,14 @@ namespace Snyk.VisualStudio.Extension
                 // caller of this method (including retries) early-returns on ToolWindow != null - leaving
                 // it set here would make this failure permanent for the rest of the session, with
                 // ToolWindowControl staying null forever since the assignment below would never run again.
+                //
+                // Retrying is cheap, not just a trade-off: MPF's own ToolWindowCollection caches one
+                // AsyncLazy<ToolWindowPane> per (tool GUID, id) for the package's lifetime, and
+                // AsyncLazy never re-invokes its factory once its task is set, faulted or not - so every
+                // retry after a genuine frame-creation failure just re-throws that same cached exception
+                // instead of re-running Activator.CreateInstance or constructing a new
+                // SnykToolWindowControl/WebView2 host. Resetting ToolWindow here only clears this
+                // package's own field, not that cache.
                 ToolWindow = null;
 
                 throw new NotSupportedException("Cannot find Snyk tool window.");

--- a/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
+++ b/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
@@ -187,14 +187,15 @@ namespace Snyk.VisualStudio.Extension
                 // Still harmless (each retry is cheap, per the MPF caching above) - just noisier logs.
                 // Not worth a second piece of state to suppress.
                 //
-                // Reset ToolWindowControl alongside it: SnykToolWindow.OnToolWindowCreated can assign
-                // both ToolWindow and ToolWindowControl as part of the same tool-window creation the
-                // Frame check above is validating. Resetting only ToolWindow would leave ToolWindowControl
-                // pointing at that pane's control while ToolWindow reads null - and SnykService.ToolWindow
-                // reaches through ToolWindowControl specifically, so the LS message handlers and the auth
-                // flow would keep driving a pane this method has just declared unusable.
+                // ToolWindowControl deliberately NOT reset alongside it: SnykToolWindow.OnToolWindowCreated
+                // can assign ToolWindowControl (via SnykService.ToolWindow, which several callers -
+                // AuthenticationFlowService among them - dereference with no null check) even when this
+                // Frame check still fails. Nulling it here would turn "maybe still usable despite a
+                // frameless pane" into a guaranteed NullReferenceException for those callers, for no
+                // benefit to this method: SnykCleanPanelCommand, the one caller that reads ToolWindow
+                // before touching ToolWindowControl, already stops at the ToolWindow == null check below
+                // regardless of what ToolWindowControl holds.
                 ToolWindow = null;
-                ToolWindowControl = null;
 
                 throw new NotSupportedException("Cannot find Snyk tool window.");
             }
@@ -248,7 +249,26 @@ namespace Snyk.VisualStudio.Extension
                 // The Edge WebView2 Runtime is a hard requirement now that the settings dialog and
                 // all tool-window panels are WebView2-hosted. Surface a clear, actionable error if
                 // it's missing rather than letting every panel fail opaquely on first navigation.
-                await WarnIfWebView2RuntimeMissingAsync();
+                //
+                // Fire-and-forget, like InitializeLanguageClient above - not just for consistency.
+                // ShowErrorInfoBar (reached via NotificationService.Instance? below) now waits for
+                // PackageInitializedAwaiter before creating the tool window, bounded so it can't hang
+                // forever - but awaiting this call inline would guarantee that wait times out on every
+                // single call, every launch: InitializeAsync cannot reach the finally that completes
+                // PackageInitializedAwaiter while blocked here awaiting the very thing that call is
+                // waiting on. Firing it instead lets InitializeAsync finish normally, so the wait this
+                // triggers can actually succeed.
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    try
+                    {
+                        await WarnIfWebView2RuntimeMissingAsync();
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Error(e, "Error checking for the WebView2 runtime");
+                    }
+                }).FireAndForget();
 
                 // Notify package has been initialized
                 IsInitialized = true;

--- a/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
+++ b/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
@@ -182,6 +182,11 @@ namespace Snyk.VisualStudio.Extension
                 // SnykToolWindowControl/WebView2 host. Resetting ToolWindow here only clears this
                 // package's own field, not that cache.
                 //
+                // Accepted cost: during a persistent failure, every InfoBar call in that window repeats
+                // this FindToolWindow-and-throw-and-log rather than failing once and staying latched.
+                // Still harmless (each retry is cheap, per the MPF caching above) - just noisier logs.
+                // Not worth a second piece of state to suppress.
+                //
                 // Reset ToolWindowControl alongside it: SnykToolWindow.OnToolWindowCreated can assign
                 // both ToolWindow and ToolWindowControl as part of the same tool-window creation the
                 // Frame check above is validating. Resetting only ToolWindow would leave ToolWindowControl

--- a/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
+++ b/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
@@ -169,32 +169,17 @@ namespace Snyk.VisualStudio.Extension
             {
                 Logger.Error("Exception: Cannot find Snyk tool window.");
 
-                // Reset before throwing: ToolWindow was just assigned a frameless pane above, and every
-                // caller of this method (including retries) early-returns on ToolWindow != null - leaving
-                // it set here would make this failure permanent for the rest of the session, with
-                // ToolWindowControl staying null forever since the assignment below would never run again.
+                // Reset before throwing, not left set: every caller (including retries) early-returns on
+                // ToolWindow != null, so leaving a frameless pane here would make this failure permanent
+                // for the session - ToolWindowControl would never get assigned below either. Retrying is
+                // cheap: MPF caches pane creation per (GUID, id), so a repeated failure re-throws rather
+                // than reconstructing - just noisier logs during a persistent failure, not repeated work.
                 //
-                // Retrying is cheap, not just a trade-off: MPF's own ToolWindowCollection caches one
-                // AsyncLazy<ToolWindowPane> per (tool GUID, id) for the package's lifetime, and
-                // AsyncLazy never re-invokes its factory once its task is set, faulted or not - so every
-                // retry after a genuine frame-creation failure just re-throws that same cached exception
-                // instead of re-running Activator.CreateInstance or constructing a new
-                // SnykToolWindowControl/WebView2 host. Resetting ToolWindow here only clears this
-                // package's own field, not that cache.
-                //
-                // Accepted cost: during a persistent failure, every InfoBar call in that window repeats
-                // this FindToolWindow-and-throw-and-log rather than failing once and staying latched.
-                // Still harmless (each retry is cheap, per the MPF caching above) - just noisier logs.
-                // Not worth a second piece of state to suppress.
-                //
-                // ToolWindowControl deliberately NOT reset alongside it: SnykToolWindow.OnToolWindowCreated
-                // can assign ToolWindowControl (via SnykService.ToolWindow, which several callers -
-                // AuthenticationFlowService among them - dereference with no null check) even when this
-                // Frame check still fails. Nulling it here would turn "maybe still usable despite a
-                // frameless pane" into a guaranteed NullReferenceException for those callers, for no
-                // benefit to this method: SnykCleanPanelCommand, the one caller that reads ToolWindow
-                // before touching ToolWindowControl, already stops at the ToolWindow == null check below
-                // regardless of what ToolWindowControl holds.
+                // ToolWindowControl deliberately left alone: OnToolWindowCreated can set it independently
+                // of this Frame check, and callers like AuthenticationFlowService dereference it with no
+                // null check - nulling it here would turn a possibly-still-usable control into a
+                // guaranteed crash for them, for no benefit (SnykCleanPanelCommand, the one caller that
+                // checks ToolWindow first, is unaffected either way).
                 ToolWindow = null;
 
                 throw new NotSupportedException("Cannot find Snyk tool window.");
@@ -250,14 +235,8 @@ namespace Snyk.VisualStudio.Extension
                 // all tool-window panels are WebView2-hosted. Surface a clear, actionable error if
                 // it's missing rather than letting every panel fail opaquely on first navigation.
                 //
-                // Fire-and-forget, like InitializeLanguageClient above - not just for consistency.
-                // ShowErrorInfoBar (reached via NotificationService.Instance? below) now waits for
-                // PackageInitializedAwaiter before creating the tool window, bounded so it can't hang
-                // forever - but awaiting this call inline would guarantee that wait times out on every
-                // single call, every launch: InitializeAsync cannot reach the finally that completes
-                // PackageInitializedAwaiter while blocked here awaiting the very thing that call is
-                // waiting on. Firing it instead lets InitializeAsync finish normally, so the wait this
-                // triggers can actually succeed.
+                // Fire-and-forget, like InitializeLanguageClient above: the InfoBar this shows waits on
+                // this method's own completion, so awaiting it inline here would deadlock.
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     try

--- a/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
+++ b/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
@@ -169,6 +169,12 @@ namespace Snyk.VisualStudio.Extension
             {
                 Logger.Error("Exception: Cannot find Snyk tool window.");
 
+                // Reset before throwing: ToolWindow was just assigned a frameless pane above, and every
+                // caller of this method (including retries) early-returns on ToolWindow != null - leaving
+                // it set here would make this failure permanent for the rest of the session, with
+                // ToolWindowControl staying null forever since the assignment below would never run again.
+                ToolWindow = null;
+
                 throw new NotSupportedException("Cannot find Snyk tool window.");
             }
 

--- a/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
@@ -22,6 +22,17 @@
         private const string KnownCaveats = "knownCaveats";
         private const string SupportLink = "https://support.snyk.io/hc/en-us/requests/new";
         private const string KnownCaveatsLink = "https://docs.snyk.io/ide-tools/visual-studio-extension/troubleshooting-and-known-issues-with-visual-studio-extension";
+
+        // Bounds the wait in EnsureToolWindowExistsAsync below. Must be bounded, not awaited
+        // unconditionally: SnykVSPackage.WarnIfWebView2RuntimeMissingAsync calls ShowErrorInfoBar
+        // synchronously from inside InitializeAsync itself, before PackageInitializedAwaiter's task is
+        // completed - an unconditional wait there deadlocks (InitializeAsync can't finish while blocked
+        // on this call, and this call can't finish waiting on InitializeAsync). A few seconds is far
+        // more than the narrow, no-network span this is really guarding (the gap between
+        // InitializeLanguageClient's fire-and-forget start and SnykScanCommand.InitializeAsync a few
+        // lines later), so this should never actually bind that legitimate wait.
+        private const int PackageInitWaitTimeoutMs = 5000;
+
         private readonly ISnykServiceProvider serviceProvider;
 
         // Keyed per element, not a single shared field: Advise() returns a cookie scoped to the
@@ -124,9 +135,23 @@
             // chain that can itself raise an InfoBar (e.g. SnykCliDownloader.ReportInstallFailure) and
             // land here first. Racing that chain would create the pane with only some of its listeners
             // wired, and ToolWindow's own null check above means it would stay half-wired for the rest
-            // of the session. SnykVSPackage.PackageInitializedAwaiter completes on every path through
-            // InitializeAsync, including its catch block, so this can't hang if init itself fails.
-            await SnykVSPackage.PackageInitializedAwaiter;
+            // of the session.
+            //
+            // Bounded (see PackageInitWaitTimeoutMs above for why this must not be an unconditional
+            // await): if the wait times out, package init hasn't reached the point where creating the
+            // pane is safe, so this call skips creating it, same as if ToolWindow had simply stayed
+            // null. A later, successful call (e.g. once the user opens the panel) still creates the
+            // pane normally.
+            var packageInitialized = await Task.WhenAny(
+                SnykVSPackage.PackageInitializedAwaiter,
+                Task.Delay(PackageInitWaitTimeoutMs)) == SnykVSPackage.PackageInitializedAwaiter;
+
+            if (!packageInitialized)
+            {
+                Logger.Warning("Timed out waiting for package initialization before showing an InfoBar; not creating the Snyk tool window this time");
+
+                return;
+            }
 
             try
             {

--- a/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
@@ -23,29 +23,17 @@
         private const string SupportLink = "https://support.snyk.io/hc/en-us/requests/new";
         private const string KnownCaveatsLink = "https://docs.snyk.io/ide-tools/visual-studio-extension/troubleshooting-and-known-issues-with-visual-studio-extension";
 
-        // Bounds the wait in EnsureToolWindowExistsAsync below. Must be bounded, not awaited
-        // unconditionally: SnykVSPackage.WarnIfWebView2RuntimeMissingAsync calls ShowErrorInfoBar
-        // synchronously from inside InitializeAsync itself, before PackageInitializedAwaiter's task is
-        // completed - an unconditional wait there deadlocks (InitializeAsync can't finish while blocked
-        // on this call, and this call can't finish waiting on InitializeAsync). A few seconds is far
-        // more than the narrow, no-network span this is really guarding (the gap between
-        // InitializeLanguageClient's fire-and-forget start and SnykScanCommand.InitializeAsync a few
-        // lines later), so this should never actually bind that legitimate wait.
+        // Bounds the wait in EnsureToolWindowExistsAsync below - must not be an unconditional await, or
+        // a caller that itself blocks package init from completing would deadlock waiting on it.
         private const int PackageInitWaitTimeoutMs = 5000;
 
         private readonly ISnykServiceProvider serviceProvider;
 
-        // Keyed per element, not a single shared field: Advise() returns a cookie scoped to the
-        // specific element it was called on, not a global ID - a single field gets overwritten by
-        // every call, so closing the first of two concurrently displayed InfoBars unadvises with
-        // whatever cookie was written last, silently corrupting the other's advise connection.
-        //
-        // Only ever pruned in OnClosed, same as messagesCache below. If the tool window is torn down
-        // (solution close, VS shutdown) without the InfoBar raising OnClosed first, both entries
-        // outlive it for the rest of the session, and the same message text can never be shown again -
-        // closing that would need a teardown hook (e.g. AfterCloseSolution) clearing both dictionaries.
-        // Accepted as-is: the failure mode is a missed message, not a crash or a leak beyond the
-        // session.
+        // Keyed per element, not a single shared field: Advise() returns a cookie scoped to the specific
+        // element it was called on, not a global ID - a shared field would get overwritten by every
+        // call, unadvising the wrong element on close. Only pruned in OnClosed, same as messagesCache
+        // below; if the tool window is torn down without OnClosed firing, both outlive it for the
+        // session (a missed message, not a crash or an unbounded leak).
         private readonly IDictionary<IVsInfoBarUIElement, uint> cookiesByElement =
             new Dictionary<IVsInfoBarUIElement, uint>();
 
@@ -114,11 +102,8 @@
 
         /// <summary>
         /// Ensures the Snyk tool window pane exists (without necessarily showing/focusing it) before an
-        /// InfoBar is attached to it (IDE-2454). ToolWindow stays null until the panel has been created
-        /// at least once - opened by the user, or by a Snyk command running EnsureInitializeToolWindowAsync
-        /// - so without this, any InfoBar shown before that point (e.g. a startup warning or a
-        /// pre-launch gate failure, before the user has ever opened the panel) was silently dropped: the
-        /// early-return check below never became true, and no message reached the user at all.
+        /// InfoBar is attached to it. ToolWindow stays null until the panel has been created at least
+        /// once, so without this, an InfoBar shown before that point was silently dropped.
         /// </summary>
         private async Task EnsureToolWindowExistsAsync()
         {
@@ -127,21 +112,13 @@
                 return;
             }
 
-            // Wait for package init to finish before creating the pane, not just for the tool window's
-            // own sake: SnykToolWindow.OnToolWindowCreated wires the pane's event listeners as part of
-            // creation, including SnykScanCommand.Instance.UpdateControlsStateCallback with no null
-            // check. SnykScanCommand.Instance is only set once SnykVSPackage.InitializeAsync reaches
-            // SnykScanCommand.InitializeAsync - which runs after the fire-and-forget language-client
-            // chain that can itself raise an InfoBar (e.g. SnykCliDownloader.ReportInstallFailure) and
-            // land here first. Racing that chain would create the pane with only some of its listeners
-            // wired, and ToolWindow's own null check above means it would stay half-wired for the rest
-            // of the session.
-            //
-            // Bounded (see PackageInitWaitTimeoutMs above for why this must not be an unconditional
-            // await): if the wait times out, package init hasn't reached the point where creating the
-            // pane is safe, so this call skips creating it, same as if ToolWindow had simply stayed
-            // null. A later, successful call (e.g. once the user opens the panel) still creates the
-            // pane normally.
+            // Wait for package init to finish before creating the pane: SnykToolWindow.OnToolWindowCreated
+            // wires up SnykScanCommand.Instance with no null check, and that instance only exists once
+            // SnykVSPackage.InitializeAsync reaches SnykScanCommand.InitializeAsync - which an InfoBar
+            // raised earlier in that same init sequence (e.g. SnykCliDownloader.ReportInstallFailure)
+            // could otherwise race, half-wiring the pane for the rest of the session. Bounded (see
+            // PackageInitWaitTimeoutMs above) so a caller that itself blocks init can't deadlock here -
+            // on timeout this call just skips creating the pane, same as if it had stayed uncreated.
             var packageInitialized = await Task.WhenAny(
                 SnykVSPackage.PackageInitializedAwaiter,
                 Task.Delay(PackageInitWaitTimeoutMs)) == SnykVSPackage.PackageInitializedAwaiter;
@@ -176,16 +153,11 @@
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             await this.EnsureToolWindowExistsAsync();
 
-            // Captured once and reused below, not re-read from the field: ToolWindow can now be reset to
-            // null by a concurrent failing EnsureInitializeToolWindowAsync (e.g. from another call to
-            // this method), and the awaits between here and AddInfoBar below give that a window to run.
-            // A stale local reference held across those awaits can't be nulled out from under us.
+            // Captured once, not re-read from the field: a concurrent failing
+            // EnsureInitializeToolWindowAsync could otherwise null the field out between this check and
+            // AddInfoBar below. Frame is checked too, not just null-ness: a pane can exist without one.
             var toolWindow = this.serviceProvider.Package.ToolWindow;
 
-            // Also check Frame, not just ToolWindow: EnsureInitializeToolWindowAsync assigns ToolWindow
-            // before validating its Frame, and throws (caught above, best-effort) rather than leaving
-            // ToolWindow null when the pane exists but its window frame does not - so ToolWindow alone
-            // being non-null does not mean AddInfoBar below has anywhere to attach to.
             if (toolWindow?.Frame == null || this.messagesCache.ContainsKey(message))
                 return;
 

--- a/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
@@ -122,11 +122,10 @@
             }
             catch (Exception e)
             {
-                // Best-effort: the ToolWindow?.Frame == null check below still applies and no-ops
-                // exactly as it did before this fix if this failed (e.g. during shutdown, before the
-                // package is fully sited - FindToolWindow/the Content cast inside
-                // EnsureInitializeToolWindowAsync can throw various exceptions in those cases, not just
-                // NotSupportedException).
+                // Best-effort: FindToolWindow/the Content cast inside EnsureInitializeToolWindowAsync
+                // can throw various exceptions (e.g. during shutdown, before the package is fully sited),
+                // not just NotSupportedException. The ToolWindow?.Frame == null check below still
+                // catches the failure and no-ops the InfoBar rather than throwing out of this method.
                 Logger.Warning(e, "Could not ensure the Snyk tool window exists before showing an InfoBar");
             }
         }

--- a/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
@@ -161,7 +161,12 @@
             element.Advise(this, out var cookie);
             this.cookiesByElement[element] = cookie;
 
-            this.messagesCache.Add(message, element);
+            // Indexer, not Add: the ContainsKey check above and this line both run on the UI thread
+            // inside this same JoinableTaskFactory.Run, but the awaits in between can pump other
+            // messages - a second call for the same text can pass its own ContainsKey check and reach
+            // this line first, in which case Add would throw on the duplicate key. The indexer just
+            // overwrites, so the later call's element replaces the earlier one instead of crashing.
+            this.messagesCache[message] = element;
 
             this.serviceProvider.Package.ToolWindow.AddInfoBar(element);
         });
@@ -192,7 +197,8 @@
             element.Advise(this, out var cookie);
             this.cookiesByElement[element] = cookie;
 
-            this.messagesCache.Add(message, element);
+            // See ShowErrorInfoBar's identical comment above for why this is an indexer, not Add.
+            this.messagesCache[message] = element;
 
             this.serviceProvider.Package.ToolWindow.AddInfoBar(element);
         });

--- a/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
@@ -24,7 +24,12 @@
         private const string KnownCaveatsLink = "https://docs.snyk.io/ide-tools/visual-studio-extension/troubleshooting-and-known-issues-with-visual-studio-extension";
         private readonly ISnykServiceProvider serviceProvider;
 
-        private uint cookie;
+        // Keyed per element, not a single shared field: Advise() returns a cookie scoped to the
+        // specific element it was called on, not a global ID - a single field gets overwritten by
+        // every call, so closing the first of two concurrently displayed InfoBars unadvises with
+        // whatever cookie was written last, silently corrupting the other's advise connection.
+        private readonly IDictionary<IVsInfoBarUIElement, uint> cookiesByElement =
+            new Dictionary<IVsInfoBarUIElement, uint>();
 
         /// <summary>
         /// Cache/save all displayed messages for prevent display same message multiple times.
@@ -50,9 +55,20 @@
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            infoBarUIElement.Unadvise(this.cookie);
+            if (this.cookiesByElement.TryGetValue(infoBarUIElement, out var elementCookie))
+            {
+                infoBarUIElement.Unadvise(elementCookie);
+                this.cookiesByElement.Remove(infoBarUIElement);
+            }
 
-            this.messagesCache.Remove(this.messagesCache.FirstOrDefault(x => x.Value == infoBarUIElement).Key);
+            // FirstOrDefault returns a default KeyValuePair (Key == null) when no match is found, and
+            // Dictionary<string, _>.Remove(null) throws - guard against that instead of assuming a match.
+            var entry = this.messagesCache.FirstOrDefault(x => x.Value == infoBarUIElement);
+
+            if (entry.Key != null)
+            {
+                this.messagesCache.Remove(entry.Key);
+            }
         });
 
         /// <summary>
@@ -116,7 +132,11 @@
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             await this.EnsureToolWindowExistsAsync();
 
-            if (this.serviceProvider.Package.ToolWindow == null || this.messagesCache.ContainsKey(message))
+            // Also check Frame, not just ToolWindow: EnsureInitializeToolWindowAsync assigns ToolWindow
+            // before validating its Frame, and throws (caught above, best-effort) rather than leaving
+            // ToolWindow null when the pane exists but its window frame does not - so ToolWindow alone
+            // being non-null does not mean AddInfoBar below has anywhere to attach to.
+            if (this.serviceProvider.Package.ToolWindow?.Frame == null || this.messagesCache.ContainsKey(message))
                 return;
 
             var text = new InfoBarTextSpan(message);
@@ -131,10 +151,11 @@
 
             var element = factory.CreateInfoBar(infoBarModel);
 
-            element.Advise(this, out this.cookie);
+            element.Advise(this, out var cookie);
+            this.cookiesByElement[element] = cookie;
 
             this.messagesCache.Add(message, element);
-            
+
             this.serviceProvider.Package.ToolWindow.AddInfoBar(element);
         });
 
@@ -147,7 +168,8 @@
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             await this.EnsureToolWindowExistsAsync();
 
-            if (this.serviceProvider.Package.ToolWindow == null || this.messagesCache.ContainsKey(message))
+            // See ShowErrorInfoBar's identical guard above for why Frame != null is checked too.
+            if (this.serviceProvider.Package.ToolWindow?.Frame == null || this.messagesCache.ContainsKey(message))
                 return;
 
             var text = new InfoBarTextSpan(message);
@@ -160,7 +182,8 @@
 
             var element = factory.CreateInfoBar(infoBarModel);
 
-            element.Advise(this, out this.cookie);
+            element.Advise(this, out var cookie);
+            this.cookiesByElement[element] = cookie;
 
             this.messagesCache.Add(message, element);
 

--- a/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
@@ -116,6 +116,18 @@
                 return;
             }
 
+            // Wait for package init to finish before creating the pane, not just for the tool window's
+            // own sake: SnykToolWindow.OnToolWindowCreated wires the pane's event listeners as part of
+            // creation, including SnykScanCommand.Instance.UpdateControlsStateCallback with no null
+            // check. SnykScanCommand.Instance is only set once SnykVSPackage.InitializeAsync reaches
+            // SnykScanCommand.InitializeAsync - which runs after the fire-and-forget language-client
+            // chain that can itself raise an InfoBar (e.g. SnykCliDownloader.ReportInstallFailure) and
+            // land here first. Racing that chain would create the pane with only some of its listeners
+            // wired, and ToolWindow's own null check above means it would stay half-wired for the rest
+            // of the session. SnykVSPackage.PackageInitializedAwaiter completes on every path through
+            // InitializeAsync, including its catch block, so this can't hang if init itself fails.
+            await SnykVSPackage.PackageInitializedAwaiter;
+
             try
             {
                 await this.serviceProvider.Package.EnsureInitializeToolWindowAsync();
@@ -139,11 +151,17 @@
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             await this.EnsureToolWindowExistsAsync();
 
+            // Captured once and reused below, not re-read from the field: ToolWindow can now be reset to
+            // null by a concurrent failing EnsureInitializeToolWindowAsync (e.g. from another call to
+            // this method), and the awaits between here and AddInfoBar below give that a window to run.
+            // A stale local reference held across those awaits can't be nulled out from under us.
+            var toolWindow = this.serviceProvider.Package.ToolWindow;
+
             // Also check Frame, not just ToolWindow: EnsureInitializeToolWindowAsync assigns ToolWindow
             // before validating its Frame, and throws (caught above, best-effort) rather than leaving
             // ToolWindow null when the pane exists but its window frame does not - so ToolWindow alone
             // being non-null does not mean AddInfoBar below has anywhere to attach to.
-            if (this.serviceProvider.Package.ToolWindow?.Frame == null || this.messagesCache.ContainsKey(message))
+            if (toolWindow?.Frame == null || this.messagesCache.ContainsKey(message))
                 return;
 
             var text = new InfoBarTextSpan(message);
@@ -168,7 +186,7 @@
             // overwrites, so the later call's element replaces the earlier one instead of crashing.
             this.messagesCache[message] = element;
 
-            this.serviceProvider.Package.ToolWindow.AddInfoBar(element);
+            toolWindow.AddInfoBar(element);
         });
 
         /// <summary>
@@ -180,8 +198,10 @@
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             await this.EnsureToolWindowExistsAsync();
 
-            // See ShowErrorInfoBar's identical guard above for why Frame != null is checked too.
-            if (this.serviceProvider.Package.ToolWindow?.Frame == null || this.messagesCache.ContainsKey(message))
+            // See ShowErrorInfoBar's identical comments above for why this is captured once and reused.
+            var toolWindow = this.serviceProvider.Package.ToolWindow;
+
+            if (toolWindow?.Frame == null || this.messagesCache.ContainsKey(message))
                 return;
 
             var text = new InfoBarTextSpan(message);
@@ -200,7 +220,7 @@
             // See ShowErrorInfoBar's identical comment above for why this is an indexer, not Add.
             this.messagesCache[message] = element;
 
-            this.serviceProvider.Package.ToolWindow.AddInfoBar(element);
+            toolWindow.AddInfoBar(element);
         });
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
@@ -28,6 +28,13 @@
         // specific element it was called on, not a global ID - a single field gets overwritten by
         // every call, so closing the first of two concurrently displayed InfoBars unadvises with
         // whatever cookie was written last, silently corrupting the other's advise connection.
+        //
+        // Only ever pruned in OnClosed, same as messagesCache below. If the tool window is torn down
+        // (solution close, VS shutdown) without the InfoBar raising OnClosed first, both entries
+        // outlive it for the rest of the session, and the same message text can never be shown again -
+        // closing that would need a teardown hook (e.g. AfterCloseSolution) clearing both dictionaries.
+        // Accepted as-is: the failure mode is a missed message, not a crash or a leak beyond the
+        // session.
         private readonly IDictionary<IVsInfoBarUIElement, uint> cookiesByElement =
             new Dictionary<IVsInfoBarUIElement, uint>();
 
@@ -115,10 +122,11 @@
             }
             catch (Exception e)
             {
-                // Best-effort: the ToolWindow == null check below still applies and no-ops exactly as it
-                // did before this fix if this failed (e.g. during shutdown, before the package is fully
-                // sited - FindToolWindow/the Content cast inside EnsureInitializeToolWindowAsync can
-                // throw various exceptions in those cases, not just NotSupportedException).
+                // Best-effort: the ToolWindow?.Frame == null check below still applies and no-ops
+                // exactly as it did before this fix if this failed (e.g. during shutdown, before the
+                // package is fully sited - FindToolWindow/the Content cast inside
+                // EnsureInitializeToolWindowAsync can throw various exceptions in those cases, not just
+                // NotSupportedException).
                 Logger.Warning(e, "Could not ensure the Snyk tool window exists before showing an InfoBar");
             }
         }

--- a/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
@@ -1,11 +1,13 @@
 ﻿namespace Snyk.VisualStudio.Extension.UI
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
     using Microsoft.VisualStudio.Imaging;
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
+    using Serilog;
     using Snyk.VisualStudio.Extension.Service;
     using Task = System.Threading.Tasks.Task;
 
@@ -14,6 +16,8 @@
     /// </summary>
     public class VsInfoBarService : IVsInfoBarUIEvents
     {
+        private static readonly ILogger Logger = LogManager.ForContext<VsInfoBarService>();
+
         private const string ContactSupport = "contactSupport";
         private const string KnownCaveats = "knownCaveats";
         private const string SupportLink = "https://support.snyk.io/hc/en-us/requests/new";
@@ -75,13 +79,43 @@
             });
 
         /// <summary>
+        /// Ensures the Snyk tool window pane exists (without necessarily showing/focusing it) before an
+        /// InfoBar is attached to it (IDE-2454). ToolWindow stays null until the panel has been created
+        /// at least once - opened by the user, or by a Snyk command running EnsureInitializeToolWindowAsync
+        /// - so without this, any InfoBar shown before that point (e.g. a startup warning or a
+        /// pre-launch gate failure, before the user has ever opened the panel) was silently dropped: the
+        /// early-return check below never became true, and no message reached the user at all.
+        /// </summary>
+        private async Task EnsureToolWindowExistsAsync()
+        {
+            if (this.serviceProvider.Package.ToolWindow != null)
+            {
+                return;
+            }
+
+            try
+            {
+                await this.serviceProvider.Package.EnsureInitializeToolWindowAsync();
+            }
+            catch (Exception e)
+            {
+                // Best-effort: the ToolWindow == null check below still applies and no-ops exactly as it
+                // did before this fix if this failed (e.g. during shutdown, before the package is fully
+                // sited - FindToolWindow/the Content cast inside EnsureInitializeToolWindowAsync can
+                // throw various exceptions in those cases, not just NotSupportedException).
+                Logger.Warning(e, "Could not ensure the Snyk tool window exists before showing an InfoBar");
+            }
+        }
+
+        /// <summary>
         /// Show message in infobar.
         /// </summary>
         /// <param name="message">Message.</param>
         public void ShowErrorInfoBar(string message) => ThreadHelper.JoinableTaskFactory.Run(async () =>
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            
+            await this.EnsureToolWindowExistsAsync();
+
             if (this.serviceProvider.Package.ToolWindow == null || this.messagesCache.ContainsKey(message))
                 return;
 
@@ -111,6 +145,7 @@
         public void ShowInformationInfoBar(string message) => ThreadHelper.JoinableTaskFactory.Run(async () =>
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await this.EnsureToolWindowExistsAsync();
 
             if (this.serviceProvider.Package.ToolWindow == null || this.messagesCache.ContainsKey(message))
                 return;

--- a/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Notifications/VsInfoBarService.cs
@@ -7,6 +7,7 @@
     using Microsoft.VisualStudio.Imaging;
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
+    using Microsoft.VisualStudio.Threading;
     using Serilog;
     using Snyk.VisualStudio.Extension.Service;
     using Task = System.Threading.Tasks.Task;
@@ -148,7 +149,10 @@
         /// Show message in infobar.
         /// </summary>
         /// <param name="message">Message.</param>
-        public void ShowErrorInfoBar(string message) => ThreadHelper.JoinableTaskFactory.Run(async () =>
+        // RunAsync + FireAndForget, not the blocking Run: this is a void method nothing awaits, and
+        // EnsureToolWindowExistsAsync below can now wait up to PackageInitWaitTimeoutMs - a blocking
+        // Run would tie up the caller's thread (often the UI thread) for that whole wait.
+        public void ShowErrorInfoBar(string message) => ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             await this.EnsureToolWindowExistsAsync();
@@ -176,21 +180,22 @@
             element.Advise(this, out var cookie);
             this.cookiesByElement[element] = cookie;
 
-            // Indexer, not Add: the ContainsKey check above and this line both run on the UI thread
-            // inside this same JoinableTaskFactory.Run, but the awaits in between can pump other
-            // messages - a second call for the same text can pass its own ContainsKey check and reach
-            // this line first, in which case Add would throw on the duplicate key. The indexer just
-            // overwrites, so the later call's element replaces the earlier one instead of crashing.
+            // Indexer, not Add: the ContainsKey check above and this line both run on the UI thread, but
+            // the awaits in between can pump other messages - a second call for the same text can pass
+            // its own ContainsKey check and reach this line first, in which case Add would throw on the
+            // duplicate key. The indexer just overwrites, so the later call's element replaces the
+            // earlier one instead of crashing.
             this.messagesCache[message] = element;
 
             toolWindow.AddInfoBar(element);
-        });
+        }).FireAndForget();
 
         /// <summary>
         /// Show message in infobar.
         /// </summary>
         /// <param name="message">Message.</param>
-        public void ShowInformationInfoBar(string message) => ThreadHelper.JoinableTaskFactory.Run(async () =>
+        // See ShowErrorInfoBar's identical comment above for why this is RunAsync + FireAndForget.
+        public void ShowInformationInfoBar(string message) => ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             await this.EnsureToolWindowExistsAsync();
@@ -218,6 +223,6 @@
             this.messagesCache[message] = element;
 
             toolWindow.AddInfoBar(element);
-        });
+        }).FireAndForget();
     }
 }


### PR DESCRIPTION
### Description

Follow-up from [IDE-2404](https://snyksec.atlassian.net/browse/IDE-2404)'s code review, filed as its own ticket ([IDE-2454](https://snyksec.atlassian.net/browse/IDE-2454)) and PR since it's independent of that branch's own gate work - lands first, that PR's own narrow copy of this fix gets reverted once this one is in.

`VsInfoBarService.ShowErrorInfoBar`/`ShowInformationInfoBar` attach the info-bar element to `SnykVSPackage.ToolWindow`, which is `null` until the Snyk panel has been created at least once (opened by the user, or via a Snyk command running `EnsureInitializeToolWindowAsync`). If neither happened, the call is a silent no-op - no exception, no fallback, no feedback to the user at all.

Pre-existing call sites with this gap:
- `SnykVSPackage.WarnIfWebView2RuntimeMissingAsync`
- `SnykCliDownloader.ReportInstallFailure` (via `NotificationService.Instance?.ShowErrorInfoBar`)
- IDE-2404's own new pre-launch gate messages (fixed there narrowly first, since it landed before this ticket existed)

Fixed at the shared choke point instead: both InfoBar methods now call `EnsureInitializeToolWindowAsync` first, covering every caller. Also widened the exception handling around that call from `NotSupportedException` only to a catch-all with logging - `FindToolWindow`/the `Content` cast can throw other things (e.g. during shutdown, before the package is fully sited).

### Testing

- Manual reasoning only - no test harness currently exercises `VsInfoBarService` directly (it's a thin wrapper over VS's `IVsInfoBarUIFactory`/`IVsWindowFrame` APIs, not mocked in this repo's test suite).
- Verified via code inspection that `EnsureInitializeToolWindowAsync`'s existing usage in `AbstractSnykCommand.Execute` follows the identical pattern already in production.

### Checklist

- [x] Read and understood the Code of Conduct and Contributing Guidelines.
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing


[IDE-2404]: https://snyksec.atlassian.net/browse/IDE-2404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2454]: https://snyksec.atlassian.net/browse/IDE-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ