### PR TITLE
fix: tolerate malformed snyk:// URIs from Windows paths [IDE-2548]

### DIFF
--- a/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClientCustomTarget.cs
+++ b/Snyk.VisualStudio.Extension.2022/Language/SnykLanguageClientCustomTarget.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
@@ -96,14 +97,17 @@ namespace Snyk.VisualStudio.Extension.Language
             // unescapes each query value once, and pre-unescaping double-decodes any value with a
             // percent sequence and can produce a string that makes new Uri(...) throw. Guard the
             // parse so a malformed URI can't escape this JSON-RPC handler.
+            Logger.Debug("OnShowDocument received uri: {Uri}", showDocumentParams.Uri);
+            var rawUri = RepairSnykSchemeAuthority(showDocumentParams.Uri);
+
             Uri uri;
             try
             {
-                uri = new Uri(showDocumentParams.Uri);
+                uri = new Uri(rawUri);
             }
             catch (UriFormatException ex)
             {
-                Logger.Warning(ex, "Ignoring showDocument request with malformed URI");
+                Logger.Warning(ex, "Ignoring showDocument request with malformed URI: {Uri}", showDocumentParams.Uri);
                 return;
             }
 
@@ -136,6 +140,21 @@ namespace Snyk.VisualStudio.Extension.Language
                 selection.Start.Character,
                 selection.End.Line,
                 selection.End.Character);
+        }
+
+        // LS at protocol 25 could emit "snyk://C:%5CMac..." which was parsed as host:port.
+        // Rebuild as "snyk:///C:/Mac...". Same shape as the file:// URI schema for Windows paths (RFC 8089), which .NET parses cleanly.
+        internal static string RepairSnykSchemeAuthority(string rawUri)
+        {
+            if (!Regex.IsMatch(rawUri, "^snyk://[A-Za-z]:%5C")) return rawUri;
+
+            var queryIndex = rawUri.IndexOf('?');
+            var head = queryIndex >= 0 ? rawUri.Substring(0, queryIndex) : rawUri;
+            var query = queryIndex >= 0 ? rawUri.Substring(queryIndex) : "";
+            var drivePath = head.Substring("snyk://".Length).Replace("%5C", "/");
+            var repairedUri = "snyk:///" + drivePath + query;
+            Logger.Debug("RepairSnykSchemeAuthority transformed uri: {Uri}", repairedUri);
+            return repairedUri;
         }
 
         // The tree emits product codenames ("code"/"oss"/"iac") in the detail-panel URI, while

--- a/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
+++ b/Snyk.VisualStudio.Extension.Tests/Language/SnykLanguageClientCustomTargetTests.cs
@@ -308,6 +308,54 @@ namespace Snyk.VisualStudio.Extension.Tests.Language
             await cut.OnShowDocument(arg);
         }
 
