### PR TITLE
docs: document driving the Windows dev VM via prlctl from macOS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,17 @@ vstest.console.exe **\bin\**\*Integration.Tests.dll
 
 The documented local workflow is opening `snyk-visual-studio-plugin.sln` in Visual Studio 2022 and using Build/Test Explorer directly. Tests use xUnit with Moq for mocking.
 
+### macOS development
+
+If working from macOS, commands can be run directly inside the Windows dev VM via `prlctl exec "<VM name>" <args...>`.
+N.b.:
+- Pass args separately, not as one quoted string.
+- Find your VM's exact name via `prlctl list -a` (`Windows 11` is Parallels' default).
+- By default this runs as `NT AUTHORITY\SYSTEM`; add `--current-user` right after the VM name to run as the logged-in user instead (needed for anything user-context-sensitive, e.g. registry reads).
+- Keep the console window hidden by default, unless it makes sense to show it for the task. Run via `powershell.exe -WindowStyle Hidden -Command '...'` (single-quoted in Bash). `-WindowStyle Hidden` hides the window shortly *after* it spawns, not before, so a brief flash on each call is normal.
+- The Mac's home directory is *usually* reachable from inside the VM as one of `Z:\`, `\\psf\Home`, `\\Mac\Home`, or `C:\Mac\Home`. Not every VM has all of these mapped, so verify with `net use` / `Test-Path` before relying on one. `C:\Users\<user>\Documents` is a separate, local, usually-empty folder, even though Windows' Documents *shell folder* may be redirected there for interactive use.
+- For anything beyond a trivial one-liner, write the PowerShell to a `.ps1` file (e.g. under one of the shared-folder paths above, so both host and guest can read/write it) and run it with `powershell.exe -WindowStyle Hidden -ExecutionPolicy Bypass -File "..."` instead. Complex inline `-Command` strings (nested quotes, `$_`, operators) commonly come out mangled through the exec layer.
+
 ## Architecture
 
 Main project: `Snyk.VisualStudio.Extension.2022/` (root namespace `Snyk.VisualStudio.Extension`), organized by feature folder:


### PR DESCRIPTION
### Description

Documents how to drive commands inside the team's Parallels Windows dev VM from macOS via `prlctl exec`, learned this session while debugging IDE-2548: VM naming (`prlctl list -a`), `--current-user` for anything user-context-sensitive, keeping the console window hidden by default, falling back to a `.ps1` file for non-trivial PowerShell (inline `-Command` strings get mangled through the exec layer), and the Mac-home-directory path aliases reachable from inside the VM.

Docs-only, no code changes. Not stacked on the IDE-2548 fix branch — separate PR by request.

### Checklist

- [x] Read and understood the Code of Conduct and Contributing Guidelines.
- [ ] Tests added and all succeed — N/A, docs-only.
- [x] Linted — N/A, markdown prose.
- [ ] README.md updated, if user-facing — N/A, internal dev-workflow doc, not user-facing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md with no runtime or build behavior impact.
> 
> **Overview**
> Adds a **macOS development** subsection to `AGENTS.md` under Build & Development Commands, describing how to run Windows-side build/test work from a Mac host through Parallels **`prlctl exec`**.
> 
> The new guidance covers VM naming, passing arguments separately, **`--current-user`** for user-context work, hiding PowerShell windows with **`-WindowStyle Hidden`**, verifying shared-folder paths to the Mac home directory, and preferring **`.ps1` scripts** over complex inline `-Command` strings to avoid quoting mangling through the exec layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 728c10c2303d3123ac3209af74124f0fcd2c7c78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->