### PR TITLE
fix: VS 2026 detection and webview command allowlist [IDE-2456] [IDE-2458]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
+++ b/Snyk.VisualStudio.Extension.2022/SnykVSPackage.cs
@@ -74,6 +74,8 @@ namespace Snyk.VisualStudio.Extension
         /// </summary>
         public const string PackageGuidString = "5ddf9abb-42ec-49b9-b201-b3e2fc2f8f89";
 
+        private const string UnknownVsVersion = "Unknown Visual Studio version";
+
         private static readonly ILogger Logger = LogManager.ForContext<SnykVSPackage>();
 
         private static readonly TaskCompletionSource<bool> initializationTaskCompletionSource =
@@ -543,21 +545,34 @@ namespace Snyk.VisualStudio.Extension
             try
             {
                 var vsVersionString = await GetVsVersionAsync();
-                var major = vsVersionString.Split('.').FirstOrDefault();
 
-                return major switch
-                {
-                    "17" => "Visual Studio 2022",
-                    "16" => "Visual Studio 2019",
-                    "15" => "Visual Studio 2017",
-                    "14" => "Visual Studio 2015",
-                    _ => "Unknown Visual Studio version"
-                };
+                return ToReadableVsVersion(vsVersionString.Split('.').FirstOrDefault());
             }
             catch
             {
-                return "Unknown Visual Studio version";
+                return UnknownVsVersion;
             }
+        }
+
+        // The name this returns is not cosmetic: it is sent as the IDE name, and the Language Server
+        // derives its config storage filename from it. A major that maps to a different string than it
+        // did previously therefore reads an orphaned config file — no trusted folders and no auth
+        // token. Every shipping major needs an explicit entry: anything unmapped shares the single
+        // unknown bucket, so a new Visual Studio release must be added here rather than left to fall
+        // through to it.
+        //
+        // internal static for testability (InternalsVisibleTo): pure mapping, no VS shell access.
+        internal static string ToReadableVsVersion(string major)
+        {
+            return major switch
+            {
+                "18" => "Visual Studio 2026",
+                "17" => "Visual Studio 2022",
+                "16" => "Visual Studio 2019",
+                "15" => "Visual Studio 2017",
+                "14" => "Visual Studio 2015",
+                _ => UnknownVsVersion
+            };
         }
     }
 }

--- a/Snyk.VisualStudio.Extension.2022/UI/Html/ExecuteCommandBridge.cs
+++ b/Snyk.VisualStudio.Extension.2022/UI/Html/ExecuteCommandBridge.cs
@@ -56,12 +56,15 @@ namespace Snyk.VisualStudio.Extension.UI.Html
         // command is rejected and logged in DispatchAsync.
         private static readonly HashSet<string> AllowedCommands = new HashSet<string>(StringComparer.Ordinal)
         {
+            "snyk.dismissFeedbackBanner",
+            "snyk.feedbackBannerInteracted",
             "snyk.login",
             "snyk.logout",
             "snyk.navigateToRange",
             "snyk.setNodeExpanded",
             "snyk.showScanErrorDetails",
             "snyk.toggleTreeFilter",
+            "snyk.trustWorkspaceFolders",
             "snyk.updateFolderConfig",
         };
 

--- a/Snyk.VisualStudio.Extension.Tests/SnykVSPackageVsVersionTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/SnykVSPackageVsVersionTests.cs
@@ -1,0 +1,48 @@
+using Xunit;
+
+namespace Snyk.VisualStudio.Extension.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="SnykVSPackage.ToReadableVsVersion"/>, the pure mapping from a
+    /// Visual Studio major version to the IDE name reported to the Language Server.
+    ///
+    /// The Language Server derives its config storage filename from that name, so an unmapped major
+    /// falls back to the shared unknown bucket and reads an orphaned config — losing trusted folders
+    /// and the auth token. These tests pin the mapping for every major the plugin supports.
+    /// </summary>
+    public class SnykVSPackageVsVersionTests
+    {
+        [Theory]
+        [InlineData("18", "Visual Studio 2026")]
+        [InlineData("17", "Visual Studio 2022")]
+        [InlineData("16", "Visual Studio 2019")]
+        [InlineData("15", "Visual Studio 2017")]
+        [InlineData("14", "Visual Studio 2015")]
+        public void ToReadableVsVersion_MapsSupportedMajorsToTheirProductName(string major, string expected)
+        {
+            Assert.Equal(expected, SnykVSPackage.ToReadableVsVersion(major));
+        }
+
+        [Theory]
+        [InlineData("19")]      // a VS release newer than any mapped here
+        [InlineData("13")]      // older than any mapped here
+        [InlineData("0")]       // GetVsVersionAsync's failure sentinel is "0.0.0"
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("nonsense")]
+        public void ToReadableVsVersion_FallsBackToUnknownForUnmappedMajors(string major)
+        {
+            Assert.Equal("Unknown Visual Studio version", SnykVSPackage.ToReadableVsVersion(major));
+        }
+
+        [Fact]
+        public void ToReadableVsVersion_DistinguishesVs2026FromVs2022()
+        {
+            // The two must not collide: sharing a name means sharing one stored config, which is how
+            // an upgrade silently inherits (or loses) the other release's trusted folders and token.
+            Assert.NotEqual(
+                SnykVSPackage.ToReadableVsVersion("17"),
+                SnykVSPackage.ToReadableVsVersion("18"));
+        }
+    }
+}

