### PR TITLE
chore: block accidental private-repo mentions via pre-commit hooks [IDE-2517]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+default_install_hook_types: [pre-commit, pre-merge-commit, commit-msg, pre-push]
 repos:
   - repo: https://github.com/gitguardian/ggshield
     rev: v1.43.0
@@ -7,3 +8,20 @@ repos:
       - id: ggshield
         language_version: python3
         stages: [pre-commit]
+  - repo: local
+    hooks:
+      - id: check-internal-repo-mentions-diff
+        name: Check commit diff for private repo mentions
+        entry: scripts/check-internal-repo-mentions-diff.sh
+        language: script
+        stages: [pre-commit, pre-merge-commit]
+      - id: check-internal-repo-mentions-msg
+        name: Check commit message for private repo mentions
+        entry: scripts/check-internal-repo-mentions-msg.sh
+        language: script
+        stages: [commit-msg]
+      - id: check-internal-repo-mentions-push
+        name: Check push for private repo mentions
+        entry: scripts/check-internal-repo-mentions-push.sh
+        language: script
+        stages: [pre-push]

--- a/scripts/check-internal-repo-mentions-diff.sh
+++ b/scripts/check-internal-repo-mentions-diff.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# pre-commit stage: block committing a mention of a private snyk/<repo> in the staged diff.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/repo-privacy-check.sh
+source "$SCRIPT_DIR/lib/repo-privacy-check.sh"
+
+added_lines=$(git diff --cached -U0 --text --no-color -- "$@" | extract_added_lines || true)
+slugs=$(printf '%s\n' "$added_lines" | extract_repo_slugs || true)
+
+[[ -z "$slugs" ]] && exit 0
+
+enforce_no_private_mentions "commit diff" "$slugs" "warn"

--- a/scripts/check-internal-repo-mentions-msg.sh
+++ b/scripts/check-internal-repo-mentions-msg.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# commit-msg stage: block committing a mention of a private snyk/<repo> in the commit message.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/repo-privacy-check.sh
+source "$SCRIPT_DIR/lib/repo-privacy-check.sh"
+
+msg_file="$1"
+slugs=$(extract_repo_slugs < "$msg_file" || true)
+
+[[ -z "$slugs" ]] && exit 0
+
+enforce_no_private_mentions "commit message" "$slugs" "warn"

--- a/scripts/check-internal-repo-mentions-push.sh
+++ b/scripts/check-internal-repo-mentions-push.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# pre-push stage: block pushing a mention of a private snyk/<repo>.
+# Network is required to push at all, so unlike the commit-time checks, a gh
+# error here blocks rather than warns.
+#
+# pre-commit exposes the push range as PRE_COMMIT_FROM_REF/PRE_COMMIT_TO_REF
+# (it consumes the raw git pre-push stdin protocol itself) and passes the
+# changed files as args, same as the other stages.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/repo-privacy-check.sh
+source "$SCRIPT_DIR/lib/repo-privacy-check.sh"
+
+if [[ -n "${PRE_COMMIT_FROM_REF:-}" && -n "${PRE_COMMIT_TO_REF:-}" ]]; then
+  added_lines=$(git diff -U0 --text --no-color "$PRE_COMMIT_FROM_REF" "$PRE_COMMIT_TO_REF" -- "$@" | extract_added_lines || true)
+  messages=$(git log --format=%B "$PRE_COMMIT_FROM_REF..$PRE_COMMIT_TO_REF" || true)
+else
+  # Initial push of a whole new history: pre-commit never sets PRE_COMMIT_TO_REF on this
+  # path (confirmed against pre-commit 4.6.2 source), so read each pushed file's content
+  # from PRE_COMMIT_LOCAL_BRANCH -- the ref actually being pushed, which pre-commit does
+  # export here -- rather than HEAD, which is wrong whenever the pushed branch isn't the
+  # one currently checked out.
+  to_ref="${PRE_COMMIT_LOCAL_BRANCH:-HEAD}"
+  added_lines=""
+  for f in "$@"; do
+    added_lines+=$'\n'"$(git show "$to_ref:$f" 2>/dev/null || true)"
+  done
+  messages=$(git log --format=%B "$to_ref" || true)
+fi
+
+slugs=$(printf '%s\n%s\n' "$added_lines" "$messages" | extract_repo_slugs || true)
+
+[[ -z "$slugs" ]] && exit 0
+
+enforce_no_private_mentions "push" "$slugs" "block"

