### PR TITLE
feat: declare support for Visual Studio 2026 (major 18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Visual Studio extension
 
 
-Visual Studio 2026 not supported.
-
-
 ## Scan early, fix as you develop: elevate your security posture
 
 Integrating security checks early in your development lifecycle helps you pass security reviews seamlessly and avoid expensive fixes down the line.
@@ -19,6 +16,8 @@ The Snyk Visual Studio extension allows you to analyze your code, infrastructure
 * **Broad language and framework support**: Snyk Open Source and Snyk Code cover a wide array of package managers, programming languages, and frameworks, with ongoing updates to support the latest technologies. For the most up-to-date information on supported languages, package managers, and frameworks, see the [supported language technologies pages](https://docs.snyk.io/supported-languages-package-managers-and-frameworks).
 
 ## How to install and set up the extension
+
+Supported versions of Visual Studio: 2022 and 2026.
 
 **Note**: For information about the versions of Visual Studio supported by the Visual Studio extension, see [Snyk IDE plugins and extensions](https://docs.snyk.io/scm-ide-and-ci-cd-integrations/snyk-ide-plugins-and-extensions). Snyk recommends always using the latest version of the Visual Studio extension.
 

--- a/Snyk.VisualStudio.Extension.2022/README.md
+++ b/Snyk.VisualStudio.Extension.2022/README.md
@@ -9,7 +9,7 @@ Snyk Security extension helps you find and fix security vulnerabilities in your 
 #### 1. Software requirements
 
 - Operating system - Windows.
-- Supported versions of Visual Studio: 2015, 2017, 2019. Compatible with Community, Professional and Enterprise.
+- Supported versions of Visual Studio: 2022 and 2026. Compatible with Community, Professional and Enterprise.
 
 #### 2. How to install the extension?
 

--- a/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
+++ b/Snyk.VisualStudio.Extension.2022/source.extension.vsixmanifest
@@ -13,10 +13,10 @@
         <Preview>false</Preview>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,19.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+        <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Community">
             <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
     </Installation>
@@ -24,7 +24,7 @@
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,19.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
### Description

Makes Visual Studio 2026 support explicit.

VS 2026 force-allows VS 2022 extensions to install regardless of the range an extension declares, so **the extension already installed and ran on 2026** — the `[17.0,18.0)` bound was never an install gate. What was missing was any explicit statement of support: the manifest declared 17.x only, and the root README said outright that 2026 was not supported.

This widens the three manifest ranges to `[17.0,19.0)` so 17.x and 18.x are *declared* targets, rather than 18.x depending on the host's compatibility allowance. The next major still requires a deliberate bump.

Supported set is now **Visual Studio 2022 and 2026**.

#### Changes

| File | Change |
| --- | --- |
| `source.extension.vsixmanifest` | `[17.0,18.0)` → `[17.0,19.0)` ×3 — 2 `InstallationTarget` (amd64, arm64) and 1 `Prerequisite` |
| `README.md` | Removed "Visual Studio 2026 not supported."; states the supported set in the install section, beside the existing note on the same topic |
| `Snyk.VisualStudio.Extension.2022/README.md` | Requirements list said 2015, 2017, 2019 → 2022 and 2026 |

All three are declarative — manifest metadata and docs. No code changes, and no behavioural change for 2022.

Note the second README was **already wrong** before this PR: it claimed 2015/2017/2019, none of which the long-standing `17.0` floor admits. Corrected to match reality rather than narrowing support.

### Relationship to #540

Because 2022 extensions were already being force-allowed onto 2026, users have already been running there — and therefore already hitting the unknown-IDE config path that #540 fixes (VS 2026 reported as "Unknown Visual Studio version", losing trusted folders and the auth token, IDE-2458). That was a live problem, not a hypothetical one.

`main` already includes #540, so this branch carries the fix. Worth keeping them together in the same release: this PR invites users to 2026 explicitly, and #540 is what makes that a working experience.

### Testing

> [!IMPORTANT]
> **Not built, and not verified on VS 2026.** The projects target `net48` and the .NET Framework reference assemblies are unavailable on macOS (`MSB3644`), so I could not compile. No automated test covers the manifest range.

Since 2026 already worked via the host's compatibility allowance, the risk here is the *transition* from implicitly-allowed to explicitly-targeted, plus any regression on 2022. Please confirm before merge:

- Installs and loads on **VS 2026 (18.x)** as an explicitly targeted host, on both amd64 and arm64 — i.e. no worse than the force-allowed path it replaces.
- Still installs and loads on **VS 2022 (17.x)**; the lower bound is unchanged, but the edit touches the 17.x path too.
- Marketplace listing still resolves for both hosts.

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CONTRIBUTING.md).
- [ ] Tests added and all succeed — n/a, manifest metadata and docs; **nothing built locally**
- [ ] Linted
- [x] README.md updated, if user-facing — both READMEs updated

### Screenshots / GIFs

_Not captured — needs a VS 2026 install to demonstrate._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
