### PR TITLE
fix(security): mention configuration-based risk in trust prompt [IDE-2137]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/MessagePanel.xaml
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/MessagePanel.xaml
@@ -58,7 +58,7 @@
                         3. Improve your code and upgrade dependencies
                     </TextBlock>
                     <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Width="550">
-                        When scanning project files, Snyk may automatically execute code, such as invoking the package manager to get dependency information, and will honor any Snyk configuration checked into the project (for example, additional CLI parameters). A malicious project could use this configuration to run arbitrary code. You should only scan projects you trust.
+                        When scanning project files, Snyk may automatically execute code, such as invoking the package manager to get dependency information, and honors any Snyk configuration checked into the project, such as additional CLI parameters passed to the Snyk CLI as-is. A malicious project could use this configuration to run arbitrary code. You should only scan projects you trust.
                         <Hyperlink NavigateUri="https://docs.snyk.io/ide-tools/visual-studio-extension/workspace-trust" RequestNavigate="Hyperlink_RequestNavigate">
                             More info
                         </Hyperlink>

--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/MessagePanel.xaml
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/MessagePanel.xaml
@@ -58,7 +58,7 @@
                         3. Improve your code and upgrade dependencies
                     </TextBlock>
                     <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Width="550">
-                        When scanning project files, Snyk may automatically execute code such as invoking the package manager to get dependency information. You should only scan projects you trust.
+                        When scanning project files, Snyk may automatically execute code, such as invoking the package manager to get dependency information, and will honor any Snyk configuration checked into the project (for example, additional CLI parameters). A malicious project could use this configuration to run arbitrary code. You should only scan projects you trust.
                         <Hyperlink NavigateUri="https://docs.snyk.io/ide-tools/visual-studio-extension/workspace-trust" RequestNavigate="Hyperlink_RequestNavigate">
                             More info
                         </Hyperlink>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Addresses [IDE-2137](https://snyksec.atlassian.net/browse/IDE-2137) ("Command injection via `window` scoped `additionalParameters`").

The reported issue is that the VS Code plugin's `snyk.advanced.additionalParameters` setting is `window`-scoped, so it can be set from a repository-checked-in `.vscode/settings.json` and is forwarded to the Snyk CLI as-is. Since CLI parameters (e.g. the Python extension's `--command`) can point at arbitrary executables/files, a crafted repository can silently inject malicious CLI parameters once a user grants folder trust. Per the triage notes on the ticket, the agreed first mitigation across all IDEs is to update the workspace-trust prompt wording, since none of the current prompts mention configuration-based risk (they only warn about code execution via package managers).

This repo (`snyk-visual-studio-plugin`) does not itself read repo-checked-in settings for folder-scoped `AdditionalParameters` — that state is pushed to the extension entirely by the Language Server (`snyk-ls` is the source of truth here, see `SnykOptionsManager.cs`). So the actionable, in-scope fix here is the wording of the trust prompt shown before a user trusts a folder and triggers a scan (`MessagePanel.xaml`, the "Trust project and scan" welcome screen).

**Old copy:**
> When scanning project files, Snyk may automatically execute code such as invoking the package manager to get dependency information. You should only scan projects you trust.

**New copy:**
> When scanning project files, Snyk may automatically execute code, such as invoking the package manager to get dependency information, and honors any Snyk configuration checked into the project, such as additional CLI parameters passed to the Snyk CLI as-is. A malicious project could use this configuration to run arbitrary code. You should only scan projects you trust.

### Known limitation / follow-up needed elsewhere

An independent review pass on this change flagged that this XAML-based prompt is only shown to a user before their first authentication (`SnykToolWindowControl.DetermineInitScreen`); an already-authenticated user opening a new/untrusted repo instead lands on the Language Server-rendered "untrusted folder" prompt in the HTML tree view (`trust_enabled=true` delegates that gate to `snyk-ls`). That LS-owned prompt copy lives outside this repo and is the higher-traffic surface for the scenario in this ticket — it should get the equivalent wording update in `snyk-ls` (this matches the "LS (all IDEs) — canonical dialog" item already called out in Ben Durrans' trust-prompt inventory on the ticket).

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CONTRIBUTING.md).
- [ ] Tests added and all succeed — no test asserted on the old copy; this is a copy-only change with no test coverage gap introduced.
- [ ] Linted
- [ ] README.md updated, if user-facing — not applicable (in-app dialog copy only).

### Screenshots / GIFs

Not captured (Windows/Visual Studio WPF build tooling is unavailable in this sandbox); the XAML was validated as well-formed XML and the affected `TextBlock` sits in a `ScrollViewer` already designed to accommodate longer trust-prompt text.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-773e4282-05b3-4241-b4a5-f61d7cb25c2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-773e4282-05b3-4241-b4a5-f61d7cb25c2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[IDE-2137]: https://snyksec.atlassian.net/browse/IDE-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