--- a/scripts/lib/repo-privacy-check.sh
+++ b/scripts/lib/repo-privacy-check.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Shared helpers for the internal-repo-mention hooks (pre-commit / commit-msg / pre-push).
+set -euo pipefail
+
+# Repos it's already fine to mention by name, either because they're public,
+# or because they're private but already named publicly.
+ALLOWED_REPOS=(
+  # Private, but already named publicly in cli's cliv2-private/go.mod dependency list.
+  "snyk/ambient-canary"
+  "snyk/cli-extension-axi"
+  "snyk/cli-extension-cos"
+  "snyk/remy-cli-extension"
+  "snyk/rift-cli-extension"
+
+  # Public: snyk/cli itself, plus its extensions/dependencies (from cli's go.mod).
+  "snyk/cli"
+  "snyk/cli-extension-agent-scan"
+  "snyk/cli-extension-ai-bom"
+  "snyk/cli-extension-dep-graph"
+  "snyk/cli-extension-iac"
+  "snyk/cli-extension-iac-rules"
+  "snyk/cli-extension-os-flows"
+  "snyk/cli-extension-sbom"
+  "snyk/cli-extension-secrets"
+  "snyk/code-client-go"
+  "snyk/container-cli"
+  "snyk/dep-graph"
+  "snyk/error-catalog-golang-public"
+  "snyk/go-application-framework"
+  "snyk/go-httpauth"
+  "snyk/policy-engine"
+  "snyk/snyk-iac-capture"
+  "snyk/snyk-ls"
+  "snyk/studio-mcp"
+
+  # Public: Snyk's own IDE repos.
+  "snyk/snyk-eclipse-plugin"
+  "snyk/snyk-intellij-plugin"
+  "snyk/snyk-visual-studio-plugin"
+  "snyk/vscode-extension"
+)
+
+is_allowed_repo() {
+  local slug="$1" r
+  for r in "${ALLOWED_REPOS[@]}"; do
+    [[ "$slug" == "$r" ]] && return 0
+  done
+  return 1
+}
+
+extract_repo_slugs() {
+  grep -aohE 'snyk/[A-Za-z0-9._-]+' | sed -E 's/[.]+$//; s/\.git$//' | sort -u
+}
+
+# Prints only added lines (excluding the "+++ b/path" file-header line) from a unified diff on stdin.
+extract_added_lines() {
+  grep -E '^\+' | grep -vE '^\+\+\+ '
+}
+
+# check_slug SLUG ON_GH_ERROR
+# ON_GH_ERROR is "warn" (don't block, just print a warning) or "block".
+# Returns 0 (pass) unless the repo is confirmed private, or a non-404 gh error occurs with ON_GH_ERROR=block.
+check_slug() {
+  local slug="$1" on_gh_error="$2" private_status gh_err
+
+  gh_err=$(mktemp)
+  if private_status=$(gh api "repos/$slug" --jq '.private' 2>"$gh_err"); then
+    rm -f "$gh_err"
+    if [[ "$private_status" == "true" ]]; then
+      echo "BLOCKED: $slug is a private repo." >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  if grep -qi '404' "$gh_err"; then
+    rm -f "$gh_err"
+    return 0 # repo doesn't exist -> not a real hit
+  fi
+
+  local err_msg
+  err_msg=$(cat "$gh_err")
+  rm -f "$gh_err"
+
+  if [[ "$on_gh_error" == "block" ]]; then
+    echo "BLOCKED: could not verify visibility of $slug via gh: $err_msg" >&2
+    return 1
+  fi
+
+  echo "WARNING: could not verify visibility of $slug via gh (continuing): $err_msg" >&2
+  return 0
+}
+
+# enforce_no_private_mentions CONTEXT_LABEL SLUGS ON_GH_ERROR
+enforce_no_private_mentions() {
+  local context="$1" slugs="$2" on_gh_error="$3" slug blocked=0
+
+  for slug in $slugs; do
+    is_allowed_repo "$slug" && continue
+    check_slug "$slug" "$on_gh_error" || blocked=1
+  done
+
+  if [[ "$blocked" == "1" ]]; then
+    echo "Private repo mention found in $context. Remove it or add it to ALLOWED_REPOS in scripts/lib/repo-privacy-check.sh if it's already safe to name." >&2
+    return 1
+  fi
+  return 0
+}


### PR DESCRIPTION
### Description

Adds three pre-commit-framework hooks (`pre-commit`/`pre-merge-commit`, `commit-msg`, `pre-push`) that block a commit/push naming a private `snyk/<repo>` by name, unless it's in the `ALLOWED_REPOS` allowlist in `scripts/lib/repo-privacy-check.sh`. Repo visibility is checked live via `gh api repos/<slug> --jq .private`. Commit-time `gh` errors warn only (offline-friendly); push-time `gh` errors block, since push already requires network.

Also adds `default_install_hook_types` so a plain `pre-commit install` wires up all four stages.

Same change as snyk-eclipse-plugin ([#453](https://github.com/snyk/snyk-eclipse-plugin/pull/453)), which merged first. No automated test suite exists for these scripts; the underlying logic was manually verified there.

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/snyk-visual-studio-plugin/blob/main/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

N/A — no UI change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-workflow guardrails only; no runtime product or auth changes, though pushes can fail if `gh` is misconfigured.
> 
> **Overview**
> Adds **local pre-commit hooks** that scan staged diffs, commit messages, and outgoing pushes for `snyk/<repo>` strings and **block** when GitHub confirms the repo is private (with an **allowlist** for repos already safe to name).
> 
> **`.pre-commit-config.yaml`** now sets `default_install_hook_types` so `pre-commit install` registers **pre-commit**, **pre-merge-commit**, **commit-msg**, and **pre-push**, and wires three new script hooks alongside existing **ggshield**.
> 
> Shared logic in `scripts/lib/repo-privacy-check.sh` uses **`gh api`** for live visibility checks: commit-time hooks **warn** on `gh` failures (offline-friendly); **pre-push** **blocks** on verification errors since network is already required. The push hook handles both normal push ranges and initial pushes via `PRE_COMMIT_LOCAL_BRANCH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb4e44ad5c14ca34f1236677ca37eb88437446a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->