+        [Fact]
+        public async Task OnShowDocument_ShouldSelectIssue_WhenUriIsMalformedWindowsPathFromLs()
+        {
+            // LS at protocol 25 can emit exactly this for a Windows path (no host, backslashes as %5C),
+            // which `new Uri` reads as host:port and throws without this leniency.
+            var toolWindowMock = SetupToolWindow();
+            var arg = ShowDocument("snyk://C:%5CMac%5CHome%5CDocuments%5CCode%5CJavaScript%5Csnyk-goof%5Cdb.js?product=code&issueId=ISSUE1&action=showInDetailPanel");
+
+            await cut.OnShowDocument(arg);
+
+            toolWindowMock.Verify(t => t.SelectedItemInTree("ISSUE1", "code"), Times.Once);
+        }
+
+        [Theory]
+        [InlineData("snyk://C:%5CMac%5CHome%5Cdb.js?a=1", "snyk:///C:/Mac/Home/db.js?a=1")]
+        [InlineData("snyk://C:%5CMac%5CHome%5Cdb.js", "snyk:///C:/Mac/Home/db.js")]
+        public void RepairSnykSchemeAuthority_ShouldRebuildWithForwardSlashes_WhenPathIsBackslashEncoded(string input, string expected)
+        {
+            Assert.Equal(expected, SnykLanguageClientCustomTarget.RepairSnykSchemeAuthority(input));
+        }
+
+        [Theory]
+        [InlineData("snyk://a:8080/foo")] // real host:port, single-letter host — must not be treated as a drive letter
+        [InlineData("snyk://x?action=showInDetailPanel")]
+        [InlineData("snyk://C:/Mac/Home/db.js?a=1")] // already forward-slash — .NET parses this fine unrepaired
+        public void RepairSnykSchemeAuthority_ShouldNotChange_WhenNotABackslashEncodedDriveLetterShape(string input)
+        {
+            Assert.Equal(input, SnykLanguageClientCustomTarget.RepairSnykSchemeAuthority(input));
+        }
+
+        [Fact]
+        public void RepairSnykSchemeAuthority_ShouldProduceCleanLocalPath_ThroughRealUriParsing()
+        {
+            var repaired = SnykLanguageClientCustomTarget.RepairSnykSchemeAuthority(
+                "snyk://C:%5CMac%5CHome%5CDocuments%5CCode%5CJavaScript%5Csnyk-goof%5Cdb.js");
+
+            Assert.Equal(@"C:\Mac\Home\Documents\Code\JavaScript\snyk-goof\db.js", new Uri(repaired).LocalPath);
+        }
+
+        [Fact]
+        public void RepairSnykSchemeAuthority_ShouldLeaveForwardSlashShapeCleanThroughRealUriParsing_WhenUnrepaired()
+        {
+            var unrepaired = SnykLanguageClientCustomTarget.RepairSnykSchemeAuthority(
+                "snyk://C:/Mac/Home/Documents/Code/JavaScript/snyk-goof/db.js");
+
+            Assert.Equal(@"C:\Mac\Home\Documents\Code\JavaScript\snyk-goof\db.js", new Uri(unrepaired).LocalPath);
+        }
+
         private Mock<ISnykToolWindow> SetupToolWindow()
         {
             var toolWindowMock = new Mock<ISnykToolWindow>();


### PR DESCRIPTION
### Description

snyk-ls can emit a `snyk://` showDocument URI with no host and a raw Windows path (e.g. `snyk://C:%5CMac%5CHome%5C...`), which .NET's `Uri` parser reads `C:` as `host:port` and rejects. That silently drops the request meant to refresh the Agent Fix panel, leaving it stuck on "Explaining..." forever.

`RepairSnykSchemeAuthority` detects the `%5C`-encoded drive-letter shape and rebuilds the URI as `snyk:///C:/...` - the same shape `file://` URIs use for Windows paths (RFC 8089) - confirmed via direct `Uri` parsing tests to come back clean, no leftover leading slash. Only `%5C` (uppercase) is handled: Go's `net/url` always percent-encodes uppercase hex, so lowercase `%5c` can't occur from the real producer, and an already-forward-slash path already parses fine unrepaired.

Root cause and fix on the snyk-ls side are separate (LS-side fix already landed there); this is defense-in-depth so the IDE keeps working against CLI/LS versions that haven't picked that up yet.

### Checklist

- [x] Read and understood the Code of Conduct and Contributing Guidelines.
- [x] Tests added and all succeed — 787/787 pass, verified in a real Windows VM (build + full `vstest.console.exe` run).
- [x] Linted
- [ ] README.md updated, if user-facing — N/A, internal parsing fix, no user-visible change beyond the bug no longer occurring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to URI normalization in the showDocument JSON-RPC path with narrow regex matching; no auth, persistence, or scan logic changes.
> 
> **Overview**
> **Fixes dropped `window/showDocument` handling** when the language server sends Windows file paths as `snyk://C:%5C...` (no authority), which .NET misreads as `host:port` and rejects—so detail-panel navigation and related UI updates could silently fail (e.g. Agent Fix stuck on “Explaining…”).
> 
> `OnShowDocument` now runs incoming URIs through **`RepairSnykSchemeAuthority`**, which detects the drive-letter + `%5C` pattern and rewrites to `snyk:///C:/...` (RFC 8089–style) before `new Uri(...)`. Other shapes (host:port, already-forward-slash paths) are left unchanged. **Debug/warning logs** include the raw URI on receive and on parse failure.
> 
> Tests cover end-to-end detail-panel selection with the LS-shaped URI, repair/no-op cases, and `Uri.LocalPath` after repair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca078e7b48f2b49a7709b086a8f08c8d5ca5f5d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->