### PR TITLE
fix: mention configuration in trust prompt text [IDE-2137]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/MessagePanel.xaml
+++ b/Snyk.VisualStudio.Extension.2022/UI/Toolwindow/MessagePanel.xaml
@@ -58,7 +58,7 @@
                         3. Improve your code and upgrade dependencies
                     </TextBlock>
                     <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Width="550">
-                        When scanning project files, Snyk may automatically execute code such as invoking the package manager to get dependency information. You should only scan projects you trust.
+                        When scanning project files, Snyk may automatically execute code and configuration, such as invoking the package manager to get dependency information. You should only scan projects you trust.
                         <Hyperlink NavigateUri="https://docs.snyk.io/ide-tools/visual-studio-extension/workspace-trust" RequestNavigate="Hyperlink_RequestNavigate">
                             More info
                         </Hyperlink>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Updates `MessagePanel.xaml` trust-and-scan panel text to mention **code and configuration** (IDE-2137).

Uses the simpler cross-IDE wording rather than the longer text from closed PR #543 (`cursor/fix-trust-prompt-wording-5c2e`).

### Verification

Visual Studio not available on Linux cloud VM — wording verified in source only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65cca110-0855-4ba7-bc5b-09755cc083f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65cca110-0855-4ba7-bc5b-09755cc083f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