--- a/Snyk.VisualStudio.Extension.Tests/UI/Html/ExecuteCommandBridgeTest.cs
+++ b/Snyk.VisualStudio.Extension.Tests/UI/Html/ExecuteCommandBridgeTest.cs
@@ -78,6 +78,11 @@ namespace Snyk.VisualStudio.Extension.Tests.UI.Html
         [InlineData("snyk.showScanErrorDetails", true)]
         [InlineData("snyk.toggleTreeFilter", true)]
         [InlineData("snyk.updateFolderConfig", true)]
+        // Dispatched by the HTML issue tree view; an omission here makes the corresponding control
+        // silently inert, since DispatchAsync drops a disallowed command with only a warning.
+        [InlineData("snyk.trustWorkspaceFolders", true)]
+        [InlineData("snyk.feedbackBannerInteracted", true)]
+        [InlineData("snyk.dismissFeedbackBanner", true)]
         // Not on the allowlist — a snyk.* prefix is no longer sufficient.
         [InlineData("snyk.anyCommand", false)]
         [InlineData("snyk.clearCache", false)]


### PR DESCRIPTION
### Description

Two independent VS 2026 defects found while migrating from VS 2022 with the latest main preview plugin. They compounded each other: the config loss raised a folder-trust prompt, and the allowlist gap meant that prompt could not be actioned — leaving the user unauthenticated, untrusted, and unable to fix either from the UI.

#### [IDE-2456] "Trust folder" button in the HTML tree view did nothing

The webview command allowlist omitted three commands the LS-served HTML issue tree view dispatches:

| Command | Was allowed |
| --- | --- |
| `snyk.trustWorkspaceFolders` | No |
| `snyk.feedbackBannerInteracted` | No |
| `snyk.dismissFeedbackBanner` | No — latent, not yet exercised |

`DispatchAsync` drops an unlisted command after a single `Logger.Warning`, so the button was inert with nothing surfaced to the user and the folder could never be trusted from the tree view — hence never scanned.

The bridge itself was fine: the click reached the host and was rejected there, not lost in JS. All three commands are already implemented server-side, so only the allowlist needed the entries.

#### [IDE-2458] VS 2026 reported as "Unknown Visual Studio version"

The version mapping stopped at major 17, so VS 2026 (major 18) fell through to the unknown bucket. That string is sent as the IDE name and the Language Server derives its config storage filename from it, so VS 2026 looked for a file that had never been written and started from an empty config — **no trusted folders and no auth token**:

```
ERR initializeHandler - unable to load folderConfig
  error="open ...\snyk\ls-config-Unknown Visual Studio version: The system cannot find the file specified."
INF - IDE: Unknown Visual Studio version/18.8
INF IsAuthenticated - no credentials found
```

Adds the major 18 entry and extracts the mapping into an `internal static` seam so the majors are pinned by unit tests instead of being reachable only through the VS shell.

### Known gap (deliberate)

This fixes detection going forward but does **not** migrate the config written under the previous IDE name, so anyone already on the VS 2026 preview still re-authenticates and re-trusts once. The fallback read belongs in the Language Server, which owns the filename; tracked on IDE-2458 rather than worked around here.

### Testing

Unit tests added for both fixes:

- `ExecuteCommandBridgeTest` — the three previously-missing commands are now allowlisted, existing negative cases (`snyk.anyCommand`, non-`snyk.*`) still rejected.
- `SnykVSPackageVsVersionTests` (new) — pins every supported major to its product name, asserts unmapped majors and the `"0.0.0"` failure sentinel fall back to unknown, and asserts VS 2026 and VS 2022 do not collide on one name.

> [!IMPORTANT]
> **I could not build or run these tests.** The projects target `net48` and the .NET Framework reference assemblies are unavailable on macOS (`MSB3644`), so compilation is unverified — please confirm the build and test run on Windows CI before review.

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CONTRIBUTING.md).
- [x] Tests added — **not yet run locally, see note above**
- [ ] Linted
- [x] README.md updated, if user-facing — n/a, no user-facing docs change

### Screenshots / GIFs

_Not captured — the repro needs a VS 2026 install; behaviour is evidenced by the log excerpts above and in the linked tickets._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[IDE-2456]: https://snyksec.atlassian.net/browse/IDE-2456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2458]: https://snyksec.atlassian.net/browse/IDE-2458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